### PR TITLE
Add two basic "copy info" buttons to about dialog for easier bug reporting

### DIFF
--- a/about.cc
+++ b/about.cc
@@ -8,7 +8,7 @@
 
 #include "utils.hh"
 
-About::About(std::vector< sptr< Dictionary::Class > > * dictonaries, QWidget * parent ): QDialog( parent )
+About::About( QWidget * parent, std::vector< sptr< Dictionary::Class > > * dictonaries ): QDialog( parent )
 {
   ui.setupUi( this );
 
@@ -49,31 +49,26 @@ About::About(std::vector< sptr< Dictionary::Class > > * dictonaries, QWidget * p
           "Qt " + QLatin1String(qVersion()) + " " +
           QSysInfo::buildAbi() + "\n" +
           compilerVersion + "\n"
-
-#ifdef Q_OS_LINUX
-      + "Flags:"
-
-    #ifdef USE_XAPIAN
-             +" USE_XAPIAN "
-    #endif
-
-    #ifdef MAKE_ZIM_SUPPORT
-             +" MAKE_ZIM_SUPPORT"
-    #endif
-
-    #ifdef MAKE_EXTRA_TIFF_HANDLER
-             +" MAKE_EXTRA_TIFF_HANDLER"
-    #endif
-
-    #ifdef NO_EPWING_SUPPORT
-             +" NO_EPWING_SUPPORT"
-    #endif
-
-    #ifdef MAKE_CHINESE_CONVERSION_SUPPORT
-             +" MAKE_CHINESE_CONVERSION_SUPPORT"
-    #endif
+    + "Flags:"
+#ifdef USE_XAPIAN
+         +" USE_XAPIAN "
 #endif
 
+#ifdef MAKE_ZIM_SUPPORT
+         +" MAKE_ZIM_SUPPORT"
+#endif
+
+#ifdef MAKE_EXTRA_TIFF_HANDLER
+         +" MAKE_EXTRA_TIFF_HANDLER"
+#endif
+
+#ifdef NO_EPWING_SUPPORT
+         +" NO_EPWING_SUPPORT"
+#endif
+
+#ifdef MAKE_CHINESE_CONVERSION_SUPPORT
+         +" MAKE_CHINESE_CONVERSION_SUPPORT"
+#endif
       );
   });
 

--- a/about.cc
+++ b/about.cc
@@ -2,12 +2,13 @@
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
 #include "about.hh"
+#include <QPushButton>
 #include <QtGui>
 #include <QSysInfo>
 
 #include "utils.hh"
 
-About::About( QWidget * parent ): QDialog( parent )
+About::About(std::vector< sptr< Dictionary::Class > > * dictonaries, QWidget * parent ): QDialog( parent )
 {
   ui.setupUi( this );
 
@@ -39,6 +40,50 @@ About::About( QWidget * parent ): QDialog( parent )
   +" (Xapian inside)"
 #endif
                          );
+
+  // copy basic debug info to clipboard
+  connect(ui.copyInfoBtn, &QPushButton::clicked, [=]{
+      QGuiApplication::clipboard()->setText(
+          "Goldendict " + version + "\n" +
+          QSysInfo::productType() + " " + QSysInfo::kernelType() + " " + QSysInfo::kernelVersion() + " " +
+          "Qt " + QLatin1String(qVersion()) + " " +
+          QSysInfo::buildAbi() + "\n" +
+          compilerVersion + "\n"
+
+#ifdef Q_OS_LINUX
+      + "Flags:"
+
+    #ifdef USE_XAPIAN
+             +" USE_XAPIAN "
+    #endif
+
+    #ifdef MAKE_ZIM_SUPPORT
+             +" MAKE_ZIM_SUPPORT"
+    #endif
+
+    #ifdef MAKE_EXTRA_TIFF_HANDLER
+             +" MAKE_EXTRA_TIFF_HANDLER"
+    #endif
+
+    #ifdef NO_EPWING_SUPPORT
+             +" NO_EPWING_SUPPORT"
+    #endif
+
+    #ifdef MAKE_CHINESE_CONVERSION_SUPPORT
+             +" MAKE_CHINESE_CONVERSION_SUPPORT"
+    #endif
+#endif
+
+      );
+  });
+
+  connect(ui.copyDictListBtn, &QPushButton::clicked, [=]{
+      QString tempDictList{};
+      for (auto dict : *dictonaries) {
+        tempDictList.append(QString::fromStdString(dict->getName() + "\n"));
+      }
+      QGuiApplication::clipboard()->setText(tempDictList);
+  });
 
   QFile creditsFile( ":/CREDITS.txt" );
 

--- a/about.hh
+++ b/about.hh
@@ -14,7 +14,7 @@ class About: public QDialog
 {
   Q_OBJECT
 public:
-  About(std::vector< sptr< Dictionary::Class > > * dictonaries, QWidget * parent = 0 );
+  About( QWidget * parent, std::vector< sptr< Dictionary::Class > > * dictonaries);
 
 private:
 

--- a/about.hh
+++ b/about.hh
@@ -5,14 +5,16 @@
 #define ABOUT_HH
 
 #include "ui_about.h"
+#include "sptr.hh"
+#include "dictionary.hh"
 #include <QDialog>
+#include <vector>
 
 class About: public QDialog
 {
   Q_OBJECT
 public:
-
-  About( QWidget * parent = 0 );
+  About(std::vector< sptr< Dictionary::Class > > * dictonaries, QWidget * parent = 0 );
 
 private:
 

--- a/about.ui
+++ b/about.ui
@@ -115,6 +115,49 @@
          </property>
         </widget>
        </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <widget class="QPushButton" name="copyInfoBtn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Copy version info</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="copyDictListBtn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Copy dictionaries list</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
       </layout>
      </item>
     </layout>

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -3224,7 +3224,7 @@ void MainWindow::visitForum()
 
 void MainWindow::showAbout()
 {
-  About about( this );
+  About about(&dictionaries, this);
 
   about.show();
   about.exec();

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -3226,7 +3226,7 @@ void MainWindow::visitForum()
 
 void MainWindow::showAbout()
 {
-  About about(&dictionaries, this);
+  About about(this, &dictionaries);
 
   about.show();
   about.exec();


### PR DESCRIPTION
This will probably reduce the useless conversation of asking bug reporter's basic system info. They can just click that button rather than screenshot.

It will include flags only for linux users since they often build things themselves.

<img src="https://user-images.githubusercontent.com/20123683/202414240-cbe6dc86-21b6-4b21-929c-9ced58819c82.png" width="400"/>

Sample output:
```
Goldendict 22.9.24-alpha.67485fd8 on Thu Nov 17 02:59:57 2022
arch linux 6.0.8-arch1-1 Qt 5.15.7 x86_64-little_endian-lp64
GCC 12.2.0
Flags: MAKE_EXTRA_TIFF_HANDLER
```

The "copy dictionaries list" does feel useless and i didn't figure out how to get what type of dict that a user are using. It is just a list of names.

Since qt6 requires c++17, i think the lambda usage is ok.