### PR TITLE
mac: ensure tabbar always show full name

### DIFF
--- a/preferences.ui
+++ b/preferences.ui
@@ -32,6 +32,9 @@
        <height>15</height>
       </size>
      </property>
+     <property name="elideMode">
+      <enum>Qt::ElideNone</enum>
+     </property>
      <property name="usesScrollButtons">
       <bool>false</bool>
      </property>

--- a/sources.ui
+++ b/sources.ui
@@ -25,6 +25,9 @@
        <height>15</height>
       </size>
      </property>
+     <property name="elideMode">
+      <enum>Qt::ElideNone</enum>
+     </property>
      <property name="usesScrollButtons">
       <bool>false</bool>
      </property>


### PR DESCRIPTION
"Elide" of mac's tabbar is too aggressive by default.

| Before  | After |
| ------------- | ------------- |
| <img width="829" alt="Screenshot 2022-12-22 at 2 14 46 AM" src="https://user-images.githubusercontent.com/20123683/209078811-e009a34f-bc1b-4cc2-a968-96e5dd5bafa9.png">  | <img width="944" alt="Screenshot 2022-12-22 at 2 12 11 AM" src="https://user-images.githubusercontent.com/20123683/209078807-77e18f70-41aa-400b-b175-95cd1473e7f7.png">  











