### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "winlibs/lib/msvc"]
 	path = winlibs/lib/msvc
-	url = git://github.com/Tvangeste/goldendict-winlibs-prebuilt.git
+	url = https://github.com/Tvangeste/goldendict-winlibs-prebuilt.git


### PR DESCRIPTION
The unauthenticated git protocol on port 9418 is no longer supported. 
https://github.blog/2021-09-01-improving-git-protocol-security-github/