### PR TITLE
fix: minor problems found by clang leaksanitizer

### DIFF
--- a/article_netmgr.cc
+++ b/article_netmgr.cc
@@ -505,7 +505,9 @@ void BlockedNetworkReply::finishedSlot()
   emit finished();
 }
 
-LocalSchemeHandler::LocalSchemeHandler(ArticleNetworkAccessManager& articleNetMgr):mManager(articleNetMgr){
+LocalSchemeHandler::LocalSchemeHandler(ArticleNetworkAccessManager& articleNetMgr, QObject *parent):
+    QWebEngineUrlSchemeHandler(parent),
+    mManager(articleNetMgr){
 
 }
 

--- a/article_netmgr.hh
+++ b/article_netmgr.hh
@@ -202,7 +202,7 @@ class LocalSchemeHandler : public QWebEngineUrlSchemeHandler
 {
   Q_OBJECT
 public:
-  LocalSchemeHandler( ArticleNetworkAccessManager & articleNetMgr );
+  LocalSchemeHandler( ArticleNetworkAccessManager & articleNetMgr, QObject *parent = nullptr);
   void requestStarted( QWebEngineUrlRequestJob * requestJob );
 
 protected:

--- a/fulltextsearch.hh
+++ b/fulltextsearch.hh
@@ -85,7 +85,7 @@ public:
     isCancelled( cancelled ),
     dictionaries( dicts ),
     hasExited( hasExited_ ),
-    timer(new QTimer(0)),
+    timer(new QTimer(this)),
     timerThread(new QThread(this))
   {
     connect(timer, &QTimer::timeout, this, &Indexing::timeout);

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -163,7 +163,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   GlobalBroadcaster::instance()->setPreference(&cfg.preferences);
 
-  localSchemeHandler = new LocalSchemeHandler( articleNetMgr );
+  localSchemeHandler = new LocalSchemeHandler( articleNetMgr, this);
   QWebEngineProfile::defaultProfile()->installUrlSchemeHandler( "gdlookup", localSchemeHandler );
   QWebEngineProfile::defaultProfile()->installUrlSchemeHandler( "bword", localSchemeHandler );
   QWebEngineProfile::defaultProfile()->installUrlSchemeHandler( "entry", localSchemeHandler );
@@ -172,15 +172,14 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   QWebEngineProfile::defaultProfile()->installUrlSchemeHandler( "ifr", iframeSchemeHandler );
 
   QStringList localSchemes = { "gdau", "gico", "qrcx", "bres", "gdprg", "gdvideo", "gdpicture", "gdtts" };
-  resourceSchemeHandler    = new ResourceSchemeHandler( articleNetMgr );
+  resourceSchemeHandler    = new ResourceSchemeHandler( articleNetMgr, this);
   for( int i = 0; i < localSchemes.size(); i++ )
   {
     QWebEngineProfile::defaultProfile()->installUrlSchemeHandler( localSchemes.at( i ).toLatin1(),
                                                                   resourceSchemeHandler );
   }
 
-  wuri = new WebUrlRequestInterceptor();
-  QWebEngineProfile::defaultProfile()->setUrlRequestInterceptor( wuri );
+  QWebEngineProfile::defaultProfile()->setUrlRequestInterceptor( new WebUrlRequestInterceptor(this) );
 
   if(!cfg.preferences.hideGoldenDictHeader){
     QWebEngineProfile::defaultProfile()->setHttpUserAgent(QWebEngineProfile::defaultProfile()->httpUserAgent()+" GoldenDict/WebEngine");

--- a/mainwindow.hh
+++ b/mainwindow.hh
@@ -84,8 +84,6 @@ private:
 
   QScopedPointer< ArticleInspector > inspector;
 
-  WebUrlRequestInterceptor *wuri;
-
   Ui::MainWindow ui;
 
   /// This widget is used as a title bar for the searchPane dock, and

--- a/resourceschemehandler.cpp
+++ b/resourceschemehandler.cpp
@@ -1,7 +1,8 @@
 #include "resourceschemehandler.h"
 
-ResourceSchemeHandler::ResourceSchemeHandler(ArticleNetworkAccessManager& articleNetMgr):mManager(articleNetMgr){
-
+ResourceSchemeHandler::ResourceSchemeHandler(ArticleNetworkAccessManager& articleNetMgr, QObject *parent):
+    QWebEngineUrlSchemeHandler(parent),
+    mManager(articleNetMgr){
 }
 void ResourceSchemeHandler::requestStarted(QWebEngineUrlRequestJob *requestJob)
 {

--- a/resourceschemehandler.h
+++ b/resourceschemehandler.h
@@ -7,7 +7,7 @@ class ResourceSchemeHandler : public QWebEngineUrlSchemeHandler
 {
     Q_OBJECT
 public:
-    ResourceSchemeHandler(ArticleNetworkAccessManager& articleNetMgr);
+    ResourceSchemeHandler(ArticleNetworkAccessManager& articleNetMgr, QObject *parent = nullptr);
     void requestStarted(QWebEngineUrlRequestJob *requestJob);
 
 protected:

--- a/weburlrequestinterceptor.h
+++ b/weburlrequestinterceptor.h
@@ -7,7 +7,7 @@ class WebUrlRequestInterceptor : public QWebEngineUrlRequestInterceptor
 {
     Q_OBJECT
 public:
-    WebUrlRequestInterceptor(QObject *p = Q_NULLPTR);
+    WebUrlRequestInterceptor(QObject *p);
     void interceptRequest(QWebEngineUrlRequestInfo &info);
   signals:
     void linkClicked( const QUrl & url );


### PR DESCRIPTION
I am playing with a new toy -> clang's memory leak sanitizer

https://clang.llvm.org/docs/AddressSanitizer.html
https://github.com/google/sanitizers

These are some minor issues found:

1 minor leak, QTimer
2 false positives
1 useless variable name

The `QTimer` has no parent, every time we do indexing (not so frequently), a few bytes will be leaked

https://github.com/xiaoyifang/goldendict/blob/8bda599dd0adc8ff3318297acb8a1e1ab90b1711/fulltextsearch.cc#L99-L117

`localSchemeHandler` and `resourceSchemeHandler` cause no issue since they live the entire lifetime of the app, and deleting them via program exit is OK. They are false positives, but just fix them in case of future analysis.

Set parent via superclass's constructor is what qt does in their code.

https://github.com/radekp/qt/blob/b881d8fb99972f1bd04ab4c84843cc8d43ddbeed/src/gui/widgets/qpushbutton.cpp#L253-L254

The solo purpose of variable `wuri` is to ensure the WebUrlRequestInterceptor object exists after `mainwindow`'s constructor.

However, the same purpose can be achieved by set the WebUrlRequestInterceptor object's parent to this.

The object will be registered to the mainwindow's children() list, thus still existing after the constructor and automatically deleted when mainwindow is gone. 
