### PR TITLE
Overhaul ScanPopup

### DIFF
--- a/config.cc
+++ b/config.cc
@@ -263,9 +263,6 @@ Preferences::Preferences():
 , limitInputPhraseLength( false )
 , inputPhraseLengthLimit( 1000 )
 , maxDictionaryRefsInContextMenu ( 20 )
-#ifndef Q_WS_X11
-, trackClipboardChanges( false )
-#endif
 , synonymSearchEnabled( true )
 {
 }
@@ -999,11 +996,6 @@ Class load()
 
     if ( !preferences.namedItem( "maxDictionaryRefsInContextMenu" ).isNull() )
       c.preferences.maxDictionaryRefsInContextMenu = preferences.namedItem( "maxDictionaryRefsInContextMenu" ).toElement().text().toUShort();
-
-#ifndef Q_WS_X11
-    if ( !preferences.namedItem( "trackClipboardChanges" ).isNull() )
-      c.preferences.trackClipboardChanges = ( preferences.namedItem( "trackClipboardChanges" ).toElement().text() == "1" );
-#endif
 
     if ( !preferences.namedItem( "synonymSearchEnabled" ).isNull() )
       c.preferences.synonymSearchEnabled = ( preferences.namedItem( "synonymSearchEnabled" ).toElement().text() == "1" );
@@ -1954,12 +1946,6 @@ void save( Class const & c )
     opt = dd.createElement( "maxDictionaryRefsInContextMenu" );
     opt.appendChild( dd.createTextNode( QString::number( c.preferences.maxDictionaryRefsInContextMenu ) ) );
     preferences.appendChild( opt );
-
-#ifndef Q_WS_X11
-    opt = dd.createElement( "trackClipboardChanges" );
-    opt.appendChild( dd.createTextNode( c.preferences.trackClipboardChanges ? "1" : "0" ) );
-    preferences.appendChild( opt );
-#endif
 
     opt = dd.createElement( "synonymSearchEnabled" );
     opt.appendChild( dd.createTextNode( c.preferences.synonymSearchEnabled ? "1" : "0" ) );

--- a/config.cc
+++ b/config.cc
@@ -227,7 +227,6 @@ Preferences::Preferences():
   enableClipboardHotkey( true ),
   clipboardHotkey( QKeySequence( "Ctrl+C,C" ) ),
 
-  enableScanPopup( true ),
   startWithScanPopupOn( false ),
   enableScanPopupModifiers( false ),
   scanPopupModifiers( 0 ),
@@ -887,7 +886,6 @@ Class load()
     if ( !preferences.namedItem( "clipboardHotkey" ).isNull() )
       c.preferences.clipboardHotkey = QKeySequence::fromString( preferences.namedItem( "clipboardHotkey" ).toElement().text() );
 
-    c.preferences.enableScanPopup = ( preferences.namedItem( "enableScanPopup" ).toElement().text() == "1" );
     c.preferences.startWithScanPopupOn = ( preferences.namedItem( "startWithScanPopupOn" ).toElement().text() == "1" );
     c.preferences.enableScanPopupModifiers = ( preferences.namedItem( "enableScanPopupModifiers" ).toElement().text() == "1" );
     c.preferences.scanPopupModifiers = ( preferences.namedItem( "scanPopupModifiers" ).toElement().text().toULong() );
@@ -1746,10 +1744,6 @@ void save( Class const & c )
 
     opt = dd.createElement( "clipboardHotkey" );
     opt.appendChild( dd.createTextNode( c.preferences.clipboardHotkey.toKeySequence().toString() ) );
-    preferences.appendChild( opt );
-
-    opt = dd.createElement( "enableScanPopup" );
-    opt.appendChild( dd.createTextNode( c.preferences.enableScanPopup ? "1":"0" ) );
     preferences.appendChild( opt );
 
     opt = dd.createElement( "startWithScanPopupOn" );

--- a/config.cc
+++ b/config.cc
@@ -230,8 +230,6 @@ Preferences::Preferences():
   startWithScanPopupOn( false ),
   enableScanPopupModifiers( false ),
   scanPopupModifiers( 0 ),
-  scanPopupAltMode( false ),
-  scanPopupAltModeSecs( 3 ),
   ignoreOwnClipboardChanges( false ),
   scanToMainWindow( false ),
   ignoreDiacritics( false ),
@@ -890,9 +888,6 @@ Class load()
     c.preferences.startWithScanPopupOn = ( preferences.namedItem( "startWithScanPopupOn" ).toElement().text() == "1" );
     c.preferences.enableScanPopupModifiers = ( preferences.namedItem( "enableScanPopupModifiers" ).toElement().text() == "1" );
     c.preferences.scanPopupModifiers = ( preferences.namedItem( "scanPopupModifiers" ).toElement().text().toULong() );
-    c.preferences.scanPopupAltMode = ( preferences.namedItem( "scanPopupAltMode" ).toElement().text() == "1" );
-    if ( !preferences.namedItem( "scanPopupAltModeSecs" ).isNull() )
-      c.preferences.scanPopupAltModeSecs = preferences.namedItem( "scanPopupAltModeSecs" ).toElement().text().toUInt();
     c.preferences.ignoreOwnClipboardChanges = ( preferences.namedItem( "ignoreOwnClipboardChanges" ).toElement().text() == "1" );
     c.preferences.scanToMainWindow = ( preferences.namedItem( "scanToMainWindow" ).toElement().text() == "1" );
     c.preferences.ignoreDiacritics = ( preferences.namedItem( "ignoreDiacritics" ).toElement().text() == "1" );
@@ -1754,14 +1749,6 @@ void save( Class const & c )
 
     opt = dd.createElement( "scanPopupModifiers" );
     opt.appendChild( dd.createTextNode( QString::number( c.preferences.scanPopupModifiers ) ) );
-    preferences.appendChild( opt );
-
-    opt = dd.createElement( "scanPopupAltMode" );
-    opt.appendChild( dd.createTextNode( c.preferences.scanPopupAltMode ? "1":"0" ) );
-    preferences.appendChild( opt );
-
-    opt = dd.createElement( "scanPopupAltModeSecs" );
-    opt.appendChild( dd.createTextNode( QString::number( c.preferences.scanPopupAltModeSecs ) ) );
     preferences.appendChild( opt );
 
     opt = dd.createElement( "ignoreOwnClipboardChanges" );

--- a/config.cc
+++ b/config.cc
@@ -237,6 +237,10 @@ Preferences::Preferences():
   ignoreDiacritics( false ),
   ignorePunctuation( false ),
 #ifdef HAVE_X11
+  // Enable both Clipboard and Selection by default so that X users can enjoy full
+  // power and disable optionally.
+  trackClipboardScan ( true ),
+  trackSelectionScan ( true ),
   showScanFlag( false ),
 #endif
   pronounceOnLoadMain( false ),
@@ -895,6 +899,8 @@ Class load()
     if( !preferences.namedItem( "ignorePunctuation" ).isNull() )
       c.preferences.ignorePunctuation = ( preferences.namedItem( "ignorePunctuation" ).toElement().text() == "1" );
 #ifdef HAVE_X11
+    c.preferences.trackClipboardScan= ( preferences.namedItem( "trackClipboardScan" ).toElement().text() == "1" );
+    c.preferences.trackSelectionScan= ( preferences.namedItem( "trackSelectionScan" ).toElement().text() == "1" );
     c.preferences.showScanFlag= ( preferences.namedItem( "showScanFlag" ).toElement().text() == "1" );
 #endif
 
@@ -1775,6 +1781,14 @@ void save( Class const & c )
     preferences.appendChild( opt );
 
 #ifdef HAVE_X11
+    opt = dd.createElement( "trackClipboardScan" );
+    opt.appendChild( dd.createTextNode( c.preferences.trackClipboardScan ? "1":"0" ) );
+    preferences.appendChild( opt );
+
+    opt = dd.createElement( "trackSelectionScan" );
+    opt.appendChild( dd.createTextNode( c.preferences.trackSelectionScan ? "1":"0" ) );
+    preferences.appendChild( opt );
+
     opt = dd.createElement( "showScanFlag" );
     opt.appendChild( dd.createTextNode( c.preferences.showScanFlag? "1":"0" ) );
     preferences.appendChild( opt );

--- a/config.hh
+++ b/config.hh
@@ -318,7 +318,6 @@ struct Preferences
   bool enableClipboardHotkey;
   HotKey clipboardHotkey;
 
-  bool enableScanPopup;
   bool startWithScanPopupOn;
   bool enableScanPopupModifiers;
   unsigned long scanPopupModifiers; // Combination of KeyboardState::Modifier

--- a/config.hh
+++ b/config.hh
@@ -329,6 +329,8 @@ struct Preferences
   bool ignoreDiacritics;
   bool ignorePunctuation;
 #ifdef HAVE_X11
+  bool trackClipboardScan;
+  bool trackSelectionScan;
   bool showScanFlag;
 #endif
 

--- a/config.hh
+++ b/config.hh
@@ -321,8 +321,6 @@ struct Preferences
   bool startWithScanPopupOn;
   bool enableScanPopupModifiers;
   unsigned long scanPopupModifiers; // Combination of KeyboardState::Modifier
-  bool scanPopupAltMode; // When you press modifier shortly after the selection
-  unsigned scanPopupAltModeSecs;
   bool ignoreOwnClipboardChanges;
 
   bool scanToMainWindow;

--- a/config.hh
+++ b/config.hh
@@ -369,9 +369,6 @@ struct Preferences
   InputPhrase sanitizeInputPhrase( QString const & inputPhrase ) const;
 
   unsigned short maxDictionaryRefsInContextMenu;
-#ifndef Q_WS_X11
-  bool trackClipboardChanges;
-#endif
 
   bool synonymSearchEnabled;
 

--- a/keyboardstate.hh
+++ b/keyboardstate.hh
@@ -27,7 +27,7 @@ public:
 
   /// Returns true if all Modifiers present within the given mask are pressed
   /// right now.
-  bool checkModifiersPressed( int mask );
+  bool static checkModifiersPressed( int mask );
 };
 
 #endif

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -406,12 +406,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   connect( trayIconMenu.addAction( tr( "Show &Main Window" ) ), SIGNAL( triggered() ),
            this, SLOT( showMainWindow() ) );
   trayIconMenu.addAction( enableScanPopupAction );
-  actTrackingClipboard = trayIconMenu.addAction( tr( "Tracking Clipboard" ) );
-  actTrackingClipboard->setCheckable(true);
-  actTrackingClipboard->setChecked(cfg.preferences.trackClipboardChanges);
-//  actTrackingClipboard->setVisible( cfg.preferences.enableScanPopup );
-  connect( actTrackingClipboard , SIGNAL( triggered(bool) ),
-           this, SLOT( trackingClipboard(bool) ) );
+
   trayIconMenu.addSeparator();
   connect( trayIconMenu.addAction( tr( "&Quit" ) ), SIGNAL( triggered() ),
            this, SLOT( quitApp() ) );
@@ -918,8 +913,8 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
 void MainWindow::clipboardChange( )
 {
-  qDebug() << "clipboard change ," << cfg.preferences.trackClipboardChanges << scanPopup.get();
-  if( scanPopup && cfg.preferences.trackClipboardChanges )
+  qDebug() << "clipboard change ," << scanPopup.get();
+  if( scanPopup )
   {
     scanPopup->translateWordFromClipboard();
   }
@@ -1485,7 +1480,7 @@ void MainWindow::makeScanPopup()
   scanPopup.reset();
 
   // Later this will be remove, we want singluar way to toggling ScanPopup
-  if ( !cfg.preferences.enableClipboardHotkey && !cfg.preferences.trackClipboardChanges )
+  if ( !cfg.preferences.enableClipboardHotkey )
     return;
 
   scanPopup = new ScanPopup( 0, cfg, articleNetMgr, audioPlayerFactory.player(),
@@ -2181,9 +2176,7 @@ void MainWindow::editPreferences()
     p.hideMenubar = cfg.preferences.hideMenubar;
     p.searchInDock = cfg.preferences.searchInDock;
     p.alwaysOnTop = cfg.preferences.alwaysOnTop;
-#ifndef Q_WS_X11
-    p.trackClipboardChanges = cfg.preferences.trackClipboardChanges;
-#endif
+
     p.proxyServer.systemProxyUser = cfg.preferences.proxyServer.systemProxyUser;
     p.proxyServer.systemProxyPassword = cfg.preferences.proxyServer.systemProxyPassword;
 
@@ -3187,12 +3180,6 @@ void MainWindow::scanEnableToggled( bool on )
 void MainWindow::showMainWindow()
 {
   toggleMainWindow( true );
-}
-
-void MainWindow::trackingClipboard( bool on )
-{
-  cfg.preferences.trackClipboardChanges = on;
-  makeScanPopup();
 }
 
 void MainWindow::visitHomepage()

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -917,18 +917,20 @@ void MainWindow::clipboardChange( QClipboard::Mode m)
 {
   if( scanPopup && enableScanningAction->isChecked()  )
   {
-    if ( cfg.preferences.enableScanPopupModifiers && KeyboardState::checkModifiersPressed(cfg.preferences.scanPopupModifiers))
-    {
       if(m == QClipboard::Clipboard){
         if(!cfg.preferences.trackClipboardScan) return;
         scanPopup->translateWordFromClipboard();
+        return;
       }
 
       if(m == QClipboard::Selection){
         if(!cfg.preferences.trackSelectionScan) return;
+        if(cfg.preferences.enableScanPopupModifiers &&
+          !KeyboardState::checkModifiersPressed(cfg.preferences.scanPopupModifiers)){
+          return;
+        }
         scanPopup->translateWordFromSelection();
       }
-    }
   }
 }
 

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -925,11 +925,25 @@ void MainWindow::clipboardChange( QClipboard::Mode m)
       }
 
       if(m == QClipboard::Selection){
+
+        // Multiple ways to stoping a word from showing up when selecting
+
+        // Explictly disabled on preferences
         if(!cfg.preferences.trackSelectionScan) return;
+
+        // Keyboard Modifier
         if(cfg.preferences.enableScanPopupModifiers &&
           !KeyboardState::checkModifiersPressed(cfg.preferences.scanPopupModifiers)){
           return;
         }
+
+        // Show a Flag instead of translate directly.
+        // And hand over the control of showing the popup to scanFlag
+        if ( cfg.preferences.showScanFlag ) {
+          emit scanPopup->showScanFlag();
+          return;
+        }
+
         scanPopup->translateWordFromSelection();
       }
 #else

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -917,6 +917,7 @@ void MainWindow::clipboardChange( QClipboard::Mode m)
 {
   if( scanPopup && enableScanningAction->isChecked()  )
   {
+#ifdef HAVE_X11
       if(m == QClipboard::Clipboard){
         if(!cfg.preferences.trackClipboardScan) return;
         scanPopup->translateWordFromClipboard();
@@ -931,7 +932,10 @@ void MainWindow::clipboardChange( QClipboard::Mode m)
         }
         scanPopup->translateWordFromSelection();
       }
-  }
+#else
+    scanPopup ->translateWordFromClipboard();
+#endif
+     }
 }
 
 void MainWindow::ctrlTabPressed()

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -230,17 +230,17 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   // scan popup
   navToolbar->addSeparator();
 
-  enableScanPopupAction = navToolbar->addAction( QIcon( ":/icons/wizard.svg" ), tr( "Scan Popup" ) );
-  enableScanPopupAction->setCheckable( true );
+  enableScanningAction = navToolbar->addAction( QIcon( ":/icons/wizard.svg" ), tr( "Enable Scanning" ) );
+  enableScanningAction->setCheckable( true );
 
-  navToolbar->widgetForAction( enableScanPopupAction )->setObjectName( "scanPopupButton" );
+  navToolbar->widgetForAction( enableScanningAction )->setObjectName( "scanPopupButton" );
   if( cfg.preferences.startWithScanPopupOn )
   {
-    enableScanPopupAction->setIcon( QIcon( ":/icons/wizard-selected.svg" ) );
-    enableScanPopupAction->setChecked( true );
+    enableScanningAction->setIcon( QIcon( ":/icons/wizard-selected.svg" ) );
+    enableScanningAction->setChecked( true );
   }
 
-  connect( enableScanPopupAction, SIGNAL( toggled( bool ) ),
+  connect( enableScanningAction, SIGNAL( toggled( bool ) ),
            this, SLOT( scanEnableToggled( bool ) ) );
 
   navToolbar->addSeparator();
@@ -405,7 +405,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   // tray icon
   connect( trayIconMenu.addAction( tr( "Show &Main Window" ) ), SIGNAL( triggered() ),
            this, SLOT( showMainWindow() ) );
-  trayIconMenu.addAction( enableScanPopupAction );
+  trayIconMenu.addAction( enableScanningAction );
 
   trayIconMenu.addSeparator();
   connect( trayIconMenu.addAction( tr( "&Quit" ) ), SIGNAL( triggered() ),
@@ -1188,7 +1188,7 @@ void MainWindow::updateTrayIcon()
   if ( trayIcon )
   {
     // Update the icon to reflect the scanning mode
-    trayIcon->setIcon( enableScanPopupAction->isChecked() ?
+    trayIcon->setIcon( enableScanningAction->isChecked() ?
         QIcon::fromTheme("goldendict-scan-tray", QIcon( ":/icons/programicon_scan.png" )) :
         QIcon::fromTheme("goldendict-tray", QIcon( ":/icons/programicon_old.png" )) );
 
@@ -1488,7 +1488,7 @@ void MainWindow::makeScanPopup()
 
   scanPopup->setStyleSheet( styleSheet() );
 
-  if ( enableScanPopupAction->isChecked() )
+  if ( enableScanningAction->isChecked() )
     scanPopup->enableScanning();
 
   connect( scanPopup.get(), SIGNAL(editGroupRequested( unsigned ) ),
@@ -3165,12 +3165,12 @@ void MainWindow::scanEnableToggled( bool on )
           mainStatusBar->showMessage( tr( "Accessibility API is not enabled" ), 10000,
                                           QPixmap( ":/icons/error.svg" ) );
 #endif
-      enableScanPopupAction->setIcon(QIcon(":/icons/wizard-selected.svg"));
+      enableScanningAction->setIcon(QIcon(":/icons/wizard-selected.svg"));
     }
     else
     {
       scanPopup->disableScanning();
-      enableScanPopupAction->setIcon(QIcon(":/icons/wizard.svg"));
+      enableScanningAction->setIcon(QIcon(":/icons/wizard.svg"));
     }
   }
 

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -228,27 +228,22 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   translateBoxToolBarAction = navToolbar->addWidget( translateBoxWidget );
 
   // scan popup
-  beforeScanPopupSeparator = navToolbar->addSeparator();
-  beforeScanPopupSeparator->setVisible( cfg.preferences.enableScanPopup );
-  navToolbar->widgetForAction( beforeScanPopupSeparator )->setObjectName( "beforeScanPopupSeparator" );
+  navToolbar->addSeparator();
 
   enableScanPopupAction = navToolbar->addAction( QIcon( ":/icons/wizard.svg" ), tr( "Scan Popup" ) );
   enableScanPopupAction->setCheckable( true );
-  enableScanPopupAction->setVisible( cfg.preferences.enableScanPopup );
+
   navToolbar->widgetForAction( enableScanPopupAction )->setObjectName( "scanPopupButton" );
-  if( cfg.preferences.enableScanPopup && cfg.preferences.startWithScanPopupOn )
+  if( cfg.preferences.startWithScanPopupOn )
   {
     enableScanPopupAction->setIcon( QIcon( ":/icons/wizard-selected.svg" ) );
     enableScanPopupAction->setChecked( true );
   }
 
-
   connect( enableScanPopupAction, SIGNAL( toggled( bool ) ),
            this, SLOT( scanEnableToggled( bool ) ) );
 
-  afterScanPopupSeparator = navToolbar->addSeparator();
-  afterScanPopupSeparator->setVisible( cfg.preferences.enableScanPopup );
-  navToolbar->widgetForAction( afterScanPopupSeparator )->setObjectName( "afterScanPopupSeparator" );
+  navToolbar->addSeparator();
 
   // sound
   navPronounce = navToolbar->addAction( QIcon( ":/icons/playsound_full.png" ), tr( "Pronounce Word (Alt+S)" ) );
@@ -2252,13 +2247,6 @@ void MainWindow::editPreferences()
     cfg.preferences = p;
 
     audioPlayerFactory.setPreferences( cfg.preferences );
-
-    beforeScanPopupSeparator->setVisible( cfg.preferences.enableScanPopup );
-    enableScanPopupAction->setVisible( cfg.preferences.enableScanPopup );
-    afterScanPopupSeparator->setVisible( cfg.preferences.enableScanPopup );
-
-    if ( !cfg.preferences.enableScanPopup )
-      enableScanPopupAction->setChecked( false );
 
     updateTrayIcon();
     applyProxySettings();

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -232,18 +232,18 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   beforeScanPopupSeparator->setVisible( cfg.preferences.enableScanPopup );
   navToolbar->widgetForAction( beforeScanPopupSeparator )->setObjectName( "beforeScanPopupSeparator" );
 
-  enableScanPopup = navToolbar->addAction( QIcon( ":/icons/wizard.svg" ), tr( "Scan Popup" ) );
-  enableScanPopup->setCheckable( true );
-  enableScanPopup->setVisible( cfg.preferences.enableScanPopup );
-  navToolbar->widgetForAction( enableScanPopup )->setObjectName( "scanPopupButton" );
+  enableScanPopupAction = navToolbar->addAction( QIcon( ":/icons/wizard.svg" ), tr( "Scan Popup" ) );
+  enableScanPopupAction->setCheckable( true );
+  enableScanPopupAction->setVisible( cfg.preferences.enableScanPopup );
+  navToolbar->widgetForAction( enableScanPopupAction )->setObjectName( "scanPopupButton" );
   if( cfg.preferences.enableScanPopup && cfg.preferences.startWithScanPopupOn )
   {
-    enableScanPopup->setIcon( QIcon( ":/icons/wizard-selected.svg" ) );
-    enableScanPopup->setChecked( true );
+    enableScanPopupAction->setIcon( QIcon( ":/icons/wizard-selected.svg" ) );
+    enableScanPopupAction->setChecked( true );
   }
 
 
-  connect( enableScanPopup, SIGNAL( toggled( bool ) ),
+  connect( enableScanPopupAction, SIGNAL( toggled( bool ) ),
            this, SLOT( scanEnableToggled( bool ) ) );
 
   afterScanPopupSeparator = navToolbar->addSeparator();
@@ -410,7 +410,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   // tray icon
   connect( trayIconMenu.addAction( tr( "Show &Main Window" ) ), SIGNAL( triggered() ),
            this, SLOT( showMainWindow() ) );
-  trayIconMenu.addAction( enableScanPopup );
+  trayIconMenu.addAction( enableScanPopupAction );
   actTrackingClipboard = trayIconMenu.addAction( tr( "Tracking Clipboard" ) );
   actTrackingClipboard->setCheckable(true);
   actTrackingClipboard->setChecked(cfg.preferences.trackClipboardChanges);
@@ -1198,7 +1198,7 @@ void MainWindow::updateTrayIcon()
   if ( trayIcon )
   {
     // Update the icon to reflect the scanning mode
-    trayIcon->setIcon( enableScanPopup->isChecked() ?
+    trayIcon->setIcon( enableScanPopupAction->isChecked() ?
         QIcon::fromTheme("goldendict-scan-tray", QIcon( ":/icons/programicon_scan.png" )) :
         QIcon::fromTheme("goldendict-tray", QIcon( ":/icons/programicon_old.png" )) );
 
@@ -1498,7 +1498,7 @@ void MainWindow::makeScanPopup()
 
   scanPopup->setStyleSheet( styleSheet() );
 
-  if ( cfg.preferences.enableScanPopup && enableScanPopup->isChecked() )
+  if ( cfg.preferences.enableScanPopup && enableScanPopupAction->isChecked() )
     scanPopup->enableScanning();
 
   connect( scanPopup.get(), SIGNAL(editGroupRequested( unsigned ) ),
@@ -2254,11 +2254,11 @@ void MainWindow::editPreferences()
     audioPlayerFactory.setPreferences( cfg.preferences );
 
     beforeScanPopupSeparator->setVisible( cfg.preferences.enableScanPopup );
-    enableScanPopup->setVisible( cfg.preferences.enableScanPopup );
+    enableScanPopupAction->setVisible( cfg.preferences.enableScanPopup );
     afterScanPopupSeparator->setVisible( cfg.preferences.enableScanPopup );
 
     if ( !cfg.preferences.enableScanPopup )
-      enableScanPopup->setChecked( false );
+      enableScanPopupAction->setChecked( false );
 
     updateTrayIcon();
     applyProxySettings();
@@ -3186,12 +3186,12 @@ void MainWindow::scanEnableToggled( bool on )
           mainStatusBar->showMessage( tr( "Accessibility API is not enabled" ), 10000,
                                           QPixmap( ":/icons/error.svg" ) );
 #endif
-      enableScanPopup->setIcon(QIcon(":/icons/wizard-selected.svg"));
+      enableScanPopupAction->setIcon(QIcon(":/icons/wizard-selected.svg"));
     }
     else
     {
       scanPopup->disableScanning();
-      enableScanPopup->setIcon(QIcon(":/icons/wizard.svg"));
+      enableScanPopupAction->setIcon(QIcon(":/icons/wizard.svg"));
     }
   }
 

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -1484,8 +1484,8 @@ void MainWindow::makeScanPopup()
 {
   scanPopup.reset();
 
-  if ( !cfg.preferences.enableScanPopup &&
-       !cfg.preferences.enableClipboardHotkey && !cfg.preferences.trackClipboardChanges )
+  // Later this will be remove, we want singluar way to toggling ScanPopup
+  if ( !cfg.preferences.enableClipboardHotkey && !cfg.preferences.trackClipboardChanges )
     return;
 
   scanPopup = new ScanPopup( 0, cfg, articleNetMgr, audioPlayerFactory.player(),
@@ -1493,7 +1493,7 @@ void MainWindow::makeScanPopup()
 
   scanPopup->setStyleSheet( styleSheet() );
 
-  if ( cfg.preferences.enableScanPopup && enableScanPopupAction->isChecked() )
+  if ( enableScanPopupAction->isChecked() )
     scanPopup->enableScanning();
 
   connect( scanPopup.get(), SIGNAL(editGroupRequested( unsigned ) ),
@@ -3161,8 +3161,6 @@ void MainWindow::trayIconActivated( QSystemTrayIcon::ActivationReason r )
 
 void MainWindow::scanEnableToggled( bool on )
 {
-  if ( !cfg.preferences.enableScanPopup )
-    return;
 
   if ( scanPopup )
   {

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -914,7 +914,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 void MainWindow::clipboardChange( )
 {
   qDebug() << "clipboard change ," << scanPopup.get();
-  if( scanPopup )
+  if( scanPopup && enableScanningAction->isChecked() )
   {
     scanPopup->translateWordFromClipboard();
   }

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -1497,10 +1497,6 @@ void MainWindow::makeScanPopup()
 {
   scanPopup.reset();
 
-  // Later this will be remove, we want singluar way to toggling ScanPopup
-  if ( !cfg.preferences.enableClipboardHotkey )
-    return;
-
   scanPopup = new ScanPopup( 0, cfg, articleNetMgr, audioPlayerFactory.player(),
                              dictionaries, groupInstances, history );
 

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -940,7 +940,7 @@ void MainWindow::clipboardChange( QClipboard::Mode m)
         // Show a Flag instead of translate directly.
         // And hand over the control of showing the popup to scanFlag
         if ( cfg.preferences.showScanFlag ) {
-          emit scanPopup->showScanFlag();
+          scanPopup->showScanFlag();
           return;
         }
 

--- a/mainwindow.hh
+++ b/mainwindow.hh
@@ -116,7 +116,7 @@ private:
           addAllTabToFavoritesAction;
   QToolBar * navToolbar;
   MainStatusBar * mainStatusBar;
-  QAction * navBack, * navForward, * navPronounce, * enableScanPopupAction;
+  QAction * navBack, * navForward, * navPronounce, * enableScanningAction;
   QAction * beforeOptionsSeparator;
   QAction * zoomIn, * zoomOut, * zoomBase;
   QAction * wordsZoomIn, * wordsZoomOut, * wordsZoomBase;

--- a/mainwindow.hh
+++ b/mainwindow.hh
@@ -117,7 +117,6 @@ private:
   QToolBar * navToolbar;
   MainStatusBar * mainStatusBar;
   QAction * navBack, * navForward, * navPronounce, * enableScanPopupAction;
-  QAction * actTrackingClipboard;
   QAction * beforeOptionsSeparator;
   QAction * zoomIn, * zoomOut, * zoomBase;
   QAction * wordsZoomIn, * wordsZoomOut, * wordsZoomBase;
@@ -415,8 +414,6 @@ private slots:
   void setAutostart( bool );
 
   void showMainWindow();
-
-  void trackingClipboard(bool);
 
   void visitHomepage();
   void visitForum();

--- a/mainwindow.hh
+++ b/mainwindow.hh
@@ -484,7 +484,7 @@ private slots:
   void showGDHelp();
   void hideGDHelp();
 
-  void clipboardChange( );
+  void clipboardChange(QClipboard::Mode m);
 
   void inspectElement( QWebEnginePage * );
 

--- a/mainwindow.hh
+++ b/mainwindow.hh
@@ -118,7 +118,7 @@ private:
   MainStatusBar * mainStatusBar;
   QAction * navBack, * navForward, * navPronounce, * enableScanPopupAction;
   QAction * actTrackingClipboard;
-  QAction * beforeScanPopupSeparator, * afterScanPopupSeparator, * beforeOptionsSeparator;
+  QAction * beforeOptionsSeparator;
   QAction * zoomIn, * zoomOut, * zoomBase;
   QAction * wordsZoomIn, * wordsZoomOut, * wordsZoomBase;
   QAction * addToFavorites, * beforeAddToFavoritesSeparator;

--- a/mainwindow.hh
+++ b/mainwindow.hh
@@ -116,7 +116,7 @@ private:
           addAllTabToFavoritesAction;
   QToolBar * navToolbar;
   MainStatusBar * mainStatusBar;
-  QAction * navBack, * navForward, * navPronounce, * enableScanPopup;
+  QAction * navBack, * navForward, * navPronounce, * enableScanPopupAction;
   QAction * actTrackingClipboard;
   QAction * beforeScanPopupSeparator, * afterScanPopupSeparator, * beforeOptionsSeparator;
   QAction * zoomIn, * zoomOut, * zoomBase;

--- a/preferences.cc
+++ b/preferences.cc
@@ -16,9 +16,6 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   Config::Preferences const & p = cfg_.preferences;
   ui.setupUi( this );
 
-  connect( ui.enableScanPopup, SIGNAL( toggled( bool ) ),
-           this, SLOT( enableScanPopupToggled( bool ) ) );
-
   connect( ui.enableScanPopupModifiers, SIGNAL( toggled( bool ) ),
            this, SLOT( enableScanPopupModifiersToggled( bool ) ) );
 
@@ -190,7 +187,6 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   ui.enableClipboardHotkey->setChecked( p.enableClipboardHotkey );
   ui.clipboardHotkey->setHotKey( p.clipboardHotkey );
 
-  ui.enableScanPopup->setChecked( p.enableScanPopup );
   ui.startWithScanPopupOn->setChecked( p.startWithScanPopupOn );
   ui.enableScanPopupModifiers->setChecked( p.enableScanPopupModifiers );
 
@@ -407,7 +403,6 @@ Config::Preferences Preferences::getPreferences()
   p.enableClipboardHotkey = ui.enableClipboardHotkey->isChecked();
   p.clipboardHotkey = ui.clipboardHotkey->getHotKey();
 
-  p.enableScanPopup = ui.enableScanPopup->isChecked();
   p.startWithScanPopupOn = ui.startWithScanPopupOn->isChecked();
   p.enableScanPopupModifiers = ui.enableScanPopupModifiers->isChecked();
 
@@ -572,14 +567,9 @@ Config::Preferences Preferences::getPreferences()
   return p;
 }
 
-void Preferences::enableScanPopupToggled( bool b )
-{
-  ui.scanPopupModifiers->setEnabled( b && ui.enableScanPopupModifiers->isChecked() );
-}
-
 void Preferences::enableScanPopupModifiersToggled( bool b )
 {
-  ui.scanPopupModifiers->setEnabled( b && ui.enableScanPopup->isChecked() );
+  ui.scanPopupModifiers->setEnabled( b );
   if( b )
     ui.showScanFlag->setChecked( false );
 }

--- a/preferences.cc
+++ b/preferences.cc
@@ -251,8 +251,12 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
 //Platform-specific options
 
 #ifdef HAVE_X11
-  ui.showScanFlag->setChecked( p.showScanFlag);
+  ui.enableX11SelectionTrack->setChecked(p.trackSelectionScan);
+  ui.enableClipboardTrack ->setChecked(p.trackClipboardScan);
+  ui.showScanFlag->setChecked(p.showScanFlag);
 #else
+  ui.enableX11SelectionTrack->hide();
+  ui.enableClipboardTrack->hide();
   ui.showScanFlag->hide();
   ui.ignoreOwnClipboardChanges->hide();
 #endif
@@ -422,6 +426,8 @@ Config::Preferences Preferences::getPreferences()
   p.ignoreOwnClipboardChanges = ui.ignoreOwnClipboardChanges->isChecked();
   p.scanToMainWindow = ui.scanToMainWindow->isChecked();
 #ifdef HAVE_X11
+  p.trackSelectionScan = ui.enableX11SelectionTrack ->isChecked();
+  p.trackClipboardScan = ui.enableClipboardTrack ->isChecked();
   p.showScanFlag= ui.showScanFlag->isChecked();
 #endif
 

--- a/preferences.cc
+++ b/preferences.cc
@@ -201,8 +201,6 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   ui.leftShift->setChecked( p.scanPopupModifiers & KeyboardState::LeftShift );
   ui.rightShift->setChecked( p.scanPopupModifiers & KeyboardState::RightShift );
 
-  ui.scanPopupAltMode->setChecked( p.scanPopupAltMode );
-  ui.scanPopupAltModeSecs->setValue( p.scanPopupAltModeSecs );
   ui.ignoreOwnClipboardChanges->setChecked( p.ignoreOwnClipboardChanges );
   ui.scanToMainWindow->setChecked( p.scanToMainWindow );
 
@@ -421,8 +419,6 @@ Config::Preferences Preferences::getPreferences()
   p.scanPopupModifiers += ui.leftShift->isChecked() ? KeyboardState::LeftShift: 0;
   p.scanPopupModifiers += ui.rightShift->isChecked() ? KeyboardState::RightShift: 0;
 
-  p.scanPopupAltMode = ui.scanPopupAltMode->isChecked();
-  p.scanPopupAltModeSecs = ui.scanPopupAltModeSecs->value();
   p.ignoreOwnClipboardChanges = ui.ignoreOwnClipboardChanges->isChecked();
   p.scanToMainWindow = ui.scanToMainWindow->isChecked();
 #ifdef HAVE_X11

--- a/preferences.hh
+++ b/preferences.hh
@@ -33,7 +33,6 @@ private:
 
 private slots:
 
-  void enableScanPopupToggled( bool );
   void enableScanPopupModifiersToggled( bool );
   void showScanFlagToggled( bool b );
 

--- a/preferences.ui
+++ b/preferences.ui
@@ -24,7 +24,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <property name="iconSize">
       <size>
@@ -661,67 +661,6 @@ in the pressed state when the word selection changes.</string>
              <string>Show scan flag when word is selected</string>
             </property>
            </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_5">
-            <item>
-             <widget class="QCheckBox" name="scanPopupAltMode">
-              <property name="toolTip">
-               <string>Normally, in order to activate a popup you have to
-maintain the chosen keys pressed while you select
-a word. With this enabled, the chosen keys may also
-be pressed shortly after the selection is done.</string>
-              </property>
-              <property name="text">
-               <string>Keys may also be pressed afterwards, within</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QSpinBox" name="scanPopupAltModeSecs">
-              <property name="toolTip">
-               <string>To avoid false positives, the keys are only monitored
-after the selection's done for a limited amount of
-seconds, which is specified here.</string>
-              </property>
-              <property name="wrapping">
-               <bool>false</bool>
-              </property>
-              <property name="frame">
-               <bool>true</bool>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-              </property>
-              <property name="minimum">
-               <number>1</number>
-              </property>
-              <property name="maximum">
-               <number>99</number>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="label_7">
-              <property name="text">
-               <string>secs</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_5">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
           </item>
           <item>
            <widget class="QCheckBox" name="ignoreOwnClipboardChanges">
@@ -1858,8 +1797,6 @@ from Stardict, Babylon and GLS dictionaries</string>
   <tabstop>rightCtrl</tabstop>
   <tabstop>leftShift</tabstop>
   <tabstop>winKey</tabstop>
-  <tabstop>scanPopupAltMode</tabstop>
-  <tabstop>scanPopupAltModeSecs</tabstop>
   <tabstop>useProxyServer</tabstop>
   <tabstop>proxyType</tabstop>
   <tabstop>proxyHost</tabstop>

--- a/preferences.ui
+++ b/preferences.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>744</width>
-    <height>506</height>
+    <width>787</width>
+    <height>629</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -24,7 +24,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <property name="iconSize">
       <size>
@@ -424,268 +424,55 @@ be the last ones.</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_10">
        <item>
-        <widget class="QGroupBox" name="enableScanPopup">
+        <widget class="QCheckBox" name="startWithScanPopupOn">
          <property name="toolTip">
-          <string>When enabled, a translation popup window would be shown each time
-you point your mouse on any word on the screen (Windows) or select
-any word with mouse (Linux). When enabled, you can switch it on and
-off from main window or tray icon.</string>
-         </property>
-         <property name="title">
-          <string>Enable scan popup functionality</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_4">
-          <item>
-           <widget class="QCheckBox" name="startWithScanPopupOn">
-            <property name="toolTip">
-             <string>Chooses whether the scan popup mode is on by default or not. If checked,
+          <string>Chooses whether the scan popup mode is on by default or not. If checked,
 the program would always start with the scan popup active.</string>
-            </property>
-            <property name="text">
-             <string>Start with scan popup turned on</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="enableScanPopupModifiers">
-            <property name="toolTip">
-             <string>With this enabled, the popup would only show up if all chosen keys are
+         </property>
+         <property name="text">
+          <string>Start with scan popup turned on</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="enableScanPopupModifiers">
+         <property name="toolTip">
+          <string>With this enabled, the popup would only show up if all chosen keys are
 in the pressed state when the word selection changes.</string>
-            </property>
-            <property name="text">
-             <string>Only show popup when all selected keys are kept pressed:</string>
-            </property>
-           </widget>
-          </item>
+         </property>
+         <property name="text">
+          <string>Only show popup when all selected keys are kept pressed:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QFrame" name="scanPopupModifiers">
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Plain</enum>
+         </property>
+         <property name="lineWidth">
+          <number>0</number>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_5">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
           <item>
-           <widget class="QFrame" name="scanPopupModifiers">
-            <property name="frameShape">
-             <enum>QFrame::NoFrame</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Plain</enum>
-            </property>
-            <property name="lineWidth">
-             <number>0</number>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_5">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout">
-               <item>
-                <spacer name="horizontalSpacer">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
-                <layout class="QGridLayout" name="gridLayout">
-                 <item row="1" column="1">
-                  <widget class="QCheckBox" name="leftCtrl">
-                   <property name="toolTip">
-                    <string>Left Ctrl only</string>
-                   </property>
-                   <property name="text">
-                    <string>Left Ctrl</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="2">
-                  <widget class="QCheckBox" name="rightShift">
-                   <property name="toolTip">
-                    <string>Right Shift only</string>
-                   </property>
-                   <property name="text">
-                    <string>Right Shift</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="0">
-                  <widget class="QCheckBox" name="altKey">
-                   <property name="toolTip">
-                    <string>Alt key</string>
-                   </property>
-                   <property name="text">
-                    <string>Alt</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QCheckBox" name="ctrlKey">
-                   <property name="toolTip">
-                    <string>Ctrl key</string>
-                   </property>
-                   <property name="text">
-                    <string>Ctrl</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="0">
-                  <widget class="QCheckBox" name="leftAlt">
-                   <property name="toolTip">
-                    <string>Left Alt only</string>
-                   </property>
-                   <property name="text">
-                    <string>Left Alt</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="2">
-                  <widget class="QCheckBox" name="shiftKey">
-                   <property name="toolTip">
-                    <string>Shift key</string>
-                   </property>
-                   <property name="text">
-                    <string>Shift</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="0">
-                  <widget class="QCheckBox" name="rightAlt">
-                   <property name="toolTip">
-                    <string>Right Alt only</string>
-                   </property>
-                   <property name="text">
-                    <string>Right Alt</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="1">
-                  <widget class="QCheckBox" name="rightCtrl">
-                   <property name="toolTip">
-                    <string>Right Ctrl only</string>
-                   </property>
-                   <property name="text">
-                    <string>Right Ctrl</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="1" column="2">
-                  <widget class="QCheckBox" name="leftShift">
-                   <property name="toolTip">
-                    <string>Left Shift only</string>
-                   </property>
-                   <property name="text">
-                    <string>Left Shift</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="3">
-                  <widget class="QCheckBox" name="winKey">
-                   <property name="toolTip">
-                    <string>Windows key or Meta key</string>
-                   </property>
-                   <property name="text">
-                    <string>Win/Meta</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item>
-                <widget class="QFrame" name="frame">
-                 <property name="frameShape">
-                  <enum>QFrame::NoFrame</enum>
-                 </property>
-                 <property name="frameShadow">
-                  <enum>QFrame::Raised</enum>
-                 </property>
-                 <property name="lineWidth">
-                  <number>0</number>
-                 </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_3">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                 </layout>
-                </widget>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <layout class="QHBoxLayout" name="horizontalLayout">
             <item>
-             <widget class="QCheckBox" name="scanPopupAltMode">
-              <property name="toolTip">
-               <string>Normally, in order to activate a popup you have to
-maintain the chosen keys pressed while you select
-a word. With this enabled, the chosen keys may also
-be pressed shortly after the selection is done.</string>
-              </property>
-              <property name="text">
-               <string>Keys may also be pressed afterwards, within</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QSpinBox" name="scanPopupAltModeSecs">
-              <property name="toolTip">
-               <string>To avoid false positives, the keys are only monitored
-after the selection's done for a limited amount of
-seconds, which is specified here.</string>
-              </property>
-              <property name="wrapping">
-               <bool>false</bool>
-              </property>
-              <property name="frame">
-               <bool>true</bool>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-              </property>
-              <property name="minimum">
-               <number>1</number>
-              </property>
-              <property name="maximum">
-               <number>99</number>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="label_7">
-              <property name="text">
-               <string>secs</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_5">
+             <spacer name="horizontalSpacer">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
@@ -697,29 +484,221 @@ seconds, which is specified here.</string>
               </property>
              </spacer>
             </item>
+            <item>
+             <layout class="QGridLayout" name="gridLayout">
+              <item row="1" column="1">
+               <widget class="QCheckBox" name="leftCtrl">
+                <property name="toolTip">
+                 <string>Left Ctrl only</string>
+                </property>
+                <property name="text">
+                 <string>Left Ctrl</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="2">
+               <widget class="QCheckBox" name="rightShift">
+                <property name="toolTip">
+                 <string>Right Shift only</string>
+                </property>
+                <property name="text">
+                 <string>Right Shift</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QCheckBox" name="altKey">
+                <property name="toolTip">
+                 <string>Alt key</string>
+                </property>
+                <property name="text">
+                 <string>Alt</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QCheckBox" name="ctrlKey">
+                <property name="toolTip">
+                 <string>Ctrl key</string>
+                </property>
+                <property name="text">
+                 <string>Ctrl</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QCheckBox" name="leftAlt">
+                <property name="toolTip">
+                 <string>Left Alt only</string>
+                </property>
+                <property name="text">
+                 <string>Left Alt</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="2">
+               <widget class="QCheckBox" name="shiftKey">
+                <property name="toolTip">
+                 <string>Shift key</string>
+                </property>
+                <property name="text">
+                 <string>Shift</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QCheckBox" name="rightAlt">
+                <property name="toolTip">
+                 <string>Right Alt only</string>
+                </property>
+                <property name="text">
+                 <string>Right Alt</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QCheckBox" name="rightCtrl">
+                <property name="toolTip">
+                 <string>Right Ctrl only</string>
+                </property>
+                <property name="text">
+                 <string>Right Ctrl</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="2">
+               <widget class="QCheckBox" name="leftShift">
+                <property name="toolTip">
+                 <string>Left Shift only</string>
+                </property>
+                <property name="text">
+                 <string>Left Shift</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="3">
+               <widget class="QCheckBox" name="winKey">
+                <property name="toolTip">
+                 <string>Windows key or Meta key</string>
+                </property>
+                <property name="text">
+                 <string>Win/Meta</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QFrame" name="frame">
+              <property name="frameShape">
+               <enum>QFrame::NoFrame</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Raised</enum>
+              </property>
+              <property name="lineWidth">
+               <number>0</number>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_3">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+              </layout>
+             </widget>
+            </item>
            </layout>
           </item>
-          <item>
-           <widget class="QCheckBox" name="showScanFlag">
-            <property name="toolTip">
-             <string>Show a flag window before showing popup window, click the flag to show popup window. </string>
-            </property>
-            <property name="text">
-             <string>Show scan flag when word is selected</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="ignoreOwnClipboardChanges">
-            <property name="toolTip">
-             <string>Do not show popup when selection or clipboard in one of GoldenDict's own windows changes</string>
-            </property>
-            <property name="text">
-             <string>Ignore GoldenDict's own selection and clipboard changes</string>
-            </property>
-           </widget>
-          </item>
          </layout>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_5">
+         <item>
+          <widget class="QCheckBox" name="scanPopupAltMode">
+           <property name="toolTip">
+            <string>Normally, in order to activate a popup you have to
+maintain the chosen keys pressed while you select
+a word. With this enabled, the chosen keys may also
+be pressed shortly after the selection is done.</string>
+           </property>
+           <property name="text">
+            <string>Keys may also be pressed afterwards, within</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="scanPopupAltModeSecs">
+           <property name="toolTip">
+            <string>To avoid false positives, the keys are only monitored
+after the selection's done for a limited amount of
+seconds, which is specified here.</string>
+           </property>
+           <property name="wrapping">
+            <bool>false</bool>
+           </property>
+           <property name="frame">
+            <bool>true</bool>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>99</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_7">
+           <property name="text">
+            <string>secs</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_5">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="showScanFlag">
+         <property name="toolTip">
+          <string>Show a flag window before showing popup window, click the flag to show popup window. </string>
+         </property>
+         <property name="text">
+          <string>Show scan flag when word is selected</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="ignoreOwnClipboardChanges">
+         <property name="toolTip">
+          <string>Do not show popup when selection or clipboard in one of GoldenDict's own windows changes</string>
+         </property>
+         <property name="text">
+          <string>Ignore GoldenDict's own selection and clipboard changes</string>
+         </property>
         </widget>
        </item>
        <item>
@@ -1844,8 +1823,6 @@ from Stardict, Babylon and GLS dictionaries</string>
   <tabstop>closeToTray</tabstop>
   <tabstop>cbAutostart</tabstop>
   <tabstop>interfaceLanguage</tabstop>
-  <tabstop>startWithScanPopupOn</tabstop>
-  <tabstop>enableScanPopupModifiers</tabstop>
   <tabstop>leftCtrl</tabstop>
   <tabstop>rightShift</tabstop>
   <tabstop>altKey</tabstop>

--- a/preferences.ui
+++ b/preferences.ui
@@ -435,44 +435,281 @@ the program would always start with the scan popup active.</string>
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="enableScanPopupModifiers">
+        <widget class="QCheckBox" name="scanToMainWindow">
          <property name="toolTip">
-          <string>With this enabled, the popup would only show up if all chosen keys are
-in the pressed state when the word selection changes.</string>
+          <string>Send translated word to main window instead of to show it in popup window</string>
          </property>
          <property name="text">
-          <string>Only show popup when all selected keys are kept pressed:</string>
+          <string>Send translated word to main window</string>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QFrame" name="scanPopupModifiers">
-         <property name="frameShape">
-          <enum>QFrame::NoFrame</enum>
+        <widget class="QCheckBox" name="enableClipboardTrack">
+         <property name="toolTip">
+          <string>Track clipboard changes when Scanning is enabled. Notice! You should always enable this unless you are on Linux.</string>
          </property>
-         <property name="frameShadow">
-          <enum>QFrame::Plain</enum>
+         <property name="text">
+          <string>Track Clipboard change</string>
          </property>
-         <property name="lineWidth">
-          <number>0</number>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="enableX11SelectionTrack">
+         <property name="title">
+          <string>Track Selection change</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_5">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_4">
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout">
+           <widget class="QCheckBox" name="enableScanPopupModifiers">
+            <property name="toolTip">
+             <string>With this enabled, the popup would only show up if all chosen keys are
+in the pressed state when the word selection changes.</string>
+            </property>
+            <property name="text">
+             <string>Only tack selection when all selected keys are kept pressed:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QFrame" name="scanPopupModifiers">
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="frameShadow">
+             <enum>QFrame::Plain</enum>
+            </property>
+            <property name="lineWidth">
+             <number>0</number>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_5">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout">
+               <item>
+                <spacer name="horizontalSpacer">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <layout class="QGridLayout" name="gridLayout">
+                 <item row="1" column="1">
+                  <widget class="QCheckBox" name="leftCtrl">
+                   <property name="toolTip">
+                    <string>Left Ctrl only</string>
+                   </property>
+                   <property name="text">
+                    <string>Left Ctrl</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="2">
+                  <widget class="QCheckBox" name="rightShift">
+                   <property name="toolTip">
+                    <string>Right Shift only</string>
+                   </property>
+                   <property name="text">
+                    <string>Right Shift</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="0">
+                  <widget class="QCheckBox" name="altKey">
+                   <property name="toolTip">
+                    <string>Alt key</string>
+                   </property>
+                   <property name="text">
+                    <string>Alt</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="1">
+                  <widget class="QCheckBox" name="ctrlKey">
+                   <property name="toolTip">
+                    <string>Ctrl key</string>
+                   </property>
+                   <property name="text">
+                    <string>Ctrl</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0">
+                  <widget class="QCheckBox" name="leftAlt">
+                   <property name="toolTip">
+                    <string>Left Alt only</string>
+                   </property>
+                   <property name="text">
+                    <string>Left Alt</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="2">
+                  <widget class="QCheckBox" name="shiftKey">
+                   <property name="toolTip">
+                    <string>Shift key</string>
+                   </property>
+                   <property name="text">
+                    <string>Shift</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="0">
+                  <widget class="QCheckBox" name="rightAlt">
+                   <property name="toolTip">
+                    <string>Right Alt only</string>
+                   </property>
+                   <property name="text">
+                    <string>Right Alt</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="1">
+                  <widget class="QCheckBox" name="rightCtrl">
+                   <property name="toolTip">
+                    <string>Right Ctrl only</string>
+                   </property>
+                   <property name="text">
+                    <string>Right Ctrl</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="2">
+                  <widget class="QCheckBox" name="leftShift">
+                   <property name="toolTip">
+                    <string>Left Shift only</string>
+                   </property>
+                   <property name="text">
+                    <string>Left Shift</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="3">
+                  <widget class="QCheckBox" name="winKey">
+                   <property name="toolTip">
+                    <string>Windows key or Meta key</string>
+                   </property>
+                   <property name="text">
+                    <string>Win/Meta</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <widget class="QFrame" name="frame">
+                 <property name="frameShape">
+                  <enum>QFrame::NoFrame</enum>
+                 </property>
+                 <property name="frameShadow">
+                  <enum>QFrame::Raised</enum>
+                 </property>
+                 <property name="lineWidth">
+                  <number>0</number>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_3">
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>0</number>
+                  </property>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="showScanFlag">
+            <property name="toolTip">
+             <string>Show a flag window before showing popup window, click the flag to show popup window. </string>
+            </property>
+            <property name="text">
+             <string>Show scan flag when word is selected</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_5">
             <item>
-             <spacer name="horizontalSpacer">
+             <widget class="QCheckBox" name="scanPopupAltMode">
+              <property name="toolTip">
+               <string>Normally, in order to activate a popup you have to
+maintain the chosen keys pressed while you select
+a word. With this enabled, the chosen keys may also
+be pressed shortly after the selection is done.</string>
+              </property>
+              <property name="text">
+               <string>Keys may also be pressed afterwards, within</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="scanPopupAltModeSecs">
+              <property name="toolTip">
+               <string>To avoid false positives, the keys are only monitored
+after the selection's done for a limited amount of
+seconds, which is specified here.</string>
+              </property>
+              <property name="wrapping">
+               <bool>false</bool>
+              </property>
+              <property name="frame">
+               <bool>true</bool>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+              </property>
+              <property name="minimum">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <number>99</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="label_7">
+              <property name="text">
+               <string>secs</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_5">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
@@ -484,254 +721,19 @@ in the pressed state when the word selection changes.</string>
               </property>
              </spacer>
             </item>
-            <item>
-             <layout class="QGridLayout" name="gridLayout">
-              <item row="1" column="1">
-               <widget class="QCheckBox" name="leftCtrl">
-                <property name="toolTip">
-                 <string>Left Ctrl only</string>
-                </property>
-                <property name="text">
-                 <string>Left Ctrl</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="2">
-               <widget class="QCheckBox" name="rightShift">
-                <property name="toolTip">
-                 <string>Right Shift only</string>
-                </property>
-                <property name="text">
-                 <string>Right Shift</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QCheckBox" name="altKey">
-                <property name="toolTip">
-                 <string>Alt key</string>
-                </property>
-                <property name="text">
-                 <string>Alt</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QCheckBox" name="ctrlKey">
-                <property name="toolTip">
-                 <string>Ctrl key</string>
-                </property>
-                <property name="text">
-                 <string>Ctrl</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QCheckBox" name="leftAlt">
-                <property name="toolTip">
-                 <string>Left Alt only</string>
-                </property>
-                <property name="text">
-                 <string>Left Alt</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="2">
-               <widget class="QCheckBox" name="shiftKey">
-                <property name="toolTip">
-                 <string>Shift key</string>
-                </property>
-                <property name="text">
-                 <string>Shift</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QCheckBox" name="rightAlt">
-                <property name="toolTip">
-                 <string>Right Alt only</string>
-                </property>
-                <property name="text">
-                 <string>Right Alt</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QCheckBox" name="rightCtrl">
-                <property name="toolTip">
-                 <string>Right Ctrl only</string>
-                </property>
-                <property name="text">
-                 <string>Right Ctrl</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="2">
-               <widget class="QCheckBox" name="leftShift">
-                <property name="toolTip">
-                 <string>Left Shift only</string>
-                </property>
-                <property name="text">
-                 <string>Left Shift</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="3">
-               <widget class="QCheckBox" name="winKey">
-                <property name="toolTip">
-                 <string>Windows key or Meta key</string>
-                </property>
-                <property name="text">
-                 <string>Win/Meta</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item>
-             <widget class="QFrame" name="frame">
-              <property name="frameShape">
-               <enum>QFrame::NoFrame</enum>
-              </property>
-              <property name="frameShadow">
-               <enum>QFrame::Raised</enum>
-              </property>
-              <property name="lineWidth">
-               <number>0</number>
-              </property>
-              <layout class="QVBoxLayout" name="verticalLayout_3">
-               <property name="leftMargin">
-                <number>0</number>
-               </property>
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <property name="rightMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
-                <number>0</number>
-               </property>
-              </layout>
-             </widget>
-            </item>
            </layout>
           </item>
+          <item>
+           <widget class="QCheckBox" name="ignoreOwnClipboardChanges">
+            <property name="toolTip">
+             <string>Do not show popup when selection or clipboard in one of GoldenDict's own windows changes</string>
+            </property>
+            <property name="text">
+             <string>Ignore GoldenDict's own selection and clipboard changes</string>
+            </property>
+           </widget>
+          </item>
          </layout>
-        </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_5">
-         <item>
-          <widget class="QCheckBox" name="scanPopupAltMode">
-           <property name="toolTip">
-            <string>Normally, in order to activate a popup you have to
-maintain the chosen keys pressed while you select
-a word. With this enabled, the chosen keys may also
-be pressed shortly after the selection is done.</string>
-           </property>
-           <property name="text">
-            <string>Keys may also be pressed afterwards, within</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="scanPopupAltModeSecs">
-           <property name="toolTip">
-            <string>To avoid false positives, the keys are only monitored
-after the selection's done for a limited amount of
-seconds, which is specified here.</string>
-           </property>
-           <property name="wrapping">
-            <bool>false</bool>
-           </property>
-           <property name="frame">
-            <bool>true</bool>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-           </property>
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>99</number>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="label_7">
-           <property name="text">
-            <string>secs</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_5">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="showScanFlag">
-         <property name="toolTip">
-          <string>Show a flag window before showing popup window, click the flag to show popup window. </string>
-         </property>
-         <property name="text">
-          <string>Show scan flag when word is selected</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="ignoreOwnClipboardChanges">
-         <property name="toolTip">
-          <string>Do not show popup when selection or clipboard in one of GoldenDict's own windows changes</string>
-         </property>
-         <property name="text">
-          <string>Ignore GoldenDict's own selection and clipboard changes</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="scanToMainWindow">
-         <property name="toolTip">
-          <string>Send translated word to main window instead of to show it in popup window</string>
-         </property>
-         <property name="text">
-          <string>Send translated word to main window</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="enableX11SelectionTrack">
-         <property name="title">
-          <string>Track Selection change</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="enableClipboardTrack">
-         <property name="toolTip">
-          <string>Track clipboard changes when Scanning is enabled. Noice! You should always enable this unless you are on Linux.</string>
-         </property>
-         <property name="text">
-          <string>Track Clipboard change</string>
-         </property>
         </widget>
        </item>
        <item>

--- a/preferences.ui
+++ b/preferences.ui
@@ -712,6 +712,29 @@ seconds, which is specified here.</string>
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="enableX11SelectionTrack">
+         <property name="title">
+          <string>Track Selection change</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="enableClipboardTrack">
+         <property name="toolTip">
+          <string>Track clipboard changes when Scanning is enabled. Noice! You should always enable this unless you are on Linux.</string>
+         </property>
+         <property name="text">
+          <string>Track Clipboard change</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_6">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/scanflag.cc
+++ b/scanflag.cc
@@ -4,29 +4,28 @@
 #include "ui_scanflag.h"
 #include <QScreen>
 
-static Qt::WindowFlags popupWindowFlags =
-
-Qt::ToolTip | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint
- | Qt::WindowDoesNotAcceptFocus
-;
 
 ScanFlag::ScanFlag(QWidget *parent) :
     QMainWindow(parent)
 {
   ui.setupUi( this );
 
-  setWindowFlags( popupWindowFlags );
+  setWindowFlags( Qt::ToolTip
+                | Qt::FramelessWindowHint
+                | Qt::WindowStaysOnTopHint
+                | Qt::WindowDoesNotAcceptFocus);
 
   setAttribute(Qt::WA_X11DoNotAcceptFocus);
 
   hideTimer.setSingleShot( true );
-  hideTimer.setInterval( 1500 );
+  hideTimer.setInterval( 1000 );
 
-  connect( &hideTimer, SIGNAL( timeout() ),
-    this, SLOT( hideWindow() ) );
+  connect( &hideTimer, &QTimer::timeout,
+    this, [=]{ hideWindow();
+  });
 
-  connect( ui.pushButton, SIGNAL( clicked( bool ) ),
-                this, SLOT( pushButtonClicked() ) );
+  connect( ui.pushButton, &QPushButton::clicked,
+           this, &ScanFlag::pushButtonClicked );
 }
 
 ScanFlag::~ScanFlag()
@@ -37,7 +36,7 @@ void ScanFlag::pushButtonClicked()
 {
   hideTimer.stop();
   hide();
-  emit showScanPopup();
+  emit requestScanPopup();
 }
 
 void ScanFlag::hideWindow()

--- a/scanflag.hh
+++ b/scanflag.hh
@@ -2,7 +2,6 @@
 #define SCAN_FLAG_H
 
 
-#include "config.hh"
 #include <QMainWindow>
 #include <QTimer>
 #include "ui_scanflag.h"
@@ -16,17 +15,16 @@ public:
 
   ~ScanFlag();
 
+  void showScanFlag();
+  void pushButtonClicked();
+  void hideWindow();
+
 signals:
-  void showScanPopup ();
+  void requestScanPopup ();
 
 private:
   Ui::ScanFlag ui;
   QTimer hideTimer;
-
-private slots:
-  void showScanFlag();
-  void pushButtonClicked();
-  void hideWindow();
 
 };
 

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -317,13 +317,7 @@ ScanPopup::ScanPopup( QWidget * parent,
 #ifdef HAVE_X11
   scanFlag = new ScanFlag( this );
 
-  connect( this, SIGNAL( showScanFlag() ),
-           scanFlag, SLOT( showScanFlag() ) );
-
-  connect( this, SIGNAL( hideScanFlag() ),
-           scanFlag, SLOT( hideWindow() ) );
-
-  connect( scanFlag, &ScanFlag::showScanPopup,
+  connect( scanFlag, &ScanFlag::requestScanPopup,
     this, [=]{
     translateWordFromSelection();
   });
@@ -1343,4 +1337,13 @@ void ScanPopup::titleChanged( ArticleView *, QString const & title )
   // Set icon for "Add to Favorites" button
   ui.sendWordToFavoritesButton->setIcon( isWordPresentedInFavorites( title, groupId ) ?
                                          blueStarIcon : starIcon );
+}
+
+
+void ScanPopup::showScanFlag(){
+  scanFlag->showScanFlag();
+}
+
+void ScanPopup::hideScanFlag(){
+  scanFlag->hideWindow();
 }

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -522,11 +522,15 @@ void ScanPopup::clipboardChanged( QClipboard::Mode m )
 #ifdef HAVE_X11
   if( cfg.preferences.ignoreOwnClipboardChanges && ownsClipboardMode( m ) )
     return;
-#endif
 
-  GD_DPRINTF( "clipboard changed\n" );
+  if(m == QClipboard::Clipboard && !cfg.preferences.trackClipboardScan){
+    return;
+  }
 
-#ifdef HAVE_X11
+  if(m == QClipboard::Selection && !cfg.preferences.trackSelectionScan){
+    return;
+  }
+
   if( m == QClipboard::Selection )
   {
     // Use delay show to prevent multiple popups while selection in progress

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -323,8 +323,10 @@ ScanPopup::ScanPopup( QWidget * parent,
   connect( this, SIGNAL( hideScanFlag() ),
            scanFlag, SLOT( hideWindow() ) );
 
-  connect( scanFlag, SIGNAL( showScanPopup() ),
-           this, SLOT( showEngagePopup() ) );
+  connect( scanFlag, &ScanFlag::showScanPopup,
+    this, [=]{
+    translateWordFromSelection();
+  });
 
   delayTimer.setSingleShot( true );
   delayTimer.setInterval( 200 );
@@ -508,6 +510,7 @@ void ScanPopup::delayShow()
 }
 #endif
 
+[[deprecated("Favor the mainWindow's clipboardChanged ones")]]
 void ScanPopup::clipboardChanged( QClipboard::Mode m )
 {
 
@@ -544,6 +547,7 @@ void ScanPopup::mouseHovered( QString const & str, bool forcePopup )
   handleInputWord( str, forcePopup );
 }
 
+[[deprecated]]
 void ScanPopup::handleInputWord( QString const & str, bool forcePopup )
 {
   Config::InputPhrase sanitizedPhrase = cfg.preferences.sanitizeInputPhrase( str );

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -278,11 +278,6 @@ ScanPopup::ScanPopup( QWidget * parent,
   connect( definition, SIGNAL( titleChanged(  ArticleView *, QString const & ) ),
            this, SLOT( titleChanged(  ArticleView *, QString const & ) ) );
 
-  connect( QApplication::clipboard(),
-           SIGNAL( changed( QClipboard::Mode ) ),
-           this,
-           SLOT( clipboardChanged( QClipboard::Mode ) ) );
-
 #ifdef Q_OS_MAC
   connect( &MouseOver::instance(), SIGNAL( hovered( QString const &, bool ) ),
            this, SLOT( mouseHovered( QString const &, bool ) ) );

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -1339,7 +1339,7 @@ void ScanPopup::titleChanged( ArticleView *, QString const & title )
                                          blueStarIcon : starIcon );
 }
 
-
+#ifdef HAVE_X11
 void ScanPopup::showScanFlag(){
   scanFlag->showScanFlag();
 }
@@ -1347,3 +1347,4 @@ void ScanPopup::showScanFlag(){
 void ScanPopup::hideScanFlag(){
   scanFlag->hideWindow();
 }
+#endif

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -317,7 +317,7 @@ ScanPopup::ScanPopup( QWidget * parent,
 #ifdef HAVE_X11
   scanFlag = new ScanFlag( this );
 
-  connect( this, SIGNAL( showScanFlag( bool ) ),
+  connect( this, SIGNAL( showScanFlag() ),
            scanFlag, SLOT( showScanFlag() ) );
 
   connect( this, SIGNAL( hideScanFlag() ),
@@ -572,7 +572,7 @@ void ScanPopup::handleInputWord( QString const & str, bool forcePopup )
 #ifdef HAVE_X11
   if ( cfg.preferences.showScanFlag ) {
     inputPhrase = pendingInputPhrase;
-    emit showScanFlag( forcePopup );
+    emit showScanFlag();
     return;
   }
 #endif

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -515,9 +515,8 @@ void ScanPopup::delayShow()
 
 void ScanPopup::clipboardChanged( QClipboard::Mode m )
 {
-//  if( !cfg.preferences.trackClipboardChanges )
-//    return;
-  if( !isScanningEnabled && !cfg.preferences.trackClipboardChanges)
+
+  if( !isScanningEnabled )
     return;
 
 #ifdef HAVE_X11

--- a/scanpopup.hh
+++ b/scanpopup.hh
@@ -157,7 +157,6 @@ private:
   QTimer hideTimer; // When mouse leaves the window, a grace period is
                     // given for it to return back. If it doesn't before
                     // this timer expires, the window gets hidden.
-  QTimer altModeExpirationTimer, altModePollingTimer; // Timers for alt mode
 
   QTimer mouseGrabPollTimer;
 
@@ -209,8 +208,6 @@ private slots:
   void on_goForwardButton_clicked();
 
   void hideTimerExpired();
-  void altModeExpired();
-  void altModePoll();
 
   /// Called repeatedly once the popup is initially engaged and we monitor the
   /// mouse as it may move away from the window. This simulates mouse grab, in

--- a/scanpopup.hh
+++ b/scanpopup.hh
@@ -81,7 +81,7 @@ signals:
 
 #ifdef HAVE_X11
   /// Interaction with scan flag window
-  void showScanFlag( bool forcePopup );
+  void showScanFlag();
   void hideScanFlag();
 #endif
 

--- a/scanpopup.hh
+++ b/scanpopup.hh
@@ -53,6 +53,13 @@ public:
   void setDictionaryIconSize();
 
   void saveConfigData();
+
+#ifdef HAVE_X11
+  /// Interaction with scan flag window
+  void showScanFlag();
+  void hideScanFlag();
+#endif
+
 signals:
 
   /// Forwarded from the dictionary bar, so that main window could act on this.
@@ -78,12 +85,6 @@ signals:
   void sendWordToFavorites( QString const & word, unsigned groupId );
   /// Check is word already presented in Favorites
   bool isWordPresentedInFavorites( QString const & word, unsigned groupId );
-
-#ifdef HAVE_X11
-  /// Interaction with scan flag window
-  void showScanFlag();
-  void hideScanFlag();
-#endif
 
 #ifdef Q_OS_WIN32
   /// Ask for source window is current translate tab


### PR DESCRIPTION
This implemented the design described here: https://github.com/xiaoyifang/goldendict/issues/203#issuecomment-1320880904

The commits are atomic, each one only does a little thing and reviewing them one by one should be easy.

I don't quite understand how this works because we have two `clipboardChange()` in `mainwindow.cc` and `scanpopup.cc`. They seem to do the same thing, but one of them is rather simple and another one is full of hacks. Both of them connect to a bunch of things.

The two implementations are both connected to the clipboard change event.

https://github.com/xiaoyifang/goldendict/blob/dc29111e880bec6b2bc98e39f2ec4221491667c0/scanpopup.cc#L284

https://github.com/xiaoyifang/goldendict/blob/dc29111e880bec6b2bc98e39f2ec4221491667c0/mainwindow.cc#L921

fix https://github.com/xiaoyifang/goldendict/issues/203
