### PR TITLE
Fix translations accidentally installed at /local

### DIFF
--- a/goldendict.pro
+++ b/goldendict.pro
@@ -191,6 +191,7 @@ freebsd {
     LIBS +=   -lexecinfo
 }
 mac {
+    QM_FILES_INSTALL_PATH = /locale/
     TARGET = GoldenDict
     # Uncomment this line to make a universal binary.
     # You will need to use Xcode 3 and Qt Carbon SDK

--- a/goldendict.pro
+++ b/goldendict.pro
@@ -75,7 +75,6 @@ mac {
     CONFIG += app_bundle
 }
     
-QM_FILES_INSTALL_PATH = /locale/
 OBJECTS_DIR = build
 UI_DIR = build
 MOC_DIR = build
@@ -85,6 +84,7 @@ LIBS += -lz \
         -llzo2
 
 win32 {
+    QM_FILES_INSTALL_PATH = /locale/
     TARGET = GoldenDict
 
     win32-msvc* {


### PR DESCRIPTION
They are only useful for win & mac's build.
fix https://github.com/xiaoyifang/goldendict/issues/213

This shouldn't break anything for linux. We already use /usr/share/...../local one
https://github.com/xiaoyifang/goldendict/blob/4f10a55f958f0b39252dbc3c3dc47374ef8ab919/goldendict.pro#L171

https://github.com/xiaoyifang/goldendict/blob/75a83b0f8182eb4a6fe95d3fd24f08f84d584680/config.cc#L2229

https://github.com/xiaoyifang/goldendict/blob/75a83b0f8182eb4a6fe95d3fd24f08f84d584680/config.cc#L2239

