### PR TITLE
ffmpeg , replace avformat_open_input's second parameter to NULL

### DIFF
--- a/ffmpegaudio.cc
+++ b/ffmpegaudio.cc
@@ -186,7 +186,7 @@ bool DecoderContext::openCodec( QString & errorString )
   int ret = 0;
   avformatOpened_ = true;
 
-  ret = avformat_open_input( &formatContext_, "_STREAM_", NULL, NULL );
+  ret = avformat_open_input( &formatContext_, NULL, NULL, NULL );
   if ( ret < 0 )
   {
     errorString = QObject::tr( "avformat_open_input() failed: %1." ).arg( avErrorString( ret ) );


### PR DESCRIPTION
the 2nd parameter is useless when context->pd is not null