### PR TITLE
Implement "goldendict://nice" url scheme handler for windows and linux

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -183,7 +183,7 @@ logFile( false )
       }
       else
         word = arguments[ i ];
-#ifdef Q_OS_WIN
+#if defined(Q_OS_LINUX) || defined (Q_OS_WIN)
         // handle url scheme like "goldendict://" on windows
         word.remove("goldendict://");
         // In microsoft Words, the / will be automatically appended

--- a/main.cc
+++ b/main.cc
@@ -183,6 +183,14 @@ logFile( false )
       }
       else
         word = arguments[ i ];
+#ifdef Q_OS_WIN
+        // handle url scheme like "goldendict://" on windows
+        word.remove("goldendict://");
+        // In microsoft Words, the / will be automatically appended
+        if(word.endsWith("/")){
+          word.chop(1);
+        }
+#endif
     }
   }
 }

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -912,6 +912,21 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   inspector.reset( new ArticleInspector( this ));
 
   connect( QApplication::clipboard(), &QClipboard::changed, this, &MainWindow::clipboardChange );
+
+#ifdef Q_OS_WIN
+  // Regiser and update URL Scheme for windows
+  // https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/aa767914(v=vs.85)
+
+  // Windows will automatically map registry key to Computer\HKEY_CLASSES_ROOT\ */
+  QSettings urlRegistry(R"(HKEY_CURRENT_USER\Software\Classes)", QSettings::NativeFormat);
+
+  urlRegistry.beginGroup("goldendict");
+  urlRegistry.setValue("Default", "URL: goldendict Protocol");
+  urlRegistry.setValue("URL Protocol", "");
+  urlRegistry.setValue("shell/open/command/Default",
+    QString("\"%1\"").arg( QDir::toNativeSeparators(QApplication::applicationFilePath())) + " \"%1\"");
+  urlRegistry.endGroup();
+#endif
 }
 
 void MainWindow::clipboardChange( QClipboard::Mode m)

--- a/redist/org.goldendict.GoldenDict.desktop
+++ b/redist/org.goldendict.GoldenDict.desktop
@@ -6,4 +6,5 @@ Name=GoldenDict
 GenericName=Multiformat Dictionary
 Comment=A feature-rich dictionary lookup program
 Icon=goldendict
-Exec=goldendict
+Exec=goldendict %u
+MimeType=x-scheme-handler/goldendict


### PR DESCRIPTION
To test this, try `goldendict://nice` on explore.exe's address bar, browser or any editor that supports hyperlinks.

This is an unobvious feature, probably we should document it somewhere, like the wiki or put it in "changes.md" which seems not updated anymore.

If the goldendict already running, GD will use the popup to show the result.

Related:

Fixes https://github.com/xiaoyifang/goldendict/issues/221
Fixes https://github.com/goldendict/goldendict/issues/735