### PR TITLE
optimize epwing reference link navigation

### DIFF
--- a/articleview.cc
+++ b/articleview.cc
@@ -423,10 +423,15 @@ void ArticleView::showDefinition( Config::InputPhrase const & phrase, unsigned g
   if ( scrollTo.size() )
     Utils::Url::addQueryItem( req, "scrollto", scrollTo );
 
-  if( delayedHighlightText.size() )
+  auto highlight = delayedHighlightText;
+  delayedHighlightText.clear();
+  if(highlight.isEmpty()&&contexts.contains("regexp")){
+    highlight= contexts["regexp"];
+  }
+
+  if( !highlight.isEmpty() )
   {
-    Utils::Url::addQueryItem( req, "regexp", delayedHighlightText );
-    delayedHighlightText.clear();
+    Utils::Url::addQueryItem( req, "regexp", highlight );
   }
 
   Contexts::Iterator pos = contexts.find( "gdanchor" );
@@ -1197,6 +1202,9 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref,
 
       if( Utils::Url::hasQueryItem( url, "gdanchor" ) )
         contexts[ "gdanchor" ] = Utils::Url::queryItemValue( url, "gdanchor" );
+
+      if( Utils::Url::hasQueryItem( url, "regexp" ) )
+        contexts[ "regexp" ] = Utils::Url::queryItemValue( url, "regexp" );
 
       showDefinition( word,
                       getGroup( ref ), newScrollTo, contexts );

--- a/epwing.cc
+++ b/epwing.cc
@@ -332,7 +332,6 @@ void EpwingDictionary::loadArticle( int articlePage,
 
   try
   {
-    qDebug()<<"epwing"<<articlePage<<articleOffset;
     Mutex::Lock _( eBook.getLibMutex() );
     eBook.getArticle( headword, text, articlePage, articleOffset, false );
   }
@@ -401,7 +400,6 @@ void EpwingDictionary::getArticleText( uint32_t articleAddress, QString & headwo
 {
   headword.clear();
   text.clear();
-    qDebug()<<"epwing"<<articleAddress;
   vector< char > chunk;
   char * articleProps;
 

--- a/epwing.cc
+++ b/epwing.cc
@@ -332,6 +332,7 @@ void EpwingDictionary::loadArticle( int articlePage,
 
   try
   {
+    qDebug()<<"epwing"<<articlePage<<articleOffset;
     Mutex::Lock _( eBook.getLibMutex() );
     eBook.getArticle( headword, text, articlePage, articleOffset, false );
   }
@@ -400,7 +401,7 @@ void EpwingDictionary::getArticleText( uint32_t articleAddress, QString & headwo
 {
   headword.clear();
   text.clear();
-
+    qDebug()<<"epwing"<<articleAddress;
   vector< char > chunk;
   char * articleProps;
 

--- a/epwing_book.hh
+++ b/epwing_book.hh
@@ -78,8 +78,9 @@ class EpwingBook
   QStringList imageCacheList, soundsCacheList, moviesCacheList, fontsCacheList;
   QMap< QString, QString > baseFontsMap, customFontsMap;
   QVector< int > refPages, refOffsets;
-  QMap< uint64_t,bool > allHeadwordPositions;
-  QMap< uint64_t, bool > allRefPositions;
+  QMap< uint64_t,EpwingHeadword > allHeadwordPositionMap;
+  QSet<uint64_t> allHeadwordsPageOffset;
+  QSet< uint64_t  > allRefPositions;
   QVector< EWPos > LinksQueue;
   int refOpenCount, refCloseCount;
   static Mutex libMutex;
@@ -151,7 +152,8 @@ public:
 
   void clearBuffers()
   {
-    allHeadwordPositions.clear();
+    allHeadwordPositionMap.clear();
+    allHeadwordsPageOffset.clear();
     allRefPositions.clear();
     LinksQueue.clear();
   }

--- a/utils.cc
+++ b/utils.cc
@@ -1,5 +1,35 @@
 #include "utils.hh"
 #include <QDir>
+#include <QTextDocumentFragment>
+
+QString Utils::trim( const QString & str ,const QRegularExpression & reg)
+{
+  QString remain;
+  int n = str.size() - 1;
+  for( ; n >= 0; --n )
+  {
+    auto c = str.at( n );
+    auto match= reg.match(QString()+c);
+    if( !match.hasMatch() )
+    {
+      remain = str.left( n + 1 );
+      break;
+    }
+  }
+
+  n = 0;
+  for( ; n < remain.size(); n++ )
+  {
+    auto c = remain.at( n );
+    auto match= reg.match(QString()+c);
+    if( !match.hasMatch() )
+    {
+      return remain.mid( n );
+    }
+  }
+
+  return "";
+}
 
 QString Utils::Path::combine(const QString& path1, const QString& path2)
 {
@@ -12,4 +42,22 @@ QString Utils::Url::getSchemeAndHost( QUrl const & url )
   auto index = _url.indexOf("://");
   auto hostEndIndex = _url.indexOf("/",index+3);
   return _url.mid(0,hostEndIndex);
+}
+
+//copy from HtmlEscaple.unescaple.
+QString Utils::Html::toPlainText( QString const & str)
+{
+  // Does it contain HTML? If it does, we need to strip it
+  if ( str.contains( '<' ) || str.contains( '&' ) )
+  {
+    QString tmp = str;
+    {
+      tmp.replace( QRegularExpression( "<(?:\\s*/?(?:div|h[1-6r]|q|p(?![alr])|br|li(?![ns])|td|blockquote|[uo]l|pre|d[dl]|nav|address))[^>]{0,}>",
+                     QRegularExpression::CaseInsensitiveOption ), " " );
+      tmp.replace( QRegularExpression( "<[^>]*>"), " ");
+
+    }
+    return QTextDocumentFragment::fromHtml( tmp.trimmed() ).toPlainText();
+  }
+  return str;
 }

--- a/utils.hh
+++ b/utils.hh
@@ -70,6 +70,8 @@ inline QString trimNonChar( const QString & str )
   return "";
 }
 
+QString trim( const QString & str ,const QRegularExpression & reg);
+
 /**
  * str="abc\r\n\u0000" should be returned as "abc"
  * @brief rstripnull
@@ -312,6 +314,11 @@ QString getSchemeAndHost( QUrl const & url );
 
 namespace Path{
 QString combine(const QString& path1, const QString& path2);
+}
+
+namespace Html{
+  // Replace html entities
+  QString toPlainText( QString const & str );
 }
 
 }


### PR DESCRIPTION
epwing is designed for ebook but not for dictionary.

In a dictionary ,a reference may link to another headword, while in an epwing book ,the link can reference to a part of the content.

In such above situation, the gd's reference link can not work as expected.