### PR TITLE
use stringbuilder instead of +

### DIFF
--- a/goldendict.pro
+++ b/goldendict.pro
@@ -35,6 +35,8 @@ CONFIG( release, debug|release ) {
   DEFINES += NDEBUG
 }
 
+DEFINES *= QT_USE_QSTRINGBUILDER
+
 # DEPENDPATH += . generators
 INCLUDEPATH += .
 


### PR DESCRIPTION
 the '+' will automatically be performed as the QStringBuilder '%' everywhere.
https://doc.qt.io/qt-5/qstring.html#more-efficient-string-construction:~:text=DEFINES%20*%3D%20QT_USE_QSTRINGBUILDER