### PR TITLE
FFmpeg 5.0 player: stop reading raw data at EOF

### DIFF
--- a/ffmpegaudio.cc
+++ b/ffmpegaudio.cc
@@ -28,6 +28,7 @@ extern "C" {
 
 #include <vector>
 
+#include "gddebug.hh"
 #include "qt4x5.hh"
 
 using std::vector;
@@ -143,7 +144,17 @@ DecoderContext::~DecoderContext()
 static int readAudioData( void * opaque, unsigned char * buffer, int bufferSize )
 {
   QDataStream * pStream = ( QDataStream * )opaque;
-  return pStream->readRawData( ( char * )buffer, bufferSize );
+  // This function is passed as the read_packet callback into avio_alloc_context().
+  // The documentation for this callback parameter states:
+  // For stream protocols, must never return 0 but rather a proper AVERROR code.
+  if( pStream->atEnd() )
+    return AVERROR_EOF;
+  const int bytesRead = pStream->readRawData( ( char * )buffer, bufferSize );
+  // QDataStream::readRawData() returns 0 at EOF => return AVERROR_EOF in this case.
+  // An error is unlikely here, so just print a warning and return AVERROR_EOF too.
+  if( bytesRead < 0 )
+    gdWarning( "readAudioData: error while reading raw data." );
+  return bytesRead > 0 ? bytesRead : AVERROR_EOF;
 }
 
 bool DecoderContext::openCodec( QString & errorString )


### PR DESCRIPTION
Since the update to FFmpeg 5.0, when FFmpeg+libao internal player is
selected, most sounds fail to be pronounced. Furthermore, each failed
pronunciation attempt increases GoldenDict's CPU usage. Finally,
GoldenDict continues to hang and utilize the CPU cores when the user
attempts to exit it.

The reason for the issue is: GoldenDict's readAudioData() returns 0 at
EOF but FFmpeg expects the callback to return AVERROR_EOF. As a result,
internal player's threads are busy calling readAudioData() indefinitely.

https://git.ffmpeg.org/gitweb/ffmpeg.git/commit/a606f27f4c610708fa96e35eed7b7537d3d8f712
documented the expected return value of the read_packet callback.
https://git.ffmpeg.org/gitweb/ffmpeg.git/commit/252500a78fe1a31abc79e6070d16f50382c39343
removed the code that handled the deprecated 0 return value gracefully.

The relevant deprecation warning
"Invalid return value 0 for stream protocol" had been flooding
GoldenDict's output for years

Fixes #1489.