### PR TITLE
dev: add .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,31 @@
+# https://clang.llvm.org/extra/clang-tidy/
+---
+Checks: >
+  -*
+  bugprone-*,
+  cert-*,
+  clang-analyzer-*,
+  clang-diagnostic-*,
+  cppcoreguidelines-*,
+  google-*,
+  misc-*,
+  modernize-*,
+  performance-*,
+  portability-*,
+  readability-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-reserved-identifier,
+  -cppcoreguidelines-owning-memory,
+  -google-default-arguments
+  -misc-non-private-member-variables-in-classes,
+  -modernize-avoid-c-arrays,
+  -modernize-use-auto,
+  -modernize-use-nodiscard,
+  -modernize-use-trailing-return-type,
+  -readability-magic-numbers,
+  -readability-function-cognitive-complexity,
+CheckOptions:
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+...
+

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,6 +18,7 @@ Checks: >
   -cppcoreguidelines-owning-memory,
   -google-default-arguments
   -misc-non-private-member-variables-in-classes,
+  -misc-const-correctness,
   -modernize-avoid-c-arrays,
   -modernize-use-auto,
   -modernize-use-nodiscard,


### PR DESCRIPTION
1st line `-*` remove all check

then add what we need

like all checks under `modernize-*,`

then remove checks that don't make sense on our code base.

the `-` prefix is to remove a check.

---

I think this aggressively enables more checks than the default of Qt Creator.

More warnings maybe popup in that IDE.

Some other checks maybe also don't make sense in our codebase, we can remove them when needed.

https://clang.llvm.org/extra/clang-tidy/
