### PR TITLE
Fix crash when search in webengine

### DIFF
--- a/articleview.cc
+++ b/articleview.cc
@@ -2374,7 +2374,7 @@ void ArticleView::performFindOperation( bool restart, bool backwards, bool check
 
   findText( text,
             f,
-            [ &text, this ]( bool match )
+            [ text, this ]( bool match )
             {
               bool setMark = !text.isEmpty() && !match;
 


### PR DESCRIPTION
When searching in webengine (with Ctrl+F) the program will crash with a segmentation fault, with console printing the following:

```bash
...
...
====reading 14798 bytes
js: Uncaught SyntaxError: Identifier 'OxfordTagSwitchCN' has already been declared
article view loaded url: "gdlookup://localhost?word=test&group=4294967294" true
getResource: b
scheme: b
host: 5
fish: Job 1, 'goldendict' terminated by signal SIGSEGV (Address boundary error)
```

This is caused by capturing a reference of a QString in a callback. When the callback is invoked the captured QString might already be deconstructed thus causing a segmentation fault. Capture by copy fixes the issue.