### PR TITLE
fix: word around to fix website return 404 with no response body

### DIFF
--- a/iframeschemehandler.cpp
+++ b/iframeschemehandler.cpp
@@ -32,6 +32,11 @@ void IframeSchemeHandler::requestStarted(QWebEngineUrlRequestJob *requestJob)
     // 404 response may have response body.
     if( reply->error() != QNetworkReply::NoError && articleString.isEmpty())
     {
+      if(reply->error()==QNetworkReply::ContentNotFoundError){
+        //work around to fix QTBUG-106573
+        requestJob->redirect(url);
+        return;
+      }
       QString emptyHtml = QString( "<html><body>%1</body></html>" ).arg( reply->errorString() );
       buffer->setData( emptyHtml.toUtf8() );
       requestJob->reply( contentType, buffer );


### PR DESCRIPTION
in current qt6.3.1 version ,there is  a regression that the 404 response with no response body.
this is a workaround waiting for the fix in Qt6.4.1