### PR TITLE
fix: revert QTimer change

### DIFF
--- a/fulltextsearch.hh
+++ b/fulltextsearch.hh
@@ -85,7 +85,7 @@ public:
     isCancelled( cancelled ),
     dictionaries( dicts ),
     hasExited( hasExited_ ),
-    timer(new QTimer(this)),
+    timer(new QTimer(nullptr)), // must be null since it will live in separate thread
     timerThread(new QThread(this))
   {
     connect(timer, &QTimer::timeout, this, &Indexing::timeout);


### PR DESCRIPTION
It is really my bad. This QTimer will live in a thread, if it is gone, then GD will crash.

It's parent must be null.

~~A better fix is probably not putting it here.~~