### PR TITLE
Modernization: Use raw strings instead of escaping everywhere

### DIFF
--- a/aard.cc
+++ b/aard.cc
@@ -392,16 +392,16 @@ string AardDictionary::convert( const string & in )
 
     QString text = QString::fromUtf8( inConverted.c_str() );
 
-    text.replace( QRegularExpression( "<\\s*a\\s+href\\s*=\\s*\\\"(w:|s:){0,1}([^#](?!ttp://)[^\\\"]*)(.)",
+    text.replace( QRegularExpression( R"(<\s*a\s+href\s*=\s*\"(w:|s:){0,1}([^#](?!ttp://)[^\"]*)(.))",
                                       QRegularExpression::DotMatchesEverythingOption ),
-                  "<a href=\"bword:\\2\"");
-    text.replace( QRegularExpression( "<\\s*a\\s+href\\s*=\\s*'(w:|s:){0,1}([^#](?!ttp://)[^']*)(.)",
+                  R"(<a href="bword:\2")");
+    text.replace( QRegularExpression( R"(<\s*a\s+href\s*=\s*'(w:|s:){0,1}([^#](?!ttp://)[^']*)(.))",
                                       QRegularExpression::DotMatchesEverythingOption ),
-                  "<a href=\"bword:\\2\"");
+                  R"(<a href="bword:\2")");
 
     // Anchors
-    text.replace( QRegularExpression( "<a\\s+href=\"bword:([^#\"]+)#([^\"]+)" ),
-                  "<a href=\"gdlookup://localhost/\\1?gdanchor=\\2" );
+    text.replace( QRegularExpression( R"(<a\s+href="bword:([^#"]+)#([^"]+))" ),
+                  R"(<a href="gdlookup://localhost/\1?gdanchor=\2)" );
 
     static QRegularExpression self_closing_divs( "(<div\\s+[^>]*)/>",
                                                  QRegularExpression::CaseInsensitiveOption );  // <div ... />

--- a/article_maker.cc
+++ b/article_maker.cc
@@ -59,15 +59,15 @@ std::string ArticleMaker::makeHtmlHeader( QString const & word,
     result += "<script> var $_$=$.noConflict(); </script>";
 
     //custom javascript
-    result += "<script type=\"text/javascript\" src=\"qrc:///scripts/gd-custom.js\"></script>";
+    result += R"(<script type="text/javascript" src="qrc:///scripts/gd-custom.js"></script>)";
 
     //iframe resizer javascript
-    result += "<script type=\"text/javascript\" src=\"qrc:///scripts/iframeResizer.min.js\"></script>";
+    result += R"(<script type="text/javascript" src="qrc:///scripts/iframeResizer.min.js"></script>)";
   }
 
   // add qwebchannel
   {
-    result += "<script type=\"text/javascript\" src=\"qrc:///qtwebchannel/qwebchannel.js\"></script>";
+    result += R"(<script type="text/javascript" src="qrc:///qtwebchannel/qwebchannel.js"></script>)";
   }
 
   // document ready ,init webchannel
@@ -84,14 +84,14 @@ std::string ArticleMaker::makeHtmlHeader( QString const & word,
 
   // Add a css stylesheet
   {
-    result += "<link href=\"qrc:///article-style.css\"  media=\"all\" rel=\"stylesheet\" type=\"text/css\">";
+    result += R"(<link href="qrc:///article-style.css"  media="all" rel="stylesheet" type="text/css">)";
 
     if ( displayStyle.size() )
     {
       // Load an additional stylesheet
       QString displayStyleCssFile = QString("qrc:///article-style-st-%1.css").arg(displayStyle);
       result += "<link href=\"" + displayStyleCssFile.toStdString() +
-                "\"  media=\"all\" rel=\"stylesheet\" type=\"text/css\">";
+                R"("  media="all" rel="stylesheet" type="text/css">)";
     }
 
     result += readCssFile(Config::getUserCssFileName() ,"all");
@@ -117,7 +117,7 @@ std::string ArticleMaker::makeHtmlHeader( QString const & word,
 
   // Add print-only css
   {
-    result += "<link href=\"qrc:///article-style-print.css\"  media=\"print\" rel=\"stylesheet\" type=\"text/css\">";
+    result += R"(<link href="qrc:///article-style-print.css"  media="print" rel="stylesheet" type="text/css">)";
 
     result += readCssFile(Config::getUserCssPrintFileName() ,"print");
 
@@ -134,20 +134,20 @@ std::string ArticleMaker::makeHtmlHeader( QString const & word,
   // This doesn't seem to be much of influence right now, but we'll keep
   // it anyway.
   if ( icon.size() )
-    result += "<link rel=\"icon\" type=\"image/png\" href=\"qrcx://localhost/flags/" + Html::escape( icon.toUtf8().data() ) + "\" />\n";
+    result += R"(<link rel="icon" type="image/png" href="qrcx://localhost/flags/)" + Html::escape( icon.toUtf8().data() ) + "\" />\n";
 
   result += "<script type=\"text/javascript\">"
             "function tr(key) {"
             " var tr_map = {"
             "\"Expand article\":\"";
   result += tr("Expand article").toUtf8().data();
-  result += "\",\"Collapse article\":\"";
+  result += R"(","Collapse article":")";
   result += tr("Collapse article").toUtf8().data();
   result += "\"  };"
             "return tr_map[key] || '';"
             "}"
             "</script>";
-  result+= "<script type=\"text/javascript\" src=\"qrc:///scripts/gd-builtin.js\"></script>";
+  result+= R"(<script type="text/javascript" src="qrc:///scripts/gd-builtin.js"></script>)";
 
 #ifdef Q_OS_WIN32
   if( GlobalBroadcaster::instance()->getPreference()->darkMode )
@@ -175,7 +175,7 @@ std::string ArticleMaker::makeHtmlHeader( QString const & word,
     QByteArray css = addonCss.readAll();
     if (!css.isEmpty()) {
       result += "<!-- Addon style css -->\n";
-      result += "<style type=\"text/css\" media=\"" + media + "\">\n";
+      result += R"(<style type="text/css" media=")" + media + "\">\n";
       result += css.data();
       result += "</style>\n";
     }
@@ -585,7 +585,7 @@ void ArticleRequest::bodyFinished()
 
         if ( closePrevSpan )
         {
-          head += "</div></div><div style=\"clear:both;\"></div><span class=\"gdarticleseparator\"></span>";
+          head += R"(</div></div><div style="clear:both;"></div><span class="gdarticleseparator"></span>)";
         }
 
         bool collapse = false;
@@ -637,15 +637,15 @@ void ArticleRequest::bodyFinished()
 
         closePrevSpan = true;
 
-        head += string( "<div class=\"gddictname\" onclick=\"gdExpandArticle(\'" ) + dictId + "\');"
+        head += string( R"(<div class="gddictname" onclick="gdExpandArticle(')" ) + dictId + "\');"
           + ( collapse ? "\" style=\"cursor:pointer;" : "" )
           + "\" id=\"gddictname-" + Html::escape( dictId ) + "\""
           + ( collapse ? string( " title=\"" ) + tr( "Expand article" ).toUtf8().data() + "\"" : "" )
-          + "><span class=\"gddicticon\"><img src=\"gico://" + Html::escape( dictId )
-          + "/dicticon.png\"></span><span class=\"gdfromprefix\">"  +
+          + R"(><span class="gddicticon"><img src="gico://)" + Html::escape( dictId )
+          + R"(/dicticon.png"></span><span class="gdfromprefix">)"  +
           Html::escape( tr( "From " ).toUtf8().data() ) + "</span><span class=\"gddicttitle\">" +
           Html::escape( activeDict->getName().c_str() ) + "</span>"
-          + "<span class=\"collapse_expand_area\"><img src=\"qrcx://localhost/icons/blank.png\" class=\""
+          + R"(<span class="collapse_expand_area"><img src="qrcx://localhost/icons/blank.png" class=")"
           + ( collapse ? "gdexpandicon" : "gdcollapseicon" )
           + "\" id=\"expandicon-" + Html::escape( dictId ) + "\""
           + ( collapse ? "" : string( " title=\"" ) + tr( "Collapse article" ).toUtf8().data() + "\"" )
@@ -782,7 +782,7 @@ int ArticleRequest::htmlTextSize( QString html )
   //https://bugreports.qt.io/browse/QTBUG-102757
   QString stripStyleSheet =
     html.remove( QRegularExpression( "<link\\s*[^>]*>", QRegularExpression::CaseInsensitiveOption ) )
-      .remove( QRegularExpression( "<script[\\s\\S]*?>[\\s\\S]*?<\\/script>", QRegularExpression::CaseInsensitiveOption|QRegularExpression::MultilineOption ) );
+      .remove( QRegularExpression( R"(<script[\s\S]*?>[\s\S]*?<\/script>)", QRegularExpression::CaseInsensitiveOption|QRegularExpression::MultilineOption ) );
   int size = QTextDocumentFragment::fromHtml( stripStyleSheet ).toPlainText().length();
 
   return size;
@@ -800,7 +800,7 @@ void ArticleRequest::stemmedSearchFinished()
 
   if ( sr.size() )
   {
-    footer += "<div class=\"gdstemmedsuggestion\"><span class=\"gdstemmedsuggestion_head\">" +
+    footer += R"(<div class="gdstemmedsuggestion"><span class="gdstemmedsuggestion_head">)" +
       Html::escape( tr( "Close words: " ).toUtf8().data() ) +
       "</span><span class=\"gdstemmedsuggestion_body\">";
 
@@ -871,7 +871,7 @@ void ArticleRequest::compoundSearchNextStep( bool lastSearchSucceeded )
       if ( !firstCompoundWasFound )
       {
         // Append the beginning
-        footer += "<div class=\"gdstemmedsuggestion\"><span class=\"gdstemmedsuggestion_head\">" +
+        footer += R"(<div class="gdstemmedsuggestion"><span class="gdstemmedsuggestion_head">)" +
           Html::escape( tr( "Compound expressions: " ).toUtf8().data() ) +
           "</span><span class=\"gdstemmedsuggestion_body\">";
 
@@ -899,7 +899,7 @@ void ArticleRequest::compoundSearchNextStep( bool lastSearchSucceeded )
 
       // Now add links to all the individual words. They conclude the result.
 
-      footer += "<div class=\"gdstemmedsuggestion\"><span class=\"gdstemmedsuggestion_head\">" +
+      footer += R"(<div class="gdstemmedsuggestion"><span class="gdstemmedsuggestion_head">)" +
         Html::escape( tr( "Individual words: " ).toUtf8().data() ) +
         "</span><span class=\"gdstemmedsuggestion_body\"";
       if( splittedWords.first[ 0 ].isRightToLeft() )

--- a/base/globalregex.cc
+++ b/base/globalregex.cc
@@ -4,39 +4,39 @@
 using namespace RX;
 
 QRegularExpression Ftx::regBrackets(
-  "(\\([\\w\\p{M}]+\\)){0,1}([\\w\\p{M}]+)(\\([\\w\\p{M}]+\\)){0,1}([\\w\\p{M}]+){0,1}(\\([\\w\\p{M}]+\\)){0,1}",
+  R"((\([\w\p{M}]+\)){0,1}([\w\p{M}]+)(\([\w\p{M}]+\)){0,1}([\w\p{M}]+){0,1}(\([\w\p{M}]+\)){0,1})",
   QRegularExpression::UseUnicodePropertiesOption );
 QRegularExpression Ftx::regSplit( "[^\\w\\p{M}]+", QRegularExpression::UseUnicodePropertiesOption );
 
 QRegularExpression Ftx::spacesRegExp( "\\W+", QRegularExpression::UseUnicodePropertiesOption );
 QRegularExpression Ftx::wordRegExp( QString( "\\w{" ) + QString::number( FTS::MinimumWordSize ) + ",}",
                                     QRegularExpression::UseUnicodePropertiesOption );
-QRegularExpression Ftx::setsRegExp( "\\[[^\\]]+\\]", QRegularExpression::CaseInsensitiveOption );
-QRegularExpression Ftx::regexRegExp( "\\\\[afnrtvdDwWsSbB]|\\\\x([0-9A-Fa-f]{4})|\\\\0([0-7]{3})",
+QRegularExpression Ftx::setsRegExp( R"(\[[^\]]+\])", QRegularExpression::CaseInsensitiveOption );
+QRegularExpression Ftx::regexRegExp( R"(\\[afnrtvdDwWsSbB]|\\x([0-9A-Fa-f]{4})|\\0([0-7]{3}))",
                                      QRegularExpression::CaseInsensitiveOption );
 
-QRegularExpression Ftx::handleRoundBracket( "[^\\w\\(\\)\\p{M}]+" ,
+QRegularExpression Ftx::handleRoundBracket( R"([^\w\(\)\p{M}]+)" ,
                                             QRegularExpression::UseUnicodePropertiesOption );
 QRegularExpression Ftx::noRoundBracket( "[^\\w\\p{M}]+",
                                         QRegularExpression::UseUnicodePropertiesOption );
 
-QRegularExpression Ftx::tokenBoundary( "[\\*\\?\\+]|\\bAnd\\b|\\bOR\\b", QRegularExpression::CaseInsensitiveOption );
-QRegularExpression Ftx::token("(\".*?\")|([\\w\\W\\+\\-]+)",QRegularExpression::DotMatchesEverythingOption|QRegularExpression::CaseInsensitiveOption);
+QRegularExpression Ftx::tokenBoundary( R"([\*\?\+]|\bAnd\b|\bOR\b)", QRegularExpression::CaseInsensitiveOption );
+QRegularExpression Ftx::token(R"((".*?")|([\w\W\+\-]+))",QRegularExpression::DotMatchesEverythingOption|QRegularExpression::CaseInsensitiveOption);
 //mdx
 
-QRegularExpression Mdx::allLinksRe( "(?:<\\s*(a(?:rea)?|img|link|script|source)(?:\\s+[^>]+|\\s*)>)",
+QRegularExpression Mdx::allLinksRe( R"((?:<\s*(a(?:rea)?|img|link|script|source)(?:\s+[^>]+|\s*)>))",
                                     QRegularExpression::CaseInsensitiveOption );
-QRegularExpression Mdx::wordCrossLink( "([\\s\"']href\\s*=)\\s*([\"'])entry://([^>#]*?)((?:#[^>]*?)?)\\2",
+QRegularExpression Mdx::wordCrossLink( R"(([\s"']href\s*=)\s*(["'])entry://([^>#]*?)((?:#[^>]*?)?)\2)",
                                        QRegularExpression::CaseInsensitiveOption );
-QRegularExpression Mdx::anchorIdRe( "([\\s\"'](?:name|id)\\s*=)\\s*([\"'])\\s*(?=\\S)",
+QRegularExpression Mdx::anchorIdRe( R"(([\s"'](?:name|id)\s*=)\s*(["'])\s*(?=\S))",
                                     QRegularExpression::CaseInsensitiveOption );
-QRegularExpression Mdx::anchorIdReWord( "([\\s\"'](?:name|id)\\s*=)\\s*([\"'])\\s*(?=\\S)([^\"]*)",
+QRegularExpression Mdx::anchorIdReWord( R"(([\s"'](?:name|id)\s*=)\s*(["'])\s*(?=\S)([^"]*))",
                                         QRegularExpression::CaseInsensitiveOption );
-QRegularExpression Mdx::anchorIdRe2( "([\\s\"'](?:name|id)\\s*=)\\s*(?=[^\"'])([^\\s\">]+)",
+QRegularExpression Mdx::anchorIdRe2( R"(([\s"'](?:name|id)\s*=)\s*(?=[^"'])([^\s">]+))",
                                      QRegularExpression::CaseInsensitiveOption );
-QRegularExpression Mdx::anchorLinkRe( "([\\s\"']href\\s*=\\s*[\"'])entry://#",
+QRegularExpression Mdx::anchorLinkRe( R"(([\s"']href\s*=\s*["'])entry://#)",
                                       QRegularExpression::CaseInsensitiveOption );
-QRegularExpression Mdx::audioRe( "([\\s\"']href\\s*=)\\s*([\"'])sound://([^\">]+)\\2",
+QRegularExpression Mdx::audioRe( R"(([\s"']href\s*=)\s*(["'])sound://([^">]+)\2)",
                                  QRegularExpression::CaseInsensitiveOption
                                    | QRegularExpression::InvertedGreedinessOption );
 QRegularExpression Mdx::stylesRe( "([\\s\"']href\\s*=)\\s*([\"'])(?!\\s*\\b(?:(?:bres|https?|ftp)://"
@@ -45,7 +45,7 @@ QRegularExpression Mdx::stylesRe( "([\\s\"']href\\s*=)\\s*([\"'])(?!\\s*\\b(?:(?
 QRegularExpression Mdx::stylesRe2( "([\\s\"']href\\s*=)\\s*(?![\\s\"']|\\b(?:(?:bres|https?|ftp)://"
                                    "|(?:data|javascript):))(?:file://)?[\\x00-\\x1f\\x7f]*\\.*/?([^\\s\">]+)",
                                    QRegularExpression::CaseInsensitiveOption );
-QRegularExpression Mdx::inlineScriptRe( "<\\s*script(?:(?=\\s)(?:(?![\\s\"']src\\s*=)[^>])+|\\s*)>",
+QRegularExpression Mdx::inlineScriptRe( R"(<\s*script(?:(?=\s)(?:(?![\s"']src\s*=)[^>])+|\s*)>)",
                                         QRegularExpression::CaseInsensitiveOption );
 QRegularExpression Mdx::closeScriptTagRe( "<\\s*/script\\s*>", QRegularExpression::CaseInsensitiveOption );
 QRegularExpression Mdx::srcRe( "([\\s\"'](?:src|srcset)\\s*=)\\s*([\"'])(?!\\s*\\b(?:(?:bres|https?|ftp)://"
@@ -55,13 +55,13 @@ QRegularExpression Mdx::srcRe2( "([\\s\"'](?:src|srcset)\\s*=)\\s*(?![\\s\"']|\\
                                 "|(?:data|javascript):))(?:file://)?[\\x00-\\x1f\\x7f]*\\.*/?([^\\s\">]+)",
                                 QRegularExpression::CaseInsensitiveOption );
 
-QRegularExpression Mdx::links( "url\\(\\s*(['\"]?)([^'\"]*)(['\"]?)\\s*\\)",
+QRegularExpression Mdx::links( R"(url\(\s*(['"]?)([^'"]*)(['"]?)\s*\))",
                                QRegularExpression::CaseInsensitiveOption );
 
-QRegularExpression Mdx::fontFace( "(?:url\\s*\\(\\s*\\\"(.*?)\\\"\\s*)\\)",
+QRegularExpression Mdx::fontFace( R"((?:url\s*\(\s*\"(.*?)\"\s*)\))",
                                     QRegularExpression::CaseInsensitiveOption|QRegularExpression::DotMatchesEverythingOption );
 
-QRegularExpression Mdx::styleElment( "(<style[^>]*>)([\\w\\W]*?)(<\\/style>)",
+QRegularExpression Mdx::styleElment( R"((<style[^>]*>)([\w\W]*?)(<\/style>))",
                                   QRegularExpression::CaseInsensitiveOption);
 
 

--- a/bgl.cc
+++ b/bgl.cc
@@ -890,20 +890,20 @@ void BglArticleRequest::run()
 
   result = QString::fromUtf8( result.c_str() )
           // onclick location to link
-          .replace( QRegularExpression( "<([a-z0-9]+)\\s+[^>]*onclick=\"[a-z.]*location(?:\\.href)\\s*=\\s*'([^']+)[^>]*>([^<]+)</\\1>",
+          .replace( QRegularExpression( R"(<([a-z0-9]+)\s+[^>]*onclick="[a-z.]*location(?:\.href)\s*=\s*'([^']+)[^>]*>([^<]+)</\1>)",
                                         QRegularExpression::CaseInsensitiveOption ),
-                    "<a href=\"\\2\">\\3</a>")
-           .replace( QRegularExpression( "(<\\s*a\\s+[^>]*href\\s*=\\s*[\"']\\s*)bword://",
+                    R"(<a href="\2">\3</a>)")
+           .replace( QRegularExpression( R"((<\s*a\s+[^>]*href\s*=\s*["']\s*)bword://)",
                                          QRegularExpression::CaseInsensitiveOption ),
                      "\\1bword:" )
           //remove invalid width, height attrs
-          .replace( QRegularExpression( "(width|height)\\s*=\\s*[\"']\\d{7,}[\"'']" ),
+          .replace( QRegularExpression( R"((width|height)\s*=\s*["']\d{7,}["''])" ),
                    "" )
           //remove invalid <br> tag
-          .replace( QRegularExpression( "<br>(<div|<table|<tbody|<tr|<td|</div>|</table>|</tbody>|</tr>|</td>|function addScript|var scNode|scNode|var atag|while\\(atag|atag=atag|document\\.getElementsByTagName|addScript|src=\"bres|<a onmouseover=\"return overlib|onclick=\"return overlib)",
+          .replace( QRegularExpression( R"(<br>(<div|<table|<tbody|<tr|<td|</div>|</table>|</tbody>|</tr>|</td>|function addScript|var scNode|scNode|var atag|while\(atag|atag=atag|document\.getElementsByTagName|addScript|src="bres|<a onmouseover="return overlib|onclick="return overlib))",
                                         QRegularExpression::CaseInsensitiveOption ),
                     "\\1" )
-          .replace( QRegularExpression( "(AUTOSTATUS, WRAP\\);\" |</DIV>|addScript\\('JS_FILE_PHONG_VT_45634'\\);|appendChild\\(scNode\\);|atag\\.firstChild;)<br>",
+          .replace( QRegularExpression( R"((AUTOSTATUS, WRAP\);" |</DIV>|addScript\('JS_FILE_PHONG_VT_45634'\);|appendChild\(scNode\);|atag\.firstChild;)<br>)",
                                         QRegularExpression::CaseInsensitiveOption ),
                     " \\1 " )
            .toUtf8().data();
@@ -1079,7 +1079,7 @@ sptr< Dictionary::DataRequest > BglDictionary::getResource( string const & name 
   {
     QString str = QString::fromUtf8( text.c_str() );
 
-    QRegularExpression charsetExp( "<\\s*charset\\s+c\\s*=\\s*[\"']?t[\"']?\\s*>((?:\\s*[0-9a-fA-F]+\\s*;\\s*)*)<\\s*/\\s*charset\\s*>",
+    QRegularExpression charsetExp( R"(<\s*charset\s+c\s*=\s*["']?t["']?\s*>((?:\s*[0-9a-fA-F]+\s*;\s*)*)<\s*/\s*charset\s*>)",
                                    QRegularExpression::CaseInsensitiveOption
                                    | QRegularExpression::InvertedGreedinessOption );
 

--- a/dictdfiles.cc
+++ b/dictdfiles.cc
@@ -341,9 +341,9 @@ sptr< Dictionary::DataRequest > DictdDictionary::getArticle( wstring const & wor
       }
       else
       {
-        static QRegularExpression phonetic( "\\\\([^\\\\]+)\\\\",
+        static QRegularExpression phonetic( R"(\\([^\\]+)\\)",
                                             QRegularExpression::CaseInsensitiveOption ); // phonetics: \stuff\ ...
-        static QRegularExpression refs( "\\{([^\\{\\}]+)\\}",
+        static QRegularExpression refs( R"(\{([^\{\}]+)\})",
                                         QRegularExpression::CaseInsensitiveOption );     // links: {stuff}
         static QRegularExpression links( "<a href=\"gdlookup://localhost/([^\"]*)\">",
                                          QRegularExpression::CaseInsensitiveOption );
@@ -360,8 +360,8 @@ sptr< Dictionary::DataRequest > DictdDictionary::getArticle( wstring const & wor
         free( articleBody );
 
         QString articleString = QString::fromUtf8( convertedText.c_str() )
-                                .replace(phonetic, "<span class=\"dictd_phonetic\">\\1</span>")
-                                .replace(refs, "<a href=\"gdlookup://localhost/\\1\">\\1</a>");
+                                .replace(phonetic, R"(<span class="dictd_phonetic">\1</span>)")
+                                .replace(refs, R"(<a href="gdlookup://localhost/\1">\1</a>)");
         convertedText.erase();
 
         int pos = 0;
@@ -546,17 +546,17 @@ void DictdDictionary::getArticleText( uint32_t articleAddress, QString & headwor
     }
     else
     {
-      static QRegularExpression phonetic( "\\\\([^\\\\]+)\\\\",
+      static QRegularExpression phonetic( R"(\\([^\\]+)\\)",
                                           QRegularExpression::CaseInsensitiveOption ); // phonetics: \stuff\ ...
-      static QRegularExpression refs( "\\{([^\\{\\}]+)\\}",
+      static QRegularExpression refs( R"(\{([^\{\}]+)\})",
                                       QRegularExpression::CaseInsensitiveOption );     // links: {stuff}
 
       string convertedText = Html::preformat( articleBody, isToLanguageRTL() );
       free( articleBody );
 
       text = QString::fromUtf8( convertedText.data(), convertedText.size() )
-            .replace(phonetic, "<span class=\"dictd_phonetic\">\\1</span>")
-            .replace(refs, "<a href=\"gdlookup://localhost/\\1\">\\1</a>");
+            .replace(phonetic, R"(<span class="dictd_phonetic">\1</span>)")
+            .replace(refs, R"(<a href="gdlookup://localhost/\1">\1</a>)");
 
       text = Html::unescape( text );
     }

--- a/dictionary.cc
+++ b/dictionary.cc
@@ -345,9 +345,9 @@ void Class::isolateCSS( QString & css, QString const & wrapperSelector )
   if( css.isEmpty() )
     return;
 
-  QRegularExpression reg1( "\\/\\*(?:.(?!\\*\\/))*.?\\*\\/",
+  QRegularExpression reg1( R"(\/\*(?:.(?!\*\/))*.?\*\/)",
                            QRegularExpression::DotMatchesEverythingOption );
-  QRegularExpression reg2( "[ \\*\\>\\+,;:\\[\\{\\]]" );
+  QRegularExpression reg2( R"([ \*\>\+,;:\[\{\]])" );
   QRegularExpression reg3( "[,;\\{]" );
 
 

--- a/dictserver.cc
+++ b/dictserver.cc
@@ -799,11 +799,11 @@ void DictServerArticleRequest::run()
             if( Utils::AtomicInt::loadAcquire( isCancelled ) || !errorString.isEmpty() )
               break;
 
-            static QRegularExpression phonetic( "\\\\([^\\\\]+)\\\\",
+            static QRegularExpression phonetic( R"(\\([^\\]+)\\)",
                                                 QRegularExpression::CaseInsensitiveOption ); // phonetics: \stuff\ ...
             static QRegularExpression divs_inside_phonetic( "</div([^>]*)><div([^>]*)>",
                                                             QRegularExpression::CaseInsensitiveOption );
-            static QRegularExpression refs( "\\{([^\\{\\}]+)\\}",
+            static QRegularExpression refs( R"(\{([^\{\}]+)\})",
                                             QRegularExpression::CaseInsensitiveOption );     // links: {stuff}
             static QRegularExpression links( "<a href=\"gdlookup://localhost/([^\"]*)\">",
                                              QRegularExpression::CaseInsensitiveOption );
@@ -819,7 +819,7 @@ void DictServerArticleRequest::run()
             articleText = QString::fromUtf8( articleStr.c_str(), articleStr.size() );
             if( !contentInHtml )
             {
-              articleText = articleText.replace(refs, "<a href=\"gdlookup://localhost/\\1\">\\1</a>" );
+              articleText = articleText.replace(refs, R"(<a href="gdlookup://localhost/\1">\1</a>)" );
 
               pos = 0;
               QString articleNewText;
@@ -834,7 +834,7 @@ void DictServerArticleRequest::run()
                 pos = match.capturedEnd();
 
                 QString phonetic_text = match.captured( 1 );
-                phonetic_text.replace( divs_inside_phonetic, "</span></div\\1><div\\2><span class=\"dictd_phonetic\">" );
+                phonetic_text.replace( divs_inside_phonetic, R"(</span></div\1><div\2><span class="dictd_phonetic">)" );
 
                 articleNewText += "<span class=\"dictd_phonetic\">" + phonetic_text + "</span>";
               }

--- a/dsl.cc
+++ b/dsl.cc
@@ -826,7 +826,7 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
       string id = "O" + getId().substr( 0, 7 ) + "_" +
                 QString::number( articleNom ).toStdString() +
                 "_opt_" + QString::number( optionalPartNom++ ).toStdString();
-    result += "<span class=\"dsl_opt\" id=\"" + id + "\">" + processNodeChildren( node ) + "</span>";
+    result += R"(<span class="dsl_opt" id=")" + id + "\">" + processNodeChildren( node ) + "</span>";
   }
   else if( node.tagName ==  U"m"  )
     result += "<div class=\"dsl_m\">" + processNodeChildren( node ) + "</div>";
@@ -869,7 +869,7 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
 
       result += addAudioLink( ref, getId() );
 
-      result += "<span class=\"dsl_s_wav\"><a href=" + ref + "><img src=\"qrcx://localhost/icons/playsound.png\" border=\"0\" align=\"absmiddle\" alt=\"Play\"/></a></span>";
+      result += "<span class=\"dsl_s_wav\"><a href=" + ref + R"(><img src="qrcx://localhost/icons/playsound.png" border="0" align="absmiddle" alt="Play"/></a></span>)";
     }
     else
     if ( Filetype::isNameOfPicture( filename ) )
@@ -968,7 +968,7 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
       url.setHost( QString::fromUtf8( getId().c_str() ) );
       url.setPath( Utils::Url::ensureLeadingSlash( QString::fromUtf8( filename.c_str() ) ) );
 
-      result += string( "<a class=\"dsl_s dsl_video\" href=\"" ) + url.toEncoded().data() + "\">"
+      result += string( R"(<a class="dsl_s dsl_video" href=")" ) + url.toEncoded().data() + "\">"
              + "<span class=\"img\"></span>"
              + "<span class=\"filename\">" + processNodeChildren( node ) + "</span>" + "</a>";
     }
@@ -981,7 +981,7 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
       url.setHost( QString::fromUtf8( getId().c_str() ) );
       url.setPath( Utils::Url::ensureLeadingSlash( QString::fromUtf8( filename.c_str() ) ) );
 
-      result += string( "<a class=\"dsl_s\" href=\"" ) + url.toEncoded().data()
+      result += string( R"(<a class="dsl_s" href=")" ) + url.toEncoded().data()
              + "\">" + processNodeChildren( node ) + "</a>";
     }
   }
@@ -1006,7 +1006,7 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
       }
     }
 
-    result += "<a class=\"dsl_url\" href=\"" + link +"\">" + processNodeChildren( node ) + "</a>";
+    result += R"(<a class="dsl_url" href=")" + link +"\">" + processNodeChildren( node ) + "</a>";
   }
   else if( node.tagName ==  U"!trs"  )
   {
@@ -1065,7 +1065,7 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
     // We generate two spans, one with accented data and another one without it, so the
     // user could pick up the best suitable option.
     string data = processNodeChildren( node );
-    result += "<span class=\"dsl_stress\"><span class=\"dsl_stress_without_accent\">" + data + "</span>"
+    result += R"(<span class="dsl_stress"><span class="dsl_stress_without_accent">)" + data + "</span>"
         + "<span class=\"dsl_stress_with_accent\">" + data + Utf8::encode( wstring( 1, 0x301 ) )
         + "</span></span>";
   }
@@ -1123,7 +1123,7 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
       }
     }
 
-    result += string( "<a class=\"dsl_ref\" href=\"" ) + url.toEncoded().data() +"\">"
+    result += string( R"(<a class="dsl_ref" href=")" ) + url.toEncoded().data() +"\">"
               + processNodeChildren( node ) + "</a>";
   }
   else if( node.tagName ==  U"@"  )
@@ -1138,7 +1138,7 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
     normalizeHeadword( nodeStr );
     url.setPath( Utils::Url::ensureLeadingSlash( gd::toQString( nodeStr ) ) );
 
-    result += string( "<a class=\"dsl_ref\" href=\"" ) + url.toEncoded().data() +"\">"
+    result += string( R"(<a class="dsl_ref" href=")" ) + url.toEncoded().data() +"\">"
               + processNodeChildren( node ) + "</a>";
   }
   else if( node.tagName ==  U"sub"  )
@@ -1159,7 +1159,7 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
   }
   else
   {
-    gdWarning( "DSL: Unknown tag \"%s\" with attributes \"%s\" found in \"%s\", article \"%s\".",
+    gdWarning( R"(DSL: Unknown tag "%s" with attributes "%s" found in "%s", article "%s".)",
                gd::toQString( node.tagName ).toUtf8().data(), gd::toQString( node.tagAttrs ).toUtf8().data(),
                getName().c_str(), gd::toQString( currentHeadword ).toUtf8().data() );
 
@@ -1513,9 +1513,9 @@ void DslDictionary::getArticleText( uint32_t articleAddress, QString & headword,
 
     // Strip tags
 
-    text.replace( QRegularExpression( "\\[(|/)(p|trn|ex|com|\\*|t|br|m[0-9]?)\\]" ), " " );
-    text.replace( QRegularExpression( "\\[(|/)lang(\\s[^\\]]*)?\\]" ), " " );
-    text.remove( QRegularExpression( "\\[[^\\\\\\[\\]]+\\]" ) );
+    text.replace( QRegularExpression( R"(\[(|/)(p|trn|ex|com|\*|t|br|m[0-9]?)\])" ), " " );
+    text.replace( QRegularExpression( R"(\[(|/)lang(\s[^\]]*)?\])" ), " " );
+    text.remove( QRegularExpression( R"(\[[^\\\[\]]+\])" ) );
 
     text.remove( QString::fromLatin1( "<<" ) );
     text.remove( QString::fromLatin1( ">>" ) );
@@ -1698,7 +1698,7 @@ void DslArticleRequest::run()
         string prefix = "O" + dict.getId().substr( 0, 7 ) + "_" + QString::number( dict.articleNom ).toStdString();
         string id1 = prefix + "_expand";
         string id2 = prefix + "_opt_";
-        string button = " <img src=\"qrcx://localhost/icons/expand_opt.png\" class=\"hidden_expand_opt\" id=\"" + id1 +
+        string button = R"( <img src="qrcx://localhost/icons/expand_opt.png" class="hidden_expand_opt" id=")" + id1 +
                         "\" onclick=\"gdExpandOptPart('" + id1 + "','" + id2 +"')\" alt=\"[+]\"/>";
         if( articleText.compare( articleText.size() - 4, 4, "</p>" ) == 0 )
           articleText.insert( articleText.size() - 4, " " + button );

--- a/dsl_details.cc
+++ b/dsl_details.cc
@@ -145,7 +145,7 @@ string findCodeForDslId( int id )
 bool isAtSignFirst( wstring const & str )
 {
   // Test if '@' is first in string except spaces and dsl tags
-  QRegularExpression reg( "[ \\t]*(?:\\[[^\\]]+\\][ \\t]*)*@", QRegularExpression::PatternOption::CaseInsensitiveOption);
+  QRegularExpression reg( R"([ \t]*(?:\[[^\]]+\][ \t]*)*@)", QRegularExpression::PatternOption::CaseInsensitiveOption);
   return gd::toQString( str ).indexOf (reg) == 0;
 }
 
@@ -356,11 +356,11 @@ ArticleDom::ArticleDom( wstring const & str, string const & dictName,
         catch( eot )
         {
           if( !dictionaryName.empty() )
-            gdWarning( "DSL: Unfinished tag \"%s\" with attributes \"%s\" found in \"%s\", article \"%s\".",
+            gdWarning( R"(DSL: Unfinished tag "%s" with attributes "%s" found in "%s", article "%s".)",
                        gd::toQString( name ).toUtf8().data(), gd::toQString( attrs ).toUtf8().data(),
                        dictionaryName.c_str(), gd::toQString( headword ).toUtf8().data() );
           else
-            gdWarning( "DSL: Unfinished tag \"%s\" with attributes \"%s\" found",
+            gdWarning( R"(DSL: Unfinished tag "%s" with attributes "%s" found)",
                        gd::toQString( name ).toUtf8().data(), gd::toQString( attrs ).toUtf8().data() );
 
           throw eot();
@@ -814,7 +814,7 @@ void ArticleDom::closeTag( wstring const & name,
   if ( warn )
   {
     if( !dictionaryName.empty() )
-      gdWarning( "No corresponding opening tag for closing tag \"%s\" found in \"%s\", article \"%s\".",
+      gdWarning( R"(No corresponding opening tag for closing tag "%s" found in "%s", article "%s".)",
                  gd::toQString( name ).toUtf8().data(), dictionaryName.c_str(),
                  gd::toQString( headword ).toUtf8().data() );
     else

--- a/epwing_book.cc
+++ b/epwing_book.cc
@@ -1041,7 +1041,7 @@ void EpwingBook::fixHeadword( QString & headword )
   headword.remove( QChar( 0x30FB ) ); // Used in Japan transcription
 
   //replace any unicode Number ,Symbol ,Punctuation ,Mark character to whitespace
-  headword.replace( QRegularExpression( "[\\p{N}\\p{S}\\p{P}\\p{M}]" ), " " );
+  headword.replace( QRegularExpression( R"([\p{N}\p{S}\p{P}\p{M}])" ), " " );
 
   //if( isHeadwordCorrect( headword) )
   //  return;
@@ -1320,7 +1320,7 @@ QByteArray EpwingBook::handleColorImage( EB_Hook_Code code,
   url.setScheme( "bres" );
   url.setHost( dictID );
   url.setPath( Utils::Url::ensureLeadingSlash( name ) );
-  QByteArray urlStr = "<p class=\"epwing_image\"><img src=\"" + url.toEncoded()
+  QByteArray urlStr = R"(<p class="epwing_image"><img src=")" + url.toEncoded()
                       + "\" alt=\"" + name.toUtf8() + "\"></p>";
 
   if( imageCacheList.contains( name, Qt::CaseSensitive ) )
@@ -1403,7 +1403,7 @@ QByteArray EpwingBook::handleMonoImage( EB_Hook_Code code,
   url.setScheme( "bres" );
   url.setHost( dictID );
   url.setPath( Utils::Url::ensureLeadingSlash( name ) );
-  QByteArray urlStr = "<span class=\"epwing_image\"><img src=\"" + url.toEncoded()
+  QByteArray urlStr = R"(<span class="epwing_image"><img src=")" + url.toEncoded()
                       + "\" alt=\"" + name.toUtf8() + "\"/></span>";
 
   if( imageCacheList.contains( name, Qt::CaseSensitive ) )
@@ -1451,7 +1451,7 @@ QByteArray EpwingBook::handleWave( EB_Hook_Code code, const unsigned int * argv 
 {
 
   if( code == EB_HOOK_END_WAVE )
-    return QByteArray( "<img src=\"qrcx://localhost/icons/playsound.png\" border=\"0\" align=\"absmiddle\" alt=\"Play\"/></a></span>" );
+    return QByteArray( R"(<img src="qrcx://localhost/icons/playsound.png" border="0" align="absmiddle" alt="Play"/></a></span>)" );
 
   // Handle EB_HOOK_BEGIN_WAVE
 
@@ -1638,7 +1638,7 @@ QByteArray EpwingBook::handleNarrowFont( const unsigned int * argv,
   url.setHost( "/");
   url.setPath( Utils::Url::ensureLeadingSlash( QDir::fromNativeSeparators( fullName ) ) );
 
-  QByteArray link = "<img class=\"epwing_narrow_font\" src=\"" + url.toEncoded() + "\"/>";
+  QByteArray link = R"(<img class="epwing_narrow_font" src=")" + url.toEncoded() + "\"/>";
 
   if( fontsCacheList.contains( fname, Qt::CaseSensitive ) )
   {
@@ -1708,7 +1708,7 @@ QByteArray EpwingBook::handleWideFont( const unsigned int * argv,
   url.setHost( "/");
   url.setPath( Utils::Url::ensureLeadingSlash( QDir::fromNativeSeparators( fullName ) ) );
 
-  QByteArray link = "<img class=\"epwing_wide_font\" src=\"" + url.toEncoded() + "\"/>";
+  QByteArray link = R"(<img class="epwing_wide_font" src=")" + url.toEncoded() + "\"/>";
 
   if( fontsCacheList.contains( fname, Qt::CaseSensitive ) )
   {

--- a/folding.cc
+++ b/folding.cc
@@ -667,7 +667,7 @@ void normalizeWhitespace( wstring & str )
 QString escapeWildcardSymbols( const QString & str )
 {
   QString escaped( str );
-  escaped.replace( QRegularExpression( "([\\[\\]\\?\\*])" ), "\\\\1" );
+  escaped.replace( QRegularExpression( R"(([\[\]\?\*]))" ), "\\\\1" );
 
   return escaped;
 }
@@ -675,7 +675,7 @@ QString escapeWildcardSymbols( const QString & str )
 QString unescapeWildcardSymbols( const QString & str )
 {
   QString unescaped( str );
-  unescaped.replace( QRegularExpression( "\\\\([\\[\\]\\?\\*])" ), "\\1" );
+  unescaped.replace( QRegularExpression( R"(\\([\[\]\?\*]))" ), "\\1" );
 
   return unescaped;
 }

--- a/forvo.cc
+++ b/forvo.cc
@@ -271,7 +271,7 @@ void ForvoArticleRequest::requestFinished( QNetworkReply * r )
                 string addTime =
                     tr( "Added %1" ).arg( item.namedItem( "addtime" ).toElement().text() ).toUtf8().data();
 
-                articleBody += "<td><a href=" + ref + " title=\"" + Html::escape( addTime ) + "\"><img src=\"qrcx://localhost/icons/playsound.png\" border=\"0\" alt=\"Play\"/></a></td>";
+                articleBody += "<td><a href=" + ref + " title=\"" + Html::escape( addTime ) + R"("><img src="qrcx://localhost/icons/playsound.png" border="0" alt="Play"/></a></td>)";
                 articleBody += string( "<td>" ) + tr( "by" ).toUtf8().data() + " <a class='forvo_user' href='"
                                + userProfile + "'>"
                                + Html::escape( user.toUtf8().data() )

--- a/gls.cc
+++ b/gls.cc
@@ -727,7 +727,7 @@ void GlsDictionary::loadArticle( uint32_t address,
   }
 
   if( isToLanguageRTL() )
-    article += "<div style=\"display:inline;\" dir=\"rtl\">";
+    article += R"(<div style="display:inline;" dir="rtl">)";
 
   QString text = QString::fromUtf8( articleBody.c_str(), articleBody.size() );
 
@@ -743,10 +743,10 @@ void GlsDictionary::loadArticle( uint32_t address,
 
 QString & GlsDictionary::filterResource( QString & article )
 {
-  QRegularExpression imgRe( "(<\\s*img\\s+[^>]*src\\s*=\\s*[\"']+)(?!(?:data|https?|ftp|qrcx):)",
+  QRegularExpression imgRe( R"((<\s*img\s+[^>]*src\s*=\s*["']+)(?!(?:data|https?|ftp|qrcx):))",
                             QRegularExpression::CaseInsensitiveOption
                             | QRegularExpression::InvertedGreedinessOption );
-  QRegularExpression linkRe( "(<\\s*link\\s+[^>]*href\\s*=\\s*[\"']+)(?!(?:data|https?|ftp):)",
+  QRegularExpression linkRe( R"((<\s*link\s+[^>]*href\s*=\s*["']+)(?!(?:data|https?|ftp):))",
                              QRegularExpression::CaseInsensitiveOption
                              | QRegularExpression::InvertedGreedinessOption );
 
@@ -755,7 +755,7 @@ QString & GlsDictionary::filterResource( QString & article )
 
   // Handle links to articles
 
-  QRegularExpression linksReg( "<a(\\s+[^>]*)href\\s*=\\s*['\"](bword://)?([^'\"]+)['\"]",
+  QRegularExpression linksReg( R"(<a(\s+[^>]*)href\s*=\s*['"](bword://)?([^'"]+)['"])",
                                QRegularExpression::CaseInsensitiveOption );
 
   int pos = 0;
@@ -803,7 +803,7 @@ QString & GlsDictionary::filterResource( QString & article )
 
   // Handle "audio" tags
 
-  QRegularExpression audioRe( "<\\s*audio\\s+src\\s*=\\s*([\"']+)([^\"']+)([\"'])\\s*>(.*)</audio>",
+  QRegularExpression audioRe( R"(<\s*audio\s+src\s*=\s*(["']+)([^"']+)(["'])\s*>(.*)</audio>)",
                               QRegularExpression::CaseInsensitiveOption
                               | QRegularExpression::DotMatchesEverythingOption
                               | QRegularExpression::InvertedGreedinessOption );
@@ -828,7 +828,7 @@ QString & GlsDictionary::filterResource( QString & article )
       QString newTag = QString::fromUtf8( ( addAudioLink( href, getId() ) + "<span class=\"gls_wav\"><a href=" + href + ">" ).c_str() );
       newTag += match.captured( 4 );
       if( match.captured( 4 ).indexOf( "<img " ) < 0 )
-        newTag += " <img src=\"qrcx://localhost/icons/playsound.png\" border=\"0\" alt=\"Play\">";
+        newTag += R"( <img src="qrcx://localhost/icons/playsound.png" border="0" alt="Play">)";
       newTag += "</a></span>";
 
       articleNewText += newTag;
@@ -1302,7 +1302,7 @@ void GlsResourceRequest::run()
       QString id = QString::fromUtf8( dict.getId().c_str() );
       int pos = 0;
 
-      QRegularExpression links( "url\\(\\s*(['\"]?)([^'\"]*)(['\"]?)\\s*\\)",
+      QRegularExpression links( R"(url\(\s*(['"]?)([^'"]*)(['"]?)\s*\))",
                                 QRegularExpression::CaseInsensitiveOption );
 
       QString newCSS;

--- a/htmlescape.cc
+++ b/htmlescape.cc
@@ -159,7 +159,7 @@ QString unescape( QString const & str, bool saveFormat )
 
 QString fromHtmlEscaped( QString const & str){
   QString retVal = str;
-  QRegularExpression regExp("(?<lt>\\&lt\\;)|(?<gt>\\&gt\\;)|(?<amp>\\&amp\\;)|(?<quot>\\&quot\\;)", QRegularExpression::PatternOption::CaseInsensitiveOption);
+  QRegularExpression regExp(R"((?<lt>\&lt\;)|(?<gt>\&gt\;)|(?<amp>\&amp\;)|(?<quot>\&quot\;))", QRegularExpression::PatternOption::CaseInsensitiveOption);
   auto match = regExp.match(str, 0);
 
   while (match.hasMatch())

--- a/hunspell.cc
+++ b/hunspell.cc
@@ -473,7 +473,7 @@ QVector< wstring > suggest( wstring & word, Mutex & hunspellMutex, Hunspell & hu
 
       wstring lowercasedWord = Folding::applySimpleCaseOnly( word );
 
-      static QRegExp cutStem( "^\\s*st:(((\\s+(?!\\w{2}:)(?!-)(?!\\+))|\\S+)+)" );
+      static QRegExp cutStem( R"(^\s*st:(((\s+(?!\w{2}:)(?!-)(?!\+))|\S+)+))" );
 
       for( vector< string >::size_type x = 0; x < suggestions.size(); ++x )
       {

--- a/loaddictionaries.cc
+++ b/loaddictionaries.cc
@@ -396,7 +396,7 @@ void loadDictionaries( QWidget * parent, bool showInitially,
     ret = ids.insert( dictionaries[ x ]->getId() );
     if( !ret.second )
     {
-      gdWarning( "Duplicate dictionary ID found: ID=%s, name=\"%s\", path=\"%s\"",
+      gdWarning( R"(Duplicate dictionary ID found: ID=%s, name="%s", path="%s")",
                  dictionaries[ x ]->getId().c_str(),
                  dictionaries[ x ]->getName().c_str(),
                  dictionaries[ x ]->getDictionaryFilenames().empty() ?

--- a/lsa.cc
+++ b/lsa.cc
@@ -286,7 +286,7 @@ sptr< Dictionary::DataRequest > LsaDictionary::getArticle( wstring const & word,
 
     result += addAudioLink( ref, getId() );
 
-    result += "<td><a href=" + ref + "><img src=\"qrcx://localhost/icons/playsound.png\" border=\"0\" alt=\"Play\"/></a></td>";
+    result += "<td><a href=" + ref + R"(><img src="qrcx://localhost/icons/playsound.png" border="0" alt="Play"/></a></td>)";
     result += "<td><a href=" + ref + ">" + i->second + "</a></td>";
     result += "</tr>";
   }
@@ -304,7 +304,7 @@ sptr< Dictionary::DataRequest > LsaDictionary::getArticle( wstring const & word,
 
     result += addAudioLink( ref, getId() );
 
-    result += "<td><a href=" + ref + "><img src=\"qrcx://localhost/icons/playsound.png\" border=\"0\" alt=\"Play\"/></a></td>";
+    result += "<td><a href=" + ref + R"(><img src="qrcx://localhost/icons/playsound.png" border="0" alt="Play"/></a></td>)";
     result += "<td><a href=" + ref + ">" + i->second + "</a></td>";
     result += "</tr>";
   }

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -3149,11 +3149,11 @@ void MainWindow::latestReleaseReplyReady()
   if ( latestReleaseReply->error() == QNetworkReply::NoError )
   {
     QString latestReleaseInfo = QString::fromUtf8( latestReleaseReply->readAll() );
-    QRegularExpression firstReleaseAnchor ("<a\\s+[^>]*?class=\\\"Link--primary\\\"[^>]*?>[^<]*?<\\/a>",QRegularExpression::DotMatchesEverythingOption|QRegularExpression::CaseInsensitiveOption);
+    QRegularExpression firstReleaseAnchor (R"(<a\s+[^>]*?class=\"Link--primary\"[^>]*?>[^<]*?<\/a>)",QRegularExpression::DotMatchesEverythingOption|QRegularExpression::CaseInsensitiveOption);
     auto match = firstReleaseAnchor.match(latestReleaseInfo);
     if(match.hasMatch()){
       auto releaseAnchor = match.captured();
-      QRegularExpression extractReleaseRx ("<a\\s+.*?href=\\\"([^\\\"]*)\\\".*?>(.*?)<\\/a>",QRegularExpression::DotMatchesEverythingOption|QRegularExpression::CaseInsensitiveOption);
+      QRegularExpression extractReleaseRx (R"(<a\s+.*?href=\"([^\"]*)\".*?>(.*?)<\/a>)",QRegularExpression::DotMatchesEverythingOption|QRegularExpression::CaseInsensitiveOption);
       auto matchParts = extractReleaseRx.match(releaseAnchor);
       if(matchParts.hasMatch()){
         latestVersion = matchParts.captured(2);
@@ -3517,7 +3517,7 @@ void MainWindow::on_saveArticle_triggered()
   QString fileName = view->getTitle().simplified();
 
   // Replace reserved filename characters
-  QRegularExpression rxName( "[/\\\\\\?\\*:\\|<>]" );
+  QRegularExpression rxName( R"([/\\\?\*:\|<>])" );
   fileName.replace( rxName, "_" );
 
   fileName += ".html";
@@ -3590,7 +3590,7 @@ void MainWindow::on_saveArticle_triggered()
 
         // MDict anchors
         QRegularExpression anchorLinkRe(
-          "(<\\s*a\\s+[^>]*\\b(?:name|id)\\b\\s*=\\s*[\"']*g[0-9a-f]{32}_)([0-9a-f]+_)(?=[^\"'])",
+          R"((<\s*a\s+[^>]*\b(?:name|id)\b\s*=\s*["']*g[0-9a-f]{32}_)([0-9a-f]+_)(?=[^"']))",
           QRegularExpression::PatternOption::CaseInsensitiveOption|QRegularExpression::UseUnicodePropertiesOption );
         html.replace( anchorLinkRe, "\\1" );
 

--- a/mdx.cc
+++ b/mdx.cc
@@ -1283,14 +1283,14 @@ QString MdxDictionary::getCachedFileName( QString filename )
 
       if( n < (qint64)data.size() )
       {
-        gdWarning( "Mdx: file \"%s\" writing error: \"%s\"", fullName.toUtf8().data(),
+        gdWarning( R"(Mdx: file "%s" writing error: "%s")", fullName.toUtf8().data(),
                                                              f.errorString().toUtf8().data() );
         return QString();
       }
     }
     else
     {
-      gdWarning( "Mdx: file \"%s\" creating error: \"%s\"", fullName.toUtf8().data(),
+      gdWarning( R"(Mdx: file "%s" creating error: "%s")", fullName.toUtf8().data(),
                                                             f.errorString().toUtf8().data() );
       return QString();
     }

--- a/mediawiki.cc
+++ b/mediawiki.cc
@@ -395,7 +395,7 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
             wikiUrl.setPath( "/" );
   
             // Update any special index.php pages to be absolute
-            articleString.replace( QRegularExpression( "<a\\shref=\"(/([\\w]*/)*index.php\\?)" ),
+            articleString.replace( QRegularExpression( R"(<a\shref="(/([\w]*/)*index.php\?))" ),
                                    QString( "<a href=\"%1\\1" ).arg( wikiUrl.toString() ) );
 
 
@@ -403,7 +403,7 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
             QRegularExpression reg1( "<audio\\s.+?</audio>",
                                      QRegularExpression::CaseInsensitiveOption
                                      | QRegularExpression::DotMatchesEverythingOption );
-            QRegularExpression reg2( "<source\\s+src=\"([^\"]+)",
+            QRegularExpression reg2( R"(<source\s+src="([^"]+))",
                                      QRegularExpression::CaseInsensitiveOption );
             pos = 0;
             it = reg1.globalMatch( articleString );
@@ -419,7 +419,7 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
               {
                 QString ref = match2.captured( 1 );
                 QString audio_url = "<a href=\"" + ref
-                                    + "\"><img src=\"qrcx://localhost/icons/playsound.png\" border=\"0\" align=\"absmiddle\" alt=\"Play\"/></a>";
+                                    + R"("><img src="qrcx://localhost/icons/playsound.png" border="0" align="absmiddle" alt="Play"/></a>)";
                 articleNewString += audio_url;
               }
               else
@@ -447,7 +447,7 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
             articleString.replace( "<a href=\"/wiki/", "<a href=\"" );
 
             // In those strings, change any underscores to spaces
-            QRegularExpression rxLink( "<a\\s+href=\"[^/:\">#]+" );
+            QRegularExpression rxLink( R"(<a\s+href="[^/:">#]+)" );
             it = rxLink.globalMatch( articleString );
             while( it.hasNext() )
             {
@@ -458,7 +458,7 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
             }
 
             //fix file: url
-            articleString.replace( QRegularExpression( "<a\\s+href=\"([^:/\"]*file%3A[^/\"]+\")",
+            articleString.replace( QRegularExpression( R"(<a\s+href="([^:/"]*file%3A[^/"]+"))",
                                                        QRegularExpression::CaseInsensitiveOption ),
 
                                    QString( "<a href=\"%1/index.php?title=\\1" ).arg( url ));
@@ -468,7 +468,7 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
 
             // Fix urls in "srcset" attribute
             pos = 0;
-            QRegularExpression regSrcset( " srcset\\s*=\\s*\"/[^\"]+\"" );
+            QRegularExpression regSrcset( R"( srcset\s*=\s*"/[^"]+")" );
             it = regSrcset.globalMatch( articleString );
             while( it.hasNext() )
             {
@@ -491,7 +491,7 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
 
             QByteArray articleBody = articleString.toUtf8();
 
-            articleBody.prepend( dictPtr->isToLanguageRTL() ? "<div class=\"mwiki\" dir=\"rtl\">" :
+            articleBody.prepend( dictPtr->isToLanguageRTL() ? R"(<div class="mwiki" dir="rtl">)" :
                                                               "<div class=\"mwiki\">" );
             articleBody.append( "</div>" );
   

--- a/programs.cc
+++ b/programs.cc
@@ -96,7 +96,7 @@ sptr< Dictionary::DataRequest > ProgramsDictionary::getArticle(
 
       result += addAudioLink( ref, getId() );
 
-      result += "<td><a href=" + ref + "><img src=\"qrcx://localhost/icons/playsound.png\" border=\"0\" alt=\"Play\"/></a></td>";
+      result += "<td><a href=" + ref + R"(><img src="qrcx://localhost/icons/playsound.png" border="0" alt="Play"/></a></td>)";
       result += "<td><a href=" + ref + ">" +
                 Html::escape( wordUtf8 ) + "</a></td>";
       result += "</tr></table>";

--- a/sdict.cc
+++ b/sdict.cc
@@ -303,7 +303,7 @@ string SdictDictionary::convert( string const & in )
 
     result.replace( QRegularExpression( "<\\s*t\\s*>",
                                         QRegularExpression::CaseInsensitiveOption ),
-                    "<span class=\"sdict_tr\" dir=\"ltr\">" );
+                    R"(<span class="sdict_tr" dir="ltr">)" );
     result.replace( QRegularExpression( "<\\s*f\\s*>",
                                         QRegularExpression::CaseInsensitiveOption ),
                     "<span class=\"sdict_forms\">" );
@@ -341,7 +341,7 @@ string SdictDictionary::convert( string const & in )
 
       m= end_link_tag.match( result, 0, QRegularExpression::PartialPreferFirstMatch );
       result.replace( end, m.captured ().length(), "</a>" );
-      result.replace( n, tag_len, QString( "<a class=\"sdict_wordref\" href=\"bword:" ) + link_text + "\">");
+      result.replace( n, tag_len, QString( R"(<a class="sdict_wordref" href="bword:)" ) + link_text + "\">");
     }
 
     // Adjust text direction for lines

--- a/slob.cc
+++ b/slob.cc
@@ -822,16 +822,16 @@ string SlobDictionary::convert( const string & in, RefEntry const & entry )
 
   // pattern of img and script
   text.replace( QRegularExpression( "<\\s*(img|script)\\s+([^>]*)src=\"(?!(?:data|https?|ftp):)(|/)([^\"]*)\"" ),
-                QString( "<\\1 \\2src=\"bres://%1/\\4\"").arg( getId().c_str() ) );
+                QString( R"(<\1 \2src="bres://%1/\4")").arg( getId().c_str() ) );
 
   // pattern <link... href="..." ...>
-  text.replace( QRegularExpression( "<\\s*link\\s+([^>]*)href=\"(?!(?:data|https?|ftp):)" ),
+  text.replace( QRegularExpression( R"(<\s*link\s+([^>]*)href="(?!(?:data|https?|ftp):))" ),
                 QString( "<link \\1href=\"bres://%1/").arg( getId().c_str() ) );
 
   // pattern <a href="..." ...>, excluding any known protocols such as http://, mailto:, #(comment)
   // these links will be translated into local definitions
   QString anchor;
-  QRegularExpression rxLink( "<\\s*a\\s+([^>]*)href=\"(?!(?:\\w+://|#|mailto:|tel:))(/|)([^\"]*)\"\\s*(title=\"[^\"]*\")?[^>]*>" );
+  QRegularExpression rxLink( R"lit(<\s*a\s+([^>]*)href="(?!(?:\w+://|#|mailto:|tel:))(/|)([^"]*)"\s*(title="[^"]*")?[^>]*>)lit" );
   QRegularExpressionMatchIterator it = rxLink.globalMatch( text );
   int pos = 0;
   QString newText;
@@ -881,11 +881,11 @@ string SlobDictionary::convert( const string & in, RefEntry const & entry )
 
   if( !texCgiPath.isEmpty() )
   {
-      QRegularExpression texImage( "<\\s*img\\s+class=\"([^\"]+)\"\\s*([^>]*)alt=\"([^\"]+)\"[^>]*>" );
+      QRegularExpression texImage( R"lit(<\s*img\s+class="([^"]+)"\s*([^>]*)alt="([^"]+)"[^>]*>)lit" );
       QRegularExpression regFrac( "\\\\[dt]frac" );
-      QRegularExpression regSpaces( "\\s+([\\{\\(\\[\\}\\)\\]])" );
+      QRegularExpression regSpaces( R"(\s+([\{\(\[\}\)\]]))" );
 
-    QRegExp multReg( "\\*\\{(\\d+)\\}([^\\{]|\\{([^\\}]+)\\})", Qt::CaseSensitive, QRegExp::RegExp2 );
+    QRegExp multReg( R"(\*\{(\d+)\}([^\{]|\{([^\}]+)\}))", Qt::CaseSensitive, QRegExp::RegExp2 );
 
     QString arrayDesc( "\\begin{array}{" );
     pos = 0;
@@ -995,7 +995,7 @@ string SlobDictionary::convert( const string & in, RefEntry const & entry )
           QProcess::execute( command,QStringList() );
         }
 
-        QString tag = QString( "<img class=\"imgtex\" src=\"file://" )
+        QString tag = QString( R"(<img class="imgtex" src="file://)" )
 #ifdef Q_OS_WIN32
                       + "/"
 #endif
@@ -1463,7 +1463,7 @@ void SlobArticleRequest::run()
 
   for( i = mainArticles.begin(); i != mainArticles.end(); ++i )
   {
-      result += "<div class=\"slobdict\"><h3 class=\"slobdict_headword\">";
+      result += R"(<div class="slobdict"><h3 class="slobdict_headword">)";
       result += i->second.first;
       result += "</h3></div>";
       result += i->second.second;
@@ -1471,7 +1471,7 @@ void SlobArticleRequest::run()
 
   for( i = alternateArticles.begin(); i != alternateArticles.end(); ++i )
   {
-      result += "<div class=\"slobdict\"><h3 class=\"slobdict_headword\">";
+      result += R"(<div class="slobdict"><h3 class="slobdict_headword">)";
       result += i->second.first;
       result += "</h3></div>";
       result += i->second.second;

--- a/sounddir.cc
+++ b/sounddir.cc
@@ -228,7 +228,7 @@ sptr< Dictionary::DataRequest > SoundDirDictionary::getArticle( wstring const & 
 
     result += addAudioLink( ref, getId() );
 
-    result += "<td><a href=" + ref + "><img src=\"qrcx://localhost/icons/playsound.png\" border=\"0\" alt=\"Play\"/></a></td>";
+    result += "<td><a href=" + ref + R"(><img src="qrcx://localhost/icons/playsound.png" border="0" alt="Play"/></a></td>)";
     result += "<td><a href=" + ref + ">" + Html::escape( displayedName ) + "</a></td>";
     result += "</tr>";
   }
@@ -272,7 +272,7 @@ sptr< Dictionary::DataRequest > SoundDirDictionary::getArticle( wstring const & 
 
     result += addAudioLink( ref, getId() );
 
-    result += "<td><a href=" + ref + "><img src=\"qrcx://localhost/icons/playsound.png\" border=\"0\" alt=\"Play\"/></a></td>";
+    result += "<td><a href=" + ref + R"(><img src="qrcx://localhost/icons/playsound.png" border="0" alt="Play"/></a></td>)";
     result += "<td><a href=" + ref + ">" + Html::escape( displayedName ) + "</a></td>";
     result += "</tr>";
   }

--- a/stardict.cc
+++ b/stardict.cc
@@ -417,11 +417,11 @@ private:
     void translatePW(QString& s){
         const int TRANSLATE_TBL_SIZE=5;
         static PWSyntaxTranslate t[TRANSLATE_TBL_SIZE]={
-            PWSyntaxTranslate("&[bB]\\s*\\{([^\\{}&]+)\\}", "<B>\\1</B>"),
-            PWSyntaxTranslate("&[iI]\\s*\\{([^\\{}&]+)\\}", "<I>\\1</I>"),
-            PWSyntaxTranslate("&[uU]\\s*\\{([^\\{}&]+)\\}", "<U>\\1</U>"),
-            PWSyntaxTranslate("&[lL]\\s*\\{([^\\{}&]+)\\}", "<SPAN style=\"color:#0000ff\">\\1</SPAN>"),
-            PWSyntaxTranslate("&[2]\\s*\\{([^\\{}&]+)\\}", "<SPAN style=\"color:#0000ff\">\\1</SPAN>")
+            PWSyntaxTranslate(R"(&[bB]\s*\{([^\{}&]+)\})", "<B>\\1</B>"),
+            PWSyntaxTranslate(R"(&[iI]\s*\{([^\{}&]+)\})", "<I>\\1</I>"),
+            PWSyntaxTranslate(R"(&[uU]\s*\{([^\{}&]+)\})", "<U>\\1</U>"),
+            PWSyntaxTranslate(R"(&[lL]\s*\{([^\{}&]+)\})", R"(<SPAN style="color:#0000ff">\1</SPAN>)"),
+            PWSyntaxTranslate(R"(&[2]\s*\{([^\{}&]+)\})", R"(<SPAN style="color:#0000ff">\1</SPAN>)")
         };
 
         QString old;
@@ -456,10 +456,10 @@ string StardictDictionary::handleResource( char type, char const * resource, siz
     {
       QString articleText = QString( "<div class=\"sdct_h\">" ) + QString::fromUtf8( resource, size ) + "</div>";
 
-      QRegularExpression imgRe( "(<\\s*img\\s+[^>]*src\\s*=\\s*[\"']+)(?!(?:data|https?|ftp):)",
+      QRegularExpression imgRe( R"((<\s*img\s+[^>]*src\s*=\s*["']+)(?!(?:data|https?|ftp):))",
                                 QRegularExpression::CaseInsensitiveOption
                                 | QRegularExpression::InvertedGreedinessOption );
-      QRegularExpression linkRe( "(<\\s*link\\s+[^>]*href\\s*=\\s*[\"']+)(?!(?:data|https?|ftp):)",
+      QRegularExpression linkRe( R"((<\s*link\s+[^>]*href\s*=\s*["']+)(?!(?:data|https?|ftp):))",
                                  QRegularExpression::CaseInsensitiveOption
                                  | QRegularExpression::InvertedGreedinessOption );
 
@@ -469,7 +469,7 @@ string StardictDictionary::handleResource( char type, char const * resource, siz
 
       // Handle links to articles
 
-      QRegularExpression linksReg( "<a(\\s*[^>]*)href\\s*=\\s*['\"](bword://)?([^'\"]+)['\"]",
+      QRegularExpression linksReg( R"(<a(\s*[^>]*)href\s*=\s*['"](bword://)?([^'"]+)['"])",
                                    QRegularExpression::CaseInsensitiveOption );
 
 
@@ -522,7 +522,7 @@ string StardictDictionary::handleResource( char type, char const * resource, siz
 
       // Handle "audio" tags
 
-      QRegularExpression audioRe( "<\\s*audio\\s*src\\s*=\\s*([\"']+)([^\"']+)([\"'])\\s*>(.*)</audio>",
+      QRegularExpression audioRe( R"(<\s*audio\s*src\s*=\s*(["']+)([^"']+)(["'])\s*>(.*)</audio>)",
                                   QRegularExpression::CaseInsensitiveOption
                                   | QRegularExpression::DotMatchesEverythingOption
                                   | QRegularExpression::InvertedGreedinessOption );
@@ -549,7 +549,7 @@ string StardictDictionary::handleResource( char type, char const * resource, siz
           newTag += match.captured( 4 );
           if( match.captured( 4 ).indexOf( "<img " ) < 0 )
 
-            newTag += " <img src=\"qrcx://localhost/icons/playsound.png\" border=\"0\" alt=\"Play\">";
+            newTag += R"( <img src="qrcx://localhost/icons/playsound.png" border="0" alt="Play">)";
           newTag += "</a></span>";
 
           articleNewText += newTag;
@@ -1478,11 +1478,11 @@ void StardictArticleRequest::run()
 
     for( i = mainArticles.begin(); i != mainArticles.end(); ++i )
     {
-        result += dict.isFromLanguageRTL() ? "<h3 class=\"sdct_headwords\" dir=\"rtl\">" : "<h3 class=\"sdct_headwords\">";
+        result += dict.isFromLanguageRTL() ? R"(<h3 class="sdct_headwords" dir="rtl">)" : "<h3 class=\"sdct_headwords\">";
         result += i->second.first;
         result += "</h3>";
         if( dict.isToLanguageRTL() )
-          result += "<div style=\"display:inline;\" dir=\"rtl\">";
+          result += R"(<div style="display:inline;" dir="rtl">)";
         result += i->second.second;
         result += cleaner;
         if( dict.isToLanguageRTL() )
@@ -1491,11 +1491,11 @@ void StardictArticleRequest::run()
 
     for( i = alternateArticles.begin(); i != alternateArticles.end(); ++i )
     {
-        result += dict.isFromLanguageRTL() ? "<h3 class=\"sdct_headwords\" dir=\"rtl\">" : "<h3 class=\"sdct_headwords\">";
+        result += dict.isFromLanguageRTL() ? R"(<h3 class="sdct_headwords" dir="rtl">)" : "<h3 class=\"sdct_headwords\">";
         result += i->second.first;
         result += "</h3>";
         if( dict.isToLanguageRTL() )
-          result += "<div style=\"display:inline;\" dir=\"rtl\">";
+          result += R"(<div style="display:inline;" dir="rtl">)";
         result += i->second.second;
         result += cleaner;
         if( dict.isToLanguageRTL() )
@@ -1750,7 +1750,7 @@ void StardictResourceRequest::run()
       QString id = QString::fromUtf8( dict.getId().c_str() );
       int pos = 0;
 
-      QRegularExpression links( "url\\(\\s*(['\"]?)([^'\"]*)(['\"]?)\\s*\\)",
+      QRegularExpression links( R"(url\(\s*(['"]?)([^'"]*)(['"]?)\s*\))",
                                 QRegularExpression::CaseInsensitiveOption );
 
       QString newCSS;

--- a/voiceengines.cc
+++ b/voiceengines.cc
@@ -100,7 +100,7 @@ sptr< Dictionary::DataRequest > VoiceEnginesDictionary::getArticle(
   string ref = string( "\"" ) + encodedUrl + "\"";
   result += addAudioLink( ref, getId() );
 
-  result += "<td><a href=" + ref + "><img src=\"qrcx://localhost/icons/playsound.png\" border=\"0\" alt=\"Play\"/></a></td>";
+  result += "<td><a href=" + ref + R"(><img src="qrcx://localhost/icons/playsound.png" border="0" alt="Play"/></a></td>)";
   result += "<td><a href=" + ref + ">" + Html::escape( wordUtf8 ) + "</a></td>";
   result += "</tr></table>";
 

--- a/website.cc
+++ b/website.cc
@@ -198,9 +198,9 @@ void WebSiteArticleRequest::requestFinished( QNetworkReply * r )
     while( !base.isEmpty() && !base.endsWith( "/" ) )
       base.chop( 1 );
 
-    QRegularExpression tags( "<\\s*(a|link|img|script)\\s+[^>]*(src|href)\\s*=\\s*['\"][^>]+>",
+    QRegularExpression tags( R"(<\s*(a|link|img|script)\s+[^>]*(src|href)\s*=\s*['"][^>]+>)",
                              QRegularExpression::CaseInsensitiveOption );
-    QRegularExpression links( "\\b(src|href)\\s*=\\s*(['\"])([^'\"]+['\"])",
+    QRegularExpression links( R"(\b(src|href)\s*=\s*(['"])([^'"]+['"]))",
                               QRegularExpression::CaseInsensitiveOption );
     int pos = 0;
     QString articleNewString;
@@ -254,7 +254,7 @@ void WebSiteArticleRequest::requestFinished( QNetworkReply * r )
     // Redirect CSS links to own handler
 
     QString prefix = QString( "bres://" ) + dictPtr->getId().c_str() + "/";
-    QRegularExpression linkTags( "(<\\s*link\\s[^>]*rel\\s*=\\s*['\"]stylesheet['\"]\\s+[^>]*href\\s*=\\s*['\"])([^'\"]+)://([^'\"]+['\"][^>]+>)",
+    QRegularExpression linkTags( R"((<\s*link\s[^>]*rel\s*=\s*['"]stylesheet['"]\s+[^>]*href\s*=\s*['"])([^'"]+)://([^'"]+['"][^>]+>))",
                                  QRegularExpression::CaseInsensitiveOption );
     pos = 0;
     it = linkTags.globalMatch( articleString );

--- a/zim.cc
+++ b/zim.cc
@@ -835,14 +835,14 @@ string ZimDictionary::convert( const string & in )
   QString text = QString::fromUtf8( in.c_str() );
 
   // replace background
-  text.replace( QRegularExpression( "<\\s*body\\s+([^>]*)(background(|-color)):([^;\"]*(;|))" ),
+  text.replace( QRegularExpression( R"(<\s*body\s+([^>]*)(background(|-color)):([^;"]*(;|)))" ),
                 QString( "<body \\1" ) );
 
   // pattern of img and script
   // text.replace( QRegularExpression( "<\\s*(img|script)\\s+([^>]*)src=(\")([^\"]*)\\3" ),
   //               QString( "<\\1 \\2src=\\3bres://%1/").arg( getId().c_str() ) );
 
-  QRegularExpression rxImgScript( "<\\s*(img|script)\\s+([^>]*)src=(\")([^\"]*)\\3" );
+  QRegularExpression rxImgScript( R"(<\s*(img|script)\s+([^>]*)src=(")([^"]*)\3)" );
   QRegularExpressionMatchIterator it = rxImgScript.globalMatch( text );
   int pos = 0;
   QString newText;
@@ -863,7 +863,7 @@ string ZimDictionary::convert( const string & in )
     if( !url.isEmpty() && !url.startsWith( "//" ) && !url.startsWith( "http://" ) && !url.startsWith( "https://" ) )
     {
       //<\\1 \\2src=\\3bres://%1/
-      url.remove(QRegularExpression("^\\.*\\/[A-Z]\\/", QRegularExpression::CaseInsensitiveOption));
+      url.remove(QRegularExpression(R"(^\.*\/[A-Z]\/)", QRegularExpression::CaseInsensitiveOption));
       replacedLink =
         QString( "<%1 %2 src=\"bres://%3/%4\"" ).arg( list[ 1 ], list[ 2 ], QString::fromStdString( getId() ), url );
     }
@@ -879,23 +879,23 @@ string ZimDictionary::convert( const string & in )
 
 
   // Fix links without '"'
-  text.replace( QRegularExpression( "href=(\\.\\.|)/([^\\s>]+)" ),
-                QString( "href=\"\\1/\\2\"" ) );
+  text.replace( QRegularExpression( R"(href=(\.\.|)/([^\s>]+))" ),
+                QString( R"(href="\1/\2")" ) );
 
   // pattern <link... href="..." ...>
-  text.replace( QRegularExpression( "<\\s*link\\s+([^>]*)href=\"(\\.\\.|)/" ),
+  text.replace( QRegularExpression( R"(<\s*link\s+([^>]*)href="(\.\.|)/)" ),
                 QString( "<link \\1href=\"bres://%1/").arg( getId().c_str() ) );
 
   // localize the http://en.wiki***.com|org/wiki/<key> series links
   // excluding those keywords that have ":" in it
   QString urlWiki = "\"http(s|)://en\\.(wiki(pedia|books|news|quote|source|voyage|versity)|wiktionary)\\.(org|com)/wiki/([^:\"]*)\"";
-  text.replace( QRegularExpression( "<\\s*a\\s+(class=\"external\"\\s+|)href=" + urlWiki ),
-                QString( "<a href=\"gdlookup://localhost/\\6\"" ) );
+  text.replace( QRegularExpression( R"(<\s*a\s+(class="external"\s+|)href=)" + urlWiki ),
+                QString( R"(<a href="gdlookup://localhost/\6")" ) );
 
   // pattern <a href="..." ...>, excluding any known protocols such as http://, mailto:, #(comment)
   // these links will be translated into local definitions
   // <meta http-equiv="Refresh" content="0;url=../dsalsrv02.uchicago.edu/cgi-bin/0994.html">
-  QRegularExpression rxLink( "<\\s*(?:a|meta)\\s+([^>]*)(?:href|url)=\"?(?!(?:\\w+://|#|mailto:|tel:))()([^\"]*)\"\\s*(title=\"[^\"]*\")?[^>]*>" );
+  QRegularExpression rxLink( R"lit(<\s*(?:a|meta)\s+([^>]*)(?:href|url)="?(?!(?:\w+://|#|mailto:|tel:))()([^"]*)"\s*(title="[^"]*")?[^>]*>)lit" );
   it = rxLink.globalMatch( text );
   pos = 0;
   while( it.hasNext() )
@@ -944,7 +944,7 @@ string ZimDictionary::convert( const string & in )
 
   // Occasionally words needs to be displayed in vertical, but <br/> were changed to <br\> somewhere
   // proper style: <a href="gdlookup://localhost/Neoptera" ... >N<br/>e<br/>o<br/>p<br/>t<br/>e<br/>r<br/>a</a>
-  QRegularExpression rxBR( "(<a href=\"gdlookup://localhost/[^\"]*\"\\s*[^>]*>)\\s*((\\w\\s*&lt;br(\\\\|/|)&gt;\\s*)+\\w)\\s*</a>",
+  QRegularExpression rxBR( R"((<a href="gdlookup://localhost/[^"]*"\s*[^>]*>)\s*((\w\s*&lt;br(\\|/|)&gt;\s*)+\w)\s*</a>)",
                            QRegularExpression::UseUnicodePropertiesOption );
   pos = 0;
   QRegularExpressionMatchIterator it2 = rxBR.globalMatch( text );
@@ -1520,7 +1520,7 @@ void ZimResourceRequest::run()
 
 sptr< Dictionary::DataRequest > ZimDictionary::getResource( string const & name )
 {
-  auto formatedName = QString::fromStdString(name).remove(QRegularExpression("^\\.*\\/[A-Z]\\/", QRegularExpression::CaseInsensitiveOption));
+  auto formatedName = QString::fromStdString(name).remove(QRegularExpression(R"(^\.*\/[A-Z]\/)", QRegularExpression::CaseInsensitiveOption));
   return std::make_shared<ZimResourceRequest>( *this, formatedName.toStdString() );
 }
 

--- a/zipsounds.cc
+++ b/zipsounds.cc
@@ -279,7 +279,7 @@ sptr< Dictionary::DataRequest > ZipSoundsDictionary::getArticle( wstring const &
 
     result += addAudioLink( ref, getId() );
 
-    result += "<td><a href=" + ref + "><img src=\"qrcx://localhost/icons/playsound.png\" border=\"0\" alt=\"Play\"/></a></td>";
+    result += "<td><a href=" + ref + R"(><img src="qrcx://localhost/icons/playsound.png" border="0" alt="Play"/></a></td>)";
     result += "<td><a href=" + ref + ">" + Html::escape( displayedName ) + "</a></td>";
     result += "</tr>";
   }
@@ -325,7 +325,7 @@ sptr< Dictionary::DataRequest > ZipSoundsDictionary::getArticle( wstring const &
 
     result += addAudioLink( ref, getId() );
 
-    result += "<td><a href=" + ref + "><img src=\"qrcx://localhost/icons/playsound.png\" border=\"0\" alt=\"Play\"/></a></td>";
+    result += "<td><a href=" + ref + R"(><img src="qrcx://localhost/icons/playsound.png" border="0" alt="Play"/></a></td>)";
     result += "<td><a href=" + ref + ">" + Html::escape( displayedName ) + "</a></td>";
     result += "</tr>";
   }


### PR DESCRIPTION
Apply this clang-tidy check:

https://clang.llvm.org/extra/clang-tidy/checks/modernize/raw-string-literal.html

We have a lot of HTML and regex-related strings. All of them are too hard to read.

The changes are automatically made by:
```bash
# generate a json compilation database 
cd build/
cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../
# apply the check
run-clang-tidy -checks="-*,modernize-raw-string-literal" -fix
```

The `run-clang-tidy(.py)` is included in newer versions of clang.

A `.clang-tidy` should be added to enforce this, and that's the next PR.