### PR TITLE
Simplify and speed up dictionary loading

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,7 +16,7 @@ Checks: >
   -bugprone-easily-swappable-parameters,
   -bugprone-reserved-identifier,
   -cppcoreguidelines-owning-memory,
-  -google-default-arguments
+  -google-default-arguments,
   -misc-non-private-member-variables-in-classes,
   -misc-const-correctness,
   -modernize-avoid-c-arrays,
@@ -24,6 +24,9 @@ Checks: >
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
   -readability-magic-numbers,
+  -google-readability-braces-around-statements,
+  -readability-braces-around-statements,
+  -readability-identifier-length,
   -readability-function-cognitive-complexity,
 CheckOptions:
   - key:             modernize-loop-convert.MinConfidence

--- a/loaddictionaries.cc
+++ b/loaddictionaries.cc
@@ -78,8 +78,8 @@ void LoadDictionaries::run()
 {
   try
   {
-    for( Config::Paths::const_iterator i = paths.begin(); i != paths.end(); ++i )
-      handlePath( *i );
+    for(const auto & path : paths)
+      handlePath( path );
 
     // Make soundDirs
     {
@@ -107,6 +107,10 @@ void LoadDictionaries::run()
   }
 }
 
+void LoadDictionaries::addDicts( const std::vector< sptr< Dictionary::Class > >& dicts ) {
+  std::move(dicts.begin(), dicts.end(), std::back_inserter(dictionaries));
+}
+
 void LoadDictionaries::handlePath( Config::Path const & path )
 {
   vector< string > allFiles;
@@ -132,112 +136,24 @@ void LoadDictionaries::handlePath( Config::Path const & path )
       allFiles.push_back( FsEncoding::encode( QDir::toNativeSeparators( fullName ) ) );
   }
 
-  {
-    vector< sptr< Dictionary::Class > > bglDictionaries =
-      Bgl::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this );
+  addDicts(Bgl::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this ) );
+  addDicts(Stardict::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this, maxHeadwordToExpand ) );
+  addDicts(Lsa::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this ) );
+  addDicts(Dsl::makeDictionaries( allFiles,FsEncoding::encode( Config::getIndexDir() ),*this,maxPictureWidth,maxHeadwordSize ) );
+  addDicts(DictdFiles::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this ) );
+  addDicts(Xdxf::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this ) );
+  addDicts(Sdict::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this ) );
+  addDicts(Aard::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this, maxHeadwordToExpand ) );
+  addDicts(ZipSounds::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this ) );
+  addDicts(Mdx::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this ) );
+  addDicts(Gls::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this ) );
 
-    dictionaries.insert( dictionaries.end(), bglDictionaries.begin(),
-                         bglDictionaries.end() );
-  }
-
-  {
-    vector< sptr< Dictionary::Class > > stardictDictionaries =
-      Stardict::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this, maxHeadwordToExpand );
-
-    dictionaries.insert( dictionaries.end(), stardictDictionaries.begin(),
-                         stardictDictionaries.end() );
-  }
-
-  {
-    vector< sptr< Dictionary::Class > > lsaDictionaries =
-      Lsa::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this );
-
-    dictionaries.insert( dictionaries.end(), lsaDictionaries.begin(),
-                         lsaDictionaries.end() );
-  }
-
-  {
-    vector< sptr< Dictionary::Class > > dslDictionaries =
-      Dsl::makeDictionaries(
-          allFiles, FsEncoding::encode( Config::getIndexDir() ), *this, maxPictureWidth, maxHeadwordSize );
-
-    dictionaries.insert( dictionaries.end(), dslDictionaries.begin(),
-                         dslDictionaries.end() );
-  }
-
-  {
-    vector< sptr< Dictionary::Class > > dictdDictionaries =
-      DictdFiles::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this );
-
-    dictionaries.insert( dictionaries.end(), dictdDictionaries.begin(),
-                         dictdDictionaries.end() );
-  }
-  {
-    vector< sptr< Dictionary::Class > > xdxfDictionaries =
-      Xdxf::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this );
-
-    dictionaries.insert( dictionaries.end(), xdxfDictionaries.begin(),
-                         xdxfDictionaries.end() );
-  }
-  {
-    vector< sptr< Dictionary::Class > > sdictDictionaries =
-      Sdict::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this );
-
-    dictionaries.insert( dictionaries.end(), sdictDictionaries.begin(),
-                         sdictDictionaries.end() );
-  }
-  {
-    vector< sptr< Dictionary::Class > > aardDictionaries =
-      Aard::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this, maxHeadwordToExpand );
-
-    dictionaries.insert( dictionaries.end(), aardDictionaries.begin(),
-                         aardDictionaries.end() );
-  }
-  {
-    vector< sptr< Dictionary::Class > > zipSoundsDictionaries =
-      ZipSounds::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this );
-
-    dictionaries.insert( dictionaries.end(), zipSoundsDictionaries.begin(),
-                         zipSoundsDictionaries.end() );
-  }
-  {
-    vector< sptr< Dictionary::Class > > mdxDictionaries =
-      Mdx::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this );
-
-    dictionaries.insert( dictionaries.end(), mdxDictionaries.begin(),
-                         mdxDictionaries.end() );
-  }
-  {
-    vector< sptr< Dictionary::Class > > glsDictionaries =
-      Gls::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this );
-
-    dictionaries.insert( dictionaries.end(), glsDictionaries.begin(),
-                         glsDictionaries.end() );
-  }
 #ifdef MAKE_ZIM_SUPPORT
-  {
-    vector< sptr< Dictionary::Class > > zimDictionaries =
-      Zim::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this, maxHeadwordToExpand );
-
-    dictionaries.insert( dictionaries.end(), zimDictionaries.begin(),
-                         zimDictionaries.end() );
-  }
-  {
-    vector< sptr< Dictionary::Class > > slobDictionaries =
-      Slob::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this, maxHeadwordToExpand );
-
-    dictionaries.insert( dictionaries.end(), slobDictionaries.begin(),
-                         slobDictionaries.end() );
-  }
+  addDicts(Zim::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this, maxHeadwordToExpand ) );
+  addDicts(Slob::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this, maxHeadwordToExpand ) );
 #endif
 #ifndef NO_EPWING_SUPPORT
-  {
-    vector< sptr< Dictionary::Class > > epwingDictionaries =
-      Epwing::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this );
-
-    dictionaries.insert( dictionaries.end(), epwingDictionaries.begin(),
-                         epwingDictionaries.end() );
-  }
+  addDicts( Epwing::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this ) );
 #endif
 }
 
@@ -285,27 +201,20 @@ void loadDictionaries( QWidget * parent, bool showInitially,
 
   dictionaries = loadDicts.getDictionaries();
 
+  // Helper function that will add a vector of dictionary::Class to the dictionary list
+  // Implemented as lambda to access method's `dictionaries` variable
+  auto  static addDicts = [&dictionaries](const vector< sptr< Dictionary::Class >> &dicts) {
+    std::move(dicts.begin(), dicts.end(), std::back_inserter(dictionaries));
+  };
+
   ///// We create transliterations synchronously since they are very simple
 
 #ifdef MAKE_CHINESE_CONVERSION_SUPPORT
-  // Make Chinese conversion
-  {
-    vector< sptr< Dictionary::Class > > chineseDictionaries =
-      Chinese::makeDictionaries( cfg.transliteration.chinese );
-
-    dictionaries.insert( dictionaries.end(), chineseDictionaries.begin(),
-                         chineseDictionaries.end() );
-  }
+  addDicts(Chinese::makeDictionaries( cfg.transliteration.chinese ));
 #endif
 
-  // Make Romaji
-  {
-    vector< sptr< Dictionary::Class > > romajiDictionaries =
-      Romaji::makeDictionaries( cfg.transliteration.romaji );
+  addDicts(Romaji::makeDictionaries( cfg.transliteration.romaji ));
 
-    dictionaries.insert( dictionaries.end(), romajiDictionaries.begin(),
-                         romajiDictionaries.end() );
-  }
 
   // Make Russian transliteration
   if ( cfg.transliteration.enableRussianTransliteration )
@@ -322,67 +231,17 @@ void loadDictionaries( QWidget * parent, bool showInitially,
   // Make Belarusian transliteration
   if ( cfg.transliteration.enableBelarusianTransliteration )
   {
-    vector< sptr< Dictionary::Class > > dicts = BelarusianTranslit::makeDictionaries();
-    dictionaries.insert( dictionaries.end(), dicts.begin(), dicts.end() );
+    addDicts(BelarusianTranslit::makeDictionaries());
   }
 
-  ///// We create MediaWiki dicts synchronously, since they use netmgr
+  addDicts(MediaWiki::makeDictionaries( loadDicts, cfg.mediawikis, dictNetMgr ));
+  addDicts(WebSite::makeDictionaries( cfg.webSites, dictNetMgr ));
+  addDicts(Forvo::makeDictionaries( loadDicts, cfg.forvo, dictNetMgr ));
+  addDicts(Lingua::makeDictionaries( loadDicts, cfg.lingua, dictNetMgr ));
+  addDicts(Programs::makeDictionaries( cfg.programs ));
+  addDicts(VoiceEngines::makeDictionaries( cfg.voiceEngines ));
+  addDicts(DictServer::makeDictionaries( cfg.dictServers ));
 
-  {
-    vector< sptr< Dictionary::Class > > dicts =
-      MediaWiki::makeDictionaries( loadDicts, cfg.mediawikis, dictNetMgr );
-
-    dictionaries.insert( dictionaries.end(), dicts.begin(), dicts.end() );
-  }
-
-  ///// WebSites are very simple, no need to create them asynchronously
-  {
-    vector< sptr< Dictionary::Class > > dicts =
-      WebSite::makeDictionaries( cfg.webSites, dictNetMgr );
-
-    dictionaries.insert( dictionaries.end(), dicts.begin(), dicts.end() );
-  }
-
-  //// Forvo dictionaries
-
-  {
-    vector< sptr< Dictionary::Class > > dicts =
-      Forvo::makeDictionaries( loadDicts, cfg.forvo, dictNetMgr );
-
-    dictionaries.insert( dictionaries.end(), dicts.begin(), dicts.end() );
-  }
-
-  //// Lingua Libre
-
-  {
-    vector< sptr< Dictionary::Class > > dicts =
-      Lingua::makeDictionaries( loadDicts, cfg.lingua, dictNetMgr );
-
-    dictionaries.insert( dictionaries.end(), dicts.begin(), dicts.end() );
-  }
-
-  //// Programs
-  {
-    vector< sptr< Dictionary::Class > > dicts =
-      Programs::makeDictionaries( cfg.programs );
-
-    dictionaries.insert( dictionaries.end(), dicts.begin(), dicts.end() );
-  }
-
-  //// Text to Speech
-  {
-    vector< sptr< Dictionary::Class > > dicts =
-      VoiceEngines::makeDictionaries( cfg.voiceEngines );
-
-    dictionaries.insert( dictionaries.end(), dicts.begin(), dicts.end() );
-  }
-
-  {
-    vector< sptr< Dictionary::Class > > dicts =
-      DictServer::makeDictionaries( cfg.dictServers );
-
-    dictionaries.insert( dictionaries.end(), dicts.begin(), dicts.end() );
-  }
 
   GD_DPRINTF( "Load done\n" );
 

--- a/loaddictionaries.hh
+++ b/loaddictionaries.hh
@@ -40,9 +40,7 @@ public:
   std::string const & getExceptionText() const
   { return exceptionText; }
 
-signals:
 
-  void indexingDictionarySignal( QString const & dictionaryName );
 
 public:
 
@@ -51,6 +49,12 @@ public:
 private:
 
   void handlePath( Config::Path const & );
+
+  // Helper function that will add a vector of dictionary::Class to the dictionary list
+  void addDicts(const std::vector< sptr< Dictionary::Class > >& dicts);
+
+signals:
+  void indexingDictionarySignal( QString const & dictionaryName );
 };
 
 /// Loads all dictionaries mentioned in the configuration passed, into the


### PR DESCRIPTION
The original code from 10+ years ago is slow and unreadable.

Old code:

It uses `{ }` to create a scope so that a temporal variable will be created and deleted later.

the `dictionaries` is a vector, and the `insert()` will _copy_ the value of `Dictionary::Class` to the vector's storage one by one. The original temporal vector will be destroyed later.

For a Dictionary::Class, it will be created -> assembled to a vector -> assigned to a temporal vector -> copied to the vector `dictionaries` (-> destroy the temporal one)

```
{
  vector< sptr< Dictionary::Class > > mdxDictionaries =
    Mdx::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this );

  dictionaries.insert( dictionaries.end(), mdxDictionaries.begin(),
                       mdxDictionaries.end() );
}

```

---

The new code:
```
void LoadDictionaries::addDicts( const std::vector< sptr< Dictionary::Class > >& dicts ) {
  std::move(dicts.begin(), dicts.end(), std::back_inserter(dictionaries));
}
```

The `std::move` from `<algorithm>` won't copy anything. It will take the pointer of each `Dictionary::Class` and give it to the vector `dictionaries`.

For a Dictionary::Class, it will be created -> assembled to a vector -> passed via reference (const &) -> _moved_ to the vector `dictionaries`.

Without copying, the new code should be faster and cleaner.

---

Due to the unholiness of having a class and a function with the SAME name `LoadDictionaries`, this helper function has to be implemented twice.

One as a private method to access class's variable.
Another as a lambda to access functions's variable.
