### PR TITLE
Refactor: use new Signal/Slot syntax

### DIFF
--- a/article_netmgr.cc
+++ b/article_netmgr.cc
@@ -25,40 +25,38 @@ using std::string;
 
     // Signals to own slots
 
-    connect( baseReply, SIGNAL( metaDataChanged() ), this, SLOT( applyMetaData() ) );
+    connect( baseReply, &QNetworkReply::metaDataChanged, this, &AllowFrameReply::applyMetaData );
 
-    connect( baseReply, SIGNAL( errorOccurred( QNetworkReply::NetworkError) ),
-             this, SLOT( applyError( QNetworkReply::NetworkError ) ) );
+    connect( baseReply, &QNetworkReply::errorOccurred, this, &AllowFrameReply::applyError );
 
-    connect( baseReply, SIGNAL( readyRead() ), this, SIGNAL( readyRead() ) );
+    connect( baseReply, &QIODevice::readyRead, this, &QIODevice::readyRead );
 
     // Redirect QNetworkReply signals
 
-    connect( baseReply, SIGNAL( downloadProgress( qint64, qint64 ) ),
-             this, SIGNAL( downloadProgress( qint64, qint64 ) ) );
+    connect( baseReply, &QNetworkReply::downloadProgress, this, &QNetworkReply::downloadProgress );
 
-    connect( baseReply, SIGNAL( encrypted() ), this, SIGNAL( encrypted() ) );
+    connect( baseReply, &QNetworkReply::encrypted, this, &QNetworkReply::encrypted );
 
-    connect( baseReply, SIGNAL( finished() ), this, SIGNAL( finished() ) );
+    connect( baseReply, &QNetworkReply::finished, this, &QNetworkReply::finished );
 
-    connect( baseReply, SIGNAL( preSharedKeyAuthenticationRequired( QSslPreSharedKeyAuthenticator * ) ),
-             this, SIGNAL( preSharedKeyAuthenticationRequired( QSslPreSharedKeyAuthenticator * ) ) );
+    connect( baseReply,
+      &QNetworkReply::preSharedKeyAuthenticationRequired,
+      this,
+      &QNetworkReply::preSharedKeyAuthenticationRequired );
 
-    connect( baseReply, SIGNAL( redirected( const QUrl & ) ), this, SIGNAL( redirected( const QUrl & ) ) );
+    connect( baseReply, &QNetworkReply::redirected, this, &QNetworkReply::redirected );
 
-    connect( baseReply, SIGNAL( sslErrors( const QList< QSslError > & ) ),
-             this, SIGNAL( sslErrors( const QList< QSslError > & ) ) );
+    connect( baseReply, &QNetworkReply::sslErrors, this, &QNetworkReply::sslErrors );
 
-    connect( baseReply, SIGNAL( uploadProgress( qint64, qint64 ) ),
-             this, SIGNAL( uploadProgress( qint64, qint64 ) ) );
+    connect( baseReply, &QNetworkReply::uploadProgress, this, &QNetworkReply::uploadProgress );
 
     // Redirect QIODevice signals
 
-    connect( baseReply, SIGNAL( aboutToClose() ), this, SIGNAL( aboutToClose() ) );
+    connect( baseReply, &QIODevice::aboutToClose, this, &QIODevice::aboutToClose );
 
-    connect( baseReply, SIGNAL( bytesWritten( qint64 ) ), this, SIGNAL( bytesWritten( qint64 ) ) );
+    connect( baseReply, &QIODevice::bytesWritten, this, &QIODevice::bytesWritten );
 
-    connect( baseReply, SIGNAL( readChannelFinished() ), this, SIGNAL( readChannelFinished() ) );
+    connect( baseReply, &QIODevice::readChannelFinished, this, &QIODevice::readChannelFinished );
 
     setOpenMode( QIODevice::ReadOnly );
   }
@@ -383,18 +381,22 @@ ArticleResourceReply::ArticleResourceReply( QObject * parent,
   if ( contentType.size() )
     setHeader( QNetworkRequest::ContentTypeHeader, contentType );
 
-  connect( req.get(), SIGNAL( updated() ),
-           this, SLOT( reqUpdated() ) );
-  
-  connect( req.get(), SIGNAL( finished() ),
-           this, SLOT( reqFinished() ) );
-  
+  connect( req.get(), &Dictionary::Request::updated, this, &ArticleResourceReply::reqUpdated );
+
+  connect( req.get(), &Dictionary::Request::finished, this, &ArticleResourceReply::reqFinished );
+
   if ( req->isFinished() || req->dataSize() > 0 )
   {
-    connect( this, SIGNAL( readyReadSignal() ),
-             this, SLOT( readyReadSlot() ), Qt::QueuedConnection );
-    connect( this, SIGNAL( finishedSignal() ),
-            this, SLOT( finishedSlot() ), Qt::QueuedConnection );
+    connect( this,
+      &ArticleResourceReply::readyReadSignal,
+      this,
+      &ArticleResourceReply::readyReadSlot,
+      Qt::QueuedConnection );
+    connect( this,
+      &ArticleResourceReply::finishedSignal,
+      this,
+      &ArticleResourceReply::finishedSlot,
+      Qt::QueuedConnection );
 
     emit readyReadSignal();
 
@@ -492,8 +494,7 @@ BlockedNetworkReply::BlockedNetworkReply( QObject * parent ): QNetworkReply( par
 {
   setError( QNetworkReply::ContentOperationNotPermittedError, "Content Blocked" );
 
-  connect( this, SIGNAL( finishedSignal() ), this, SLOT( finishedSlot() ),
-           Qt::QueuedConnection );
+  connect( this, &BlockedNetworkReply::finishedSignal, this, &BlockedNetworkReply::finishedSlot, Qt::QueuedConnection );
 
   emit finishedSignal(); // This way we call readyRead()/finished() sometime later
 }

--- a/articleview.cc
+++ b/articleview.cc
@@ -252,13 +252,11 @@ ArticleView::ArticleView( QWidget * parent, ArticleNetworkAccessManager & nm, Au
 
   goBackAction.setShortcut( QKeySequence( "Alt+Left" ) );
   ui.definition->addAction( &goBackAction );
-  connect( &goBackAction, SIGNAL( triggered() ),
-           this, SLOT( back() ) );
+  connect( &goBackAction, &QAction::triggered, this, &ArticleView::back );
 
   goForwardAction.setShortcut( QKeySequence( "Alt+Right" ) );
   ui.definition->addAction( &goForwardAction );
-  connect( &goForwardAction, SIGNAL( triggered() ),
-           this, SLOT( forward() ) );
+  connect( &goForwardAction, &QAction::triggered, this, &ArticleView::forward );
 
   ui.definition->pageAction( QWebEnginePage::Copy )->setShortcut( QKeySequence::Copy );
   ui.definition->addAction( ui.definition->pageAction( QWebEnginePage::Copy ) );
@@ -270,53 +268,48 @@ ArticleView::ArticleView( QWidget * parent, ArticleNetworkAccessManager & nm, Au
 
   ui.definition->setContextMenuPolicy( Qt::CustomContextMenu );
 
-  connect(ui.definition, SIGNAL(loadFinished(bool)), this,
-          SLOT(loadFinished(bool)));
+  connect( ui.definition, &QWebEngineView::loadFinished, this, &ArticleView::loadFinished );
 
-  connect(ui.definition, SIGNAL(loadProgress(int)), this,
-          SLOT(loadProgress(int)));
-  connect( ui.definition, SIGNAL( linkClicked( QUrl ) ), this, SLOT( linkClicked( QUrl ) ) );
+  connect( ui.definition, &QWebEngineView::loadProgress, this, &ArticleView::loadProgress );
+  connect( ui.definition, &ArticleWebView::linkClicked, this, &ArticleView::linkClicked );
 
-  connect( ui.definition->page(), SIGNAL( titleChanged( QString  ) ),
-           this, SLOT( handleTitleChanged( QString  ) ) );
+  connect( ui.definition->page(), &QWebEnginePage::titleChanged, this, &ArticleView::handleTitleChanged );
 
-  connect( ui.definition->page(), SIGNAL( urlChanged(QUrl) ),
-           this, SLOT( handleUrlChanged(QUrl) ) );
+  connect( ui.definition->page(), &QWebEnginePage::urlChanged, this, &ArticleView::handleUrlChanged );
 
-  connect( ui.definition, SIGNAL( customContextMenuRequested( QPoint const & ) ),
-           this, SLOT( contextMenuRequested( QPoint const & ) ) );
+  connect( ui.definition, &QWidget::customContextMenuRequested, this, &ArticleView::contextMenuRequested );
 
-  connect( ui.definition->page(), SIGNAL( linkHovered ( const QString &) ),
-           this, SLOT( linkHovered ( const QString & ) ) );
+  connect( ui.definition->page(),
+    SIGNAL( linkHovered( const QString & ) ),
+    this,
+    SLOT( linkHovered( const QString & ) ) );
 
-  connect( ui.definition, SIGNAL( doubleClicked( QPoint ) ),this,SLOT( doubleClicked( QPoint ) ) );
+  connect( ui.definition, &ArticleWebView::doubleClicked, this, &ArticleView::doubleClicked );
 
   pasteAction.setShortcut( QKeySequence::Paste  );
   ui.definition->addAction( &pasteAction );
-  connect( &pasteAction, SIGNAL( triggered() ), this, SLOT( pasteTriggered() ) );
+  connect( &pasteAction, &QAction::triggered, this, &ArticleView::pasteTriggered );
 
   articleUpAction.setShortcut( QKeySequence( "Alt+Up" ) );
   ui.definition->addAction( &articleUpAction );
-  connect( &articleUpAction, SIGNAL( triggered() ), this, SLOT( moveOneArticleUp() ) );
+  connect( &articleUpAction, &QAction::triggered, this, &ArticleView::moveOneArticleUp );
 
   articleDownAction.setShortcut( QKeySequence( "Alt+Down" ) );
   ui.definition->addAction( &articleDownAction );
-  connect( &articleDownAction, SIGNAL( triggered() ), this, SLOT( moveOneArticleDown() ) );
+  connect( &articleDownAction, &QAction::triggered, this, &ArticleView::moveOneArticleDown );
 
   ui.definition->addAction( &openSearchAction );
-  connect( &openSearchAction, SIGNAL( triggered() ), this, SLOT( openSearch() ) );
+  connect( &openSearchAction, &QAction::triggered, this, &ArticleView::openSearch );
 
   selectCurrentArticleAction.setShortcut( QKeySequence( "Ctrl+Shift+A" ));
   selectCurrentArticleAction.setText( tr( "Select Current Article" ) );
   ui.definition->addAction( &selectCurrentArticleAction );
-  connect( &selectCurrentArticleAction, SIGNAL( triggered() ),
-           this, SLOT( selectCurrentArticle() ) );
+  connect( &selectCurrentArticleAction, &QAction::triggered, this, &ArticleView::selectCurrentArticle );
 
   copyAsTextAction.setShortcut( QKeySequence( "Ctrl+Shift+C" ) );
   copyAsTextAction.setText( tr( "Copy as text" ) );
   ui.definition->addAction( &copyAsTextAction );
-  connect( &copyAsTextAction, SIGNAL( triggered() ),
-           this, SLOT( copyAsText() ) );
+  connect( &copyAsTextAction, &QAction::triggered, this, &ArticleView::copyAsText );
 
   inspectAction.setShortcut( QKeySequence( Qt::Key_F12 ) );
   inspectAction.setText( tr( "Inspect" ) );
@@ -359,11 +352,9 @@ ArticleView::ArticleView( QWidget * parent, ArticleNetworkAccessManager & nm, Au
   // Variable name for store current selection range
   rangeVarName = QString( "sr_%1" ).arg( QString::number( (quint64)this, 16 ) );
 
-  connect(GlobalBroadcaster::instance(), SIGNAL( dictionaryChanges(ActiveDictIds)), this,
-          SLOT(setActiveDictIds(ActiveDictIds)));
+  connect( GlobalBroadcaster::instance(), &GlobalBroadcaster::dictionaryChanges, this, &ArticleView::setActiveDictIds );
 
-  connect( GlobalBroadcaster::instance(), &GlobalBroadcaster::dictionaryClear, this,
-           &ArticleView::dictionaryClear );
+  connect( GlobalBroadcaster::instance(), &GlobalBroadcaster::dictionaryClear, this, &ArticleView::dictionaryClear );
 
   channel = new QWebChannel(ui.definition->page());
   agent = new ArticleViewAgent(this);
@@ -1221,8 +1212,7 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref,
 
       resourceDownloadRequests.push_back( req );
 
-      connect( req.get(), SIGNAL( finished() ),
-               this, SLOT( resourceDownloadFinished() ) );
+      connect( req.get(), &Dictionary::Request::finished, this, &ArticleView::resourceDownloadFinished );
     }
     else
     if ( url.scheme() == "gdau" && url.host() == "search" )
@@ -1270,8 +1260,7 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref,
                 if ( !req->isFinished() )
                 {
                   // Queued loading
-                  connect( req.get(), SIGNAL( finished() ),
-                           this, SLOT( resourceDownloadFinished() ) );
+                  connect( req.get(), &Dictionary::Request::finished, this, &ArticleView::resourceDownloadFinished );
                 }
                 else
                 {
@@ -1310,8 +1299,7 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref,
             if ( !req->isFinished() )
             {
               // Queued loading
-              connect( req.get(), SIGNAL( finished() ),
-                       this, SLOT( resourceDownloadFinished() ) );
+              connect( req.get(), &Dictionary::Request::finished, this, &ArticleView::resourceDownloadFinished );
             }
             else
             {
@@ -1360,8 +1348,7 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref,
 
         resourceDownloadRequests.push_back( req );
 
-        connect( req.get(), SIGNAL( finished() ),
-                 this, SLOT( resourceDownloadFinished() ) );
+        connect( req.get(), &Dictionary::Request::finished, this, &ArticleView::resourceDownloadFinished );
       }
     }
 
@@ -1387,8 +1374,7 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref,
         // Found the corresponding program.
         Programs::RunInstance * req = new Programs::RunInstance;
 
-        connect( req, SIGNAL(finished(QByteArray,QString)),
-                 req, SLOT( deleteLater() ) );
+        connect( req, &Programs::RunInstance::finished, req, &QObject::deleteLater );
 
         QString error;
 
@@ -1964,7 +1950,7 @@ void ArticleView::contextMenuRequested( QPoint const & pos )
 
   if ( !menu.isEmpty() )
   {
-    connect( this, SIGNAL( closePopupMenu() ), &menu, SLOT( close() ) );
+    connect( this, &ArticleView::closePopupMenu, &menu, &QWidget::close );
     QAction * result = menu.exec( ui.definition->mapToGlobal( pos ) );
 
     if ( !result )
@@ -2098,7 +2084,11 @@ void ArticleView::resourceDownloadFinished()
              Dictionary::WebMultimediaDownload::isAudioUrl( resourceDownloadUrl ) )
         {
           // Audio data
-          connect( audioPlayer.data(), SIGNAL( error( QString ) ), this, SLOT( audioPlayerError( QString ) ), Qt::UniqueConnection );
+          connect( audioPlayer.data(),
+            &AudioPlayerInterface::error,
+            this,
+            &ArticleView::audioPlayerError,
+            Qt::UniqueConnection );
           QString errorMessage = audioPlayer->play( data.data(), data.size() );
           if( !errorMessage.isEmpty() )
             QMessageBox::critical( this, "GoldenDict", tr( "Failed to play sound file: %1" ).arg( errorMessage ) );
@@ -2739,18 +2729,16 @@ ResourceToSaveHandler::ResourceToSaveHandler(ArticleView * view, QString const &
   fileName( fileName ),
   alreadyDone( false )
 {
-  connect( this, SIGNAL( statusBarMessage( QString, int, QPixmap ) ),
-           view, SIGNAL( statusBarMessage( QString, int, QPixmap ) ) );
+  connect( this, &ResourceToSaveHandler::statusBarMessage, view, &ArticleView::statusBarMessage );
 }
 
-void ResourceToSaveHandler::addRequest( sptr<Dictionary::DataRequest> req )
+void ResourceToSaveHandler::addRequest( sptr< Dictionary::DataRequest > req )
 {
   if( !alreadyDone )
   {
     downloadRequests.push_back( req );
 
-    connect( req.get(), SIGNAL( finished() ),
-             this, SLOT( downloadFinished() ) );
+    connect( req.get(), &Dictionary::Request::finished, this, &ResourceToSaveHandler::downloadFinished );
   }
 }
 

--- a/dictheadwords.cc
+++ b/dictheadwords.cc
@@ -72,46 +72,38 @@ DictHeadwords::DictHeadwords( QWidget *parent, Config::Class & cfg_,
 
   ui.autoApply->setChecked( cfg.headwordsDialog.autoApply );
 
-  connect( this, SIGNAL( finished( int ) ), this, SLOT( savePos() ) );
+  connect( this, &QDialog::finished, this, &DictHeadwords::savePos );
 
   if( !fromMainWindow )
   {
     ui.helpButton->hide();
-    connect( this, SIGNAL( closeDialog() ), this, SLOT( accept() ) );
+    connect( this, &DictHeadwords::closeDialog, this, &QDialog::accept );
   }
   else
   {
-    connect( ui.helpButton, SIGNAL( clicked() ),
-             this, SLOT( helpRequested() ) );
+    connect( ui.helpButton, &QAbstractButton::clicked, this, &DictHeadwords::helpRequested );
 
     helpAction.setShortcut( QKeySequence( "F1" ) );
     helpAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
 
-    connect( &helpAction, SIGNAL( triggered() ),
-             this, SLOT( helpRequested() ) );
+    connect( &helpAction, &QAction::triggered, this, &DictHeadwords::helpRequested );
 
     addAction( &helpAction );
   }
 
-  connect( ui.OKButton, SIGNAL( clicked( bool ) ), this, SLOT( okButtonClicked() ) );
-  connect( ui.exportButton, SIGNAL( clicked( bool ) ), this, SLOT( exportButtonClicked() ) );
-  connect( ui.applyButton, SIGNAL( clicked( bool ) ), this, SLOT( filterChanged() ) );
+  connect( ui.OKButton, &QAbstractButton::clicked, this, &DictHeadwords::okButtonClicked );
+  connect( ui.exportButton, &QAbstractButton::clicked, this, &DictHeadwords::exportButtonClicked );
+  connect( ui.applyButton, &QAbstractButton::clicked, this, &DictHeadwords::filterChanged );
 
-  connect( ui.autoApply, SIGNAL( stateChanged( int ) ),
-           this, SLOT( autoApplyStateChanged( int ) ) );
+  connect( ui.autoApply, &QCheckBox::stateChanged, this, &DictHeadwords::autoApplyStateChanged );
 
-  connect( ui.filterLine, SIGNAL( textChanged( QString ) ),
-           this, SLOT( filterChangedInternal() ) );
-  connect( ui.searchModeCombo, SIGNAL( currentIndexChanged( int ) ),
-           this, SLOT( filterChangedInternal() ) );
-  connect( ui.matchCase, SIGNAL( stateChanged( int ) ),
-           this, SLOT( filterChangedInternal() ) );
+  connect( ui.filterLine, &QLineEdit::textChanged, this, &DictHeadwords::filterChangedInternal );
+  connect( ui.searchModeCombo, &QComboBox::currentIndexChanged, this, &DictHeadwords::filterChangedInternal );
+  connect( ui.matchCase, &QCheckBox::stateChanged, this, &DictHeadwords::filterChangedInternal );
 
-  connect( ui.headersListView, SIGNAL( clicked( QModelIndex ) ),
-           this, SLOT( itemClicked( QModelIndex ) ) );
+  connect( ui.headersListView, &QAbstractItemView::clicked, this, &DictHeadwords::itemClicked );
 
-  connect( proxy, SIGNAL( dataChanged( QModelIndex, QModelIndex ) ),
-           this, SLOT( showHeadwordsNumber() ) );
+  connect( proxy, &QAbstractItemModel::dataChanged, this, &DictHeadwords::showHeadwordsNumber );
 
   ui.headersListView->installEventFilter( this );
 
@@ -204,7 +196,7 @@ void DictHeadwords::filterChangedInternal()
 {
   // emit signal in async manner, to avoid UI slowdown
   if( ui.autoApply->isChecked() )
-    QTimer::singleShot( 100, this, SLOT( filterChanged() ) );
+    QTimer::singleShot( 100, this, &DictHeadwords::filterChanged );
 }
 
 void DictHeadwords::filterChanged()

--- a/dictinfo.cc
+++ b/dictinfo.cc
@@ -11,7 +11,7 @@ DictInfo::DictInfo( Config::Class &cfg_, QWidget *parent ) :
   ui.setupUi( this );
   if( cfg.dictInfoGeometry.size() > 0 )
     restoreGeometry( cfg.dictInfoGeometry );
-  connect( this, SIGNAL( finished( int ) ), this, SLOT( savePos( int ) ) );
+  connect( this, &QDialog::finished, this, &DictInfo::savePos );
 }
 
 void DictInfo::showInfo( sptr<Dictionary::Class> dict )

--- a/dictionarybar.cc
+++ b/dictionarybar.cc
@@ -22,11 +22,9 @@ DictionaryBar::DictionaryBar( QWidget * parent,
 
   maxDictionaryRefsAction = new QAction(  QIcon(":/icons/expand_opt.png"), tr( "Extended menu with all dictionaries..." ), this );
 
-  connect( &events, SIGNAL( mutedDictionariesChanged() ),
-           this, SLOT( mutedDictionariesChanged() ) );
+  connect( &events, &Config::Events::mutedDictionariesChanged, this, &DictionaryBar::mutedDictionariesChanged );
 
-  connect( this, SIGNAL(actionTriggered(QAction*)),
-           this, SLOT(actionWasTriggered(QAction*)) );
+  connect( this, &QToolBar::actionTriggered, this, &DictionaryBar::actionWasTriggered );
 }
 
 static QString elideDictName( QString const & name )
@@ -169,7 +167,7 @@ void DictionaryBar::showContextMenu( QContextMenuEvent * event, bool extended )
     action->setIconVisibleInMenu( true );
   }
 
-  connect( this, SIGNAL( closePopupMenu() ), &menu, SLOT( close() ) );
+  connect( this, &DictionaryBar::closePopupMenu, &menu, &QWidget::close );
 
   QAction * result = menu.exec( event->globalPos() );
 

--- a/editdictionaries.cc
+++ b/editdictionaries.cc
@@ -47,25 +47,23 @@ EditDictionaries::EditDictionaries( QWidget * parent, Config::Class & cfg_,
   ui.tabs->addTab( orderAndProps, QIcon(":/icons/book.svg"), tr( "&Dictionaries" ) );
   ui.tabs->addTab( groups.get(), QIcon(":/icons/bookcase.svg"), tr( "&Groups" ) );
 
-  connect( ui.buttons, SIGNAL( clicked( QAbstractButton * ) ),
-           this, SLOT( buttonBoxClicked( QAbstractButton * ) ) );
+  connect( ui.buttons, &QDialogButtonBox::clicked, this, &EditDictionaries::buttonBoxClicked );
 
-  connect( &sources, SIGNAL( rescan() ), this, SLOT( rescanSources() ) );
+  connect( &sources, &Sources::rescan, this, &EditDictionaries::rescanSources );
 
-  connect( groups.get(), SIGNAL( showDictionaryInfo( QString const & ) ),
-           this, SIGNAL( showDictionaryInfo( QString const & ) ) );
+  connect( groups.get(), &Groups::showDictionaryInfo, this, &EditDictionaries::showDictionaryInfo );
 
-  connect( orderAndProps, SIGNAL( showDictionaryHeadwords( QString const & ) ),
-           this, SIGNAL( showDictionaryHeadwords( QString const & ) ) );
+  connect( orderAndProps.data(),
+    &OrderAndProps::showDictionaryHeadwords,
+    this,
+    &EditDictionaries::showDictionaryHeadwords );
 
-  connect( ui.buttons, SIGNAL( helpRequested() ),
-           this, SLOT( helpRequested() ) );
+  connect( ui.buttons, &QDialogButtonBox::helpRequested, this, &EditDictionaries::helpRequested );
 
   helpAction.setShortcut( QKeySequence( "F1" ) );
   helpAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
 
-  connect( &helpAction, SIGNAL( triggered() ),
-           this, SLOT( helpRequested() ) );
+  connect( &helpAction, &QAction::triggered, this, &EditDictionaries::helpRequested );
 
   addAction( &helpAction );
 
@@ -278,8 +276,7 @@ void EditDictionaries::helpRequested()
     {
       helpWindow->setWindowFlags( Qt::Window );
 
-      connect( helpWindow, SIGNAL( needClose() ),
-               this, SLOT( closeHelp() ) );
+      connect( helpWindow, &Help::HelpWindow::needClose, this, &EditDictionaries::closeHelp );
       helpWindow->showHelpFor( "Manage dictionaries" );
       helpWindow->show();
     }

--- a/externalaudioplayer.cc
+++ b/externalaudioplayer.cc
@@ -84,8 +84,7 @@ void ExternalAudioPlayer::onViewerDestroyed( QObject * destroyedViewer )
 QString ExternalAudioPlayer::startViewer()
 {
   Q_ASSERT( !exitingViewer && viewer );
-  connect( viewer.data(), SIGNAL( destroyed( QObject * ) ),
-           this, SLOT( onViewerDestroyed( QObject * ) ) );
+  connect( viewer.data(), &QObject::destroyed, this, &ExternalAudioPlayer::onViewerDestroyed );
   try
   {
     viewer->start();

--- a/externalviewer.cc
+++ b/externalviewer.cc
@@ -33,10 +33,8 @@ ExternalViewer::ExternalViewer( const char * data, int size,
 
 void ExternalViewer::start() 
 {
-  connect( &viewer, SIGNAL( finished( int, QProcess::ExitStatus ) ),
-           this, SLOT( deleteLater() ) );
-  connect( &viewer, SIGNAL( errorOccurred( QProcess::ProcessError ) ),
-           this, SLOT( deleteLater() ) );
+  connect( &viewer, &QProcess::finished, this, &QObject::deleteLater );
+  connect( &viewer, &QProcess::errorOccurred, this, &QObject::deleteLater );
 
   QStringList args = parseCommandLine( viewerCmdLine );
 
@@ -58,7 +56,7 @@ bool ExternalViewer::stop()
   if( viewer.state() == QProcess::NotRunning )
     return true;
   viewer.terminate();
-  QTimer::singleShot( 1000, &viewer, SLOT( kill() ) ); // In case terminate() fails.
+  QTimer::singleShot( 1000, &viewer, &QProcess::kill ); // In case terminate() fails.
   return false;
 }
 

--- a/extlineedit.cc
+++ b/extlineedit.cc
@@ -20,10 +20,10 @@ ExtLineEdit::ExtLineEdit(QWidget *parent) :
     ensurePolished();
     updateMargins();
 
-    connect(iconButtons[Left], SIGNAL(clicked()), this, SLOT(iconClicked()));
-    connect(iconButtons[Right], SIGNAL(clicked()), this, SLOT(iconClicked()));
+    connect( iconButtons[ Left ], &QAbstractButton::clicked, this, &ExtLineEdit::iconClicked );
+    connect( iconButtons[ Right ], &QAbstractButton::clicked, this, &ExtLineEdit::iconClicked );
 
-    connect(this, SIGNAL( textChanged( QString ) ), this, SLOT( updateButtons( QString ) ) );
+    connect( this, &QLineEdit::textChanged, this, &ExtLineEdit::updateButtons );
 }
 
 ExtLineEdit::~ExtLineEdit()

--- a/favoritespanewidget.cc
+++ b/favoritespanewidget.cc
@@ -32,8 +32,7 @@ void FavoritesPaneWidget::setUp( Config::Class * cfg, QMenu * menu )
   m_deleteSelectedAction->setShortcut( QKeySequence( QKeySequence::Delete ) );
   m_deleteSelectedAction->setShortcutContext( Qt::WidgetWithChildrenShortcut );
   addAction( m_deleteSelectedAction );
-  connect( m_deleteSelectedAction, SIGNAL( triggered() ),
-           this, SLOT( deleteSelectedItems() ) );
+  connect( m_deleteSelectedAction, &QAction::triggered, this, &FavoritesPaneWidget::deleteSelectedItems );
 
   // Copy selected items to clipboard
   m_copySelectedToClipboard = new QAction( this );
@@ -41,14 +40,13 @@ void FavoritesPaneWidget::setUp( Config::Class * cfg, QMenu * menu )
   m_copySelectedToClipboard->setShortcut( QKeySequence( QKeySequence::Copy ) );
   m_copySelectedToClipboard->setShortcutContext( Qt::WidgetWithChildrenShortcut );
   addAction( m_copySelectedToClipboard );
-  connect( m_copySelectedToClipboard, SIGNAL( triggered() ),
-           this, SLOT( copySelectedItems() ) );
+  connect( m_copySelectedToClipboard, &QAction::triggered, this, &FavoritesPaneWidget::copySelectedItems );
 
   // Add folder to tree view
   m_addFolder = new QAction( this );
   m_addFolder->setText( tr( "Add folder" ) );
   addAction( m_addFolder );
-  connect( m_addFolder, SIGNAL( triggered() ), this, SLOT( addFolder() ) );
+  connect( m_addFolder, &QAction::triggered, this, &FavoritesPaneWidget::addFolder );
 
 
   // Handle context menu, reusing some of the top-level window's History menu
@@ -88,14 +86,11 @@ void FavoritesPaneWidget::setUp( Config::Class * cfg, QMenu * menu )
   if( oldModel )
     oldModel->deleteLater();
 
-  connect( m_favoritesTree, SIGNAL( expanded( QModelIndex ) ),
-           m_favoritesModel, SLOT( itemExpanded( QModelIndex ) ) );
+  connect( m_favoritesTree, &QTreeView::expanded, m_favoritesModel, &FavoritesModel::itemExpanded );
 
-  connect( m_favoritesTree, SIGNAL( collapsed( QModelIndex ) ),
-           m_favoritesModel, SLOT( itemCollapsed( QModelIndex ) ) );
+  connect( m_favoritesTree, &QTreeView::collapsed, m_favoritesModel, &FavoritesModel::itemCollapsed );
 
-  connect( m_favoritesModel, SIGNAL( expandItem( QModelIndex) ),
-           m_favoritesTree, SLOT( expand( QModelIndex ) ) );
+  connect( m_favoritesModel, &FavoritesModel::expandItem, m_favoritesTree, &QTreeView::expand );
 
   m_favoritesModel->checkAllNodesForExpand();
   m_favoritesTree->viewport()->setAcceptDrops( true );
@@ -115,14 +110,14 @@ void FavoritesPaneWidget::setUp( Config::Class * cfg, QMenu * menu )
   m_favoritesTree->viewport()->installEventFilter( this );
 
   // list selection and keyboard navigation
-  connect( m_favoritesTree, SIGNAL( clicked( QModelIndex const & ) ),
-           this, SLOT( onItemClicked( QModelIndex const & ) ) );
+  connect( m_favoritesTree, &QAbstractItemView::clicked, this, &FavoritesPaneWidget::onItemClicked );
 
-  connect ( m_favoritesTree->selectionModel(), SIGNAL( selectionChanged ( QItemSelection const & , QItemSelection const & ) ),
-      this, SLOT( onSelectionChanged( QItemSelection const & ) ) );
+  connect( m_favoritesTree->selectionModel(),
+    SIGNAL( selectionChanged( QItemSelection const &, QItemSelection const & ) ),
+    this,
+    SLOT( onSelectionChanged( QItemSelection const & ) ) );
 
-  connect( m_favoritesTree, SIGNAL( customContextMenuRequested( QPoint const & ) ),
-           this, SLOT( showCustomMenu( QPoint const & ) ) );
+  connect( m_favoritesTree, &QWidget::customContextMenuRequested, this, &FavoritesPaneWidget::showCustomMenu );
 }
 
 FavoritesPaneWidget::~FavoritesPaneWidget()

--- a/ffmpegaudio.cc
+++ b/ffmpegaudio.cc
@@ -63,9 +63,9 @@ void AudioService::playMemory( const char * ptr, int size )
   QByteArray audioData( ptr, size );
   DecoderThread * thread = new DecoderThread( audioData, this );
 
-  connect( thread, SIGNAL( error( QString ) ), this, SIGNAL( error( QString ) ) );
-  connect( this, SIGNAL( cancelPlaying( bool ) ), thread, SLOT( cancel( bool ) ), Qt::DirectConnection );
-  connect( thread, SIGNAL( finished() ), thread, SLOT( deleteLater() ) );
+  connect( thread, &DecoderThread::error, this, &AudioService::error );
+  connect( this, &AudioService::cancelPlaying, thread, &DecoderThread::cancel, Qt::DirectConnection );
+  connect( thread, &QThread::finished, thread, &QObject::deleteLater );
 
   thread->start();
 }

--- a/ffmpegaudioplayer.hh
+++ b/ffmpegaudioplayer.hh
@@ -16,21 +16,14 @@ class AudioPlayer : public AudioPlayerInterface
 {
   Q_OBJECT
 public:
-  AudioPlayer()
-  {
-    connect( &AudioService::instance(), SIGNAL( error( QString ) ),
-             this, SIGNAL( error( QString ) ) );
-  }
+ AudioPlayer() { connect( &AudioService::instance(), &AudioService::error, this, &AudioPlayerInterface::error ); }
 
-  ~AudioPlayer()
-  {
-    stop();
-  }
+ ~AudioPlayer() { stop(); }
 
-  virtual QString play( const char * data, int size )
-  {
-    AudioService::instance().playMemory( data, size );
-    return QString();
+ virtual QString play( const char * data, int size )
+ {
+   AudioService::instance().playMemory( data, size );
+   return QString();
   }
 
   virtual void stop()

--- a/forvo.cc
+++ b/forvo.cc
@@ -117,10 +117,8 @@ ForvoArticleRequest::ForvoArticleRequest( wstring const & str,
   apiKey( apiKey_ ), languageCode( languageCode_ ),
   dictionaryId( dictionaryId_ )
 {
-  connect( &mgr, SIGNAL( finished( QNetworkReply * ) ),
-           this, SLOT( requestFinished( QNetworkReply * ) ),
-           Qt::QueuedConnection );
-  
+  connect( &mgr, &QNetworkAccessManager::finished, this, &ForvoArticleRequest::requestFinished, Qt::QueuedConnection );
+
   addQuery(  mgr, str );
 
   for( unsigned x = 0; x < alts.size(); ++x )

--- a/fulltextsearch.cc
+++ b/fulltextsearch.cc
@@ -108,7 +108,7 @@ void FtsIndexing::doIndexing()
 
     Indexing *idx = new Indexing( isCancelled, dictionaries, indexingExited );
 
-    connect( idx, SIGNAL( sendNowIndexingName( QString ) ), this, SLOT( setNowIndexedName( QString ) ) );
+    connect( idx, &Indexing::sendNowIndexingName, this, &FtsIndexing::setNowIndexedName );
 
     QThreadPool::globalInstance()->start( idx );
 
@@ -238,8 +238,7 @@ FullTextSearchDialog::FullTextSearchDialog( QWidget * parent,
 
   setNewIndexingName( ftsIdx.nowIndexingName() );
 
-  connect( &ftsIdx, SIGNAL( newIndexingName( QString ) ),
-           this, SLOT( setNewIndexingName( QString ) ) );
+  connect( &ftsIdx, &FtsIndexing::newIndexingName, this, &FullTextSearchDialog::setNewIndexingName );
 
   ui.searchMode->addItem( tr( "Whole words" ), WholeWords );
   ui.searchMode->addItem( tr( "Plain text"), PlainText );
@@ -297,38 +296,33 @@ FullTextSearchDialog::FullTextSearchDialog( QWidget * parent,
 
   setLimitsUsing();
 
-  connect( ui.checkBoxDistanceBetweenWords, SIGNAL( stateChanged( int ) ),
-           this, SLOT( setLimitsUsing() ) );
-  connect( ui.checkBoxArticlesPerDictionary, SIGNAL( stateChanged( int ) ),
-           this, SLOT( setLimitsUsing() ) );
-  connect( ui.searchMode, SIGNAL( currentIndexChanged( int ) ),
-           this, SLOT( setLimitsUsing() ) );
-  connect( ui.checkBoxIgnoreWordOrder, SIGNAL( stateChanged( int ) ),
-           this, SLOT( ignoreWordsOrderClicked() ) );
-  connect( ui.checkBoxIgnoreDiacritics, SIGNAL( stateChanged( int ) ),
-           this, SLOT( ignoreDiacriticsClicked() ) );
+  connect( ui.checkBoxDistanceBetweenWords, &QCheckBox::stateChanged, this, &FullTextSearchDialog::setLimitsUsing );
+  connect( ui.checkBoxArticlesPerDictionary, &QCheckBox::stateChanged, this, &FullTextSearchDialog::setLimitsUsing );
+  connect( ui.searchMode, &QComboBox::currentIndexChanged, this, &FullTextSearchDialog::setLimitsUsing );
+  connect( ui.checkBoxIgnoreWordOrder, &QCheckBox::stateChanged, this, &FullTextSearchDialog::ignoreWordsOrderClicked );
+  connect( ui.checkBoxIgnoreDiacritics,
+    &QCheckBox::stateChanged,
+    this,
+    &FullTextSearchDialog::ignoreDiacriticsClicked );
 
   model = new HeadwordsListModel( this, results, activeDicts );
   ui.headwordsView->setModel( model );
 
   ui.articlesFoundLabel->setText( tr( "Articles found: " ) + "0" );
 
-  connect( ui.headwordsView, SIGNAL( clicked( QModelIndex ) ),
-           this, SLOT( itemClicked( QModelIndex ) ) );
+  connect( ui.headwordsView, &QAbstractItemView::clicked, this, &FullTextSearchDialog::itemClicked );
 
-  connect( this, SIGNAL( finished( int ) ), this, SLOT( saveData() ) );
+  connect( this, &QDialog::finished, this, &FullTextSearchDialog::saveData );
 
   connect( ui.OKButton, SIGNAL( clicked() ), this, SLOT( accept() ) );
   connect( ui.cancelButton, SIGNAL( clicked() ), this, SLOT( reject() ) );
 
-  connect( ui.helpButton, SIGNAL( clicked() ),
-           this, SLOT( helpRequested() ) );
+  connect( ui.helpButton, &QAbstractButton::clicked, this, &FullTextSearchDialog::helpRequested );
 
   helpAction.setShortcut( QKeySequence( "F1" ) );
   helpAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
 
-  connect( &helpAction, SIGNAL( triggered() ),
-           this, SLOT( helpRequested() ) );
+  connect( &helpAction, &QAction::triggered, this, &FullTextSearchDialog::helpRequested );
 
   addAction( &helpAction );
 
@@ -492,11 +486,17 @@ void FullTextSearchDialog::accept()
                                                               ignoreWordsOrder,
                                                               ignoreDiacritics
                                                             );
-    connect( req.get(), SIGNAL( finished() ),
-             this, SLOT( searchReqFinished() ), Qt::QueuedConnection );
+    connect( req.get(),
+      &Dictionary::Request::finished,
+      this,
+      &FullTextSearchDialog::searchReqFinished,
+      Qt::QueuedConnection );
 
-    connect( req.get(), SIGNAL( matchCount(int) ),
-             this, SLOT( matchCount(int) ), Qt::QueuedConnection );
+    connect( req.get(),
+      &Dictionary::Request::matchCount,
+      this,
+      &FullTextSearchDialog::matchCount,
+      Qt::QueuedConnection );
 
     searchReqs.push_back( req );
   }

--- a/groupcombobox.cc
+++ b/groupcombobox.cc
@@ -14,19 +14,16 @@ GroupComboBox::GroupComboBox( QWidget * parent ): QComboBox( parent ),
   setToolTip( tr( "Choose a Group (Alt+G)" ) );
 
   popupAction.setShortcut( QKeySequence( "Alt+G" ) );
-  connect( &popupAction, SIGNAL( triggered() ),
-           this, SLOT( popupGroups() ) );
+  connect( &popupAction, &QAction::triggered, this, &GroupComboBox::popupGroups );
 
   addAction( &popupAction );
 
   selectNextAction.setShortcut( QKeySequence( "Alt+PgDown" ) );
-  connect( &selectNextAction, SIGNAL( triggered() ),
-           this, SLOT( selectNextGroup() ) );
+  connect( &selectNextAction, &QAction::triggered, this, &GroupComboBox::selectNextGroup );
   addAction( &selectNextAction );
 
   selectPreviousAction.setShortcut( QKeySequence( "Alt+PgUp" ) );
-  connect( &selectPreviousAction, SIGNAL( triggered() ),
-           this, SLOT( selectPreviousGroup() ) );
+  connect( &selectPreviousAction, &QAction::triggered, this, &GroupComboBox::selectPreviousGroup );
   addAction( &selectPreviousAction );
 
   setMaxVisibleItems( 30 );

--- a/groups.cc
+++ b/groups.cc
@@ -37,36 +37,25 @@ Groups::Groups( QWidget * parent,
   ui.groups->setCornerWidget( groupsListButton );
   groupsListButton->setFocusPolicy( Qt::ClickFocus );
 
-  connect(groupsListMenu, SIGNAL( aboutToShow() ), this, SLOT( fillGroupsMenu() ) );
-  connect(groupsListMenu, SIGNAL( triggered( QAction * ) ),
-          this, SLOT( switchToGroup( QAction * ) ) );
+  connect( groupsListMenu, &QMenu::aboutToShow, this, &Groups::fillGroupsMenu );
+  connect( groupsListMenu, &QMenu::triggered, this, &Groups::switchToGroup );
 
   // Populate groups' widget
 
   ui.groups->populate( groups, dicts, ui.dictionaries->getCurrentDictionaries() );
 
-  connect( ui.addGroup, SIGNAL( clicked() ),
-           this, SLOT( addNew() ) );
-  connect( ui.renameGroup, SIGNAL( clicked() ),
-           this, SLOT( renameCurrent() ) );
-  connect( ui.removeGroup, SIGNAL( clicked() ),
-           this, SLOT( removeCurrent() ) );
-  connect( ui.removeAllGroups, SIGNAL( clicked() ),
-           this, SLOT( removeAll() ) );
-  connect( ui.addDictsToGroup, SIGNAL( clicked() ),
-           this, SLOT( addToGroup() ) );
-  connect( ui.dictionaries, SIGNAL(  doubleClicked(const QModelIndex &) ),
-           this, SLOT( addToGroup() ) );
-  connect( ui.removeDictsFromGroup, SIGNAL( clicked() ),
-           this, SLOT( removeFromGroup() ) );
-  connect( ui.autoGroups, SIGNAL( clicked() ),
-           this, SLOT( addAutoGroups() ) );
-  connect( ui.groups, SIGNAL( showDictionaryInfo( QString const & ) ),
-           this, SIGNAL( showDictionaryInfo( QString const & ) ) );
+  connect( ui.addGroup, &QAbstractButton::clicked, this, &Groups::addNew );
+  connect( ui.renameGroup, &QAbstractButton::clicked, this, &Groups::renameCurrent );
+  connect( ui.removeGroup, &QAbstractButton::clicked, this, &Groups::removeCurrent );
+  connect( ui.removeAllGroups, &QAbstractButton::clicked, this, &Groups::removeAll );
+  connect( ui.addDictsToGroup, &QAbstractButton::clicked, this, &Groups::addToGroup );
+  connect( ui.dictionaries, &QAbstractItemView::doubleClicked, this, &Groups::addToGroup );
+  connect( ui.removeDictsFromGroup, &QAbstractButton::clicked, this, &Groups::removeFromGroup );
+  connect( ui.autoGroups, &QAbstractButton::clicked, this, &Groups::addAutoGroups );
+  connect( ui.groups, &DictGroupsWidget::showDictionaryInfo, this, &Groups::showDictionaryInfo );
 
   ui.dictionaries->setContextMenuPolicy( Qt::CustomContextMenu );
-  connect( ui.dictionaries, SIGNAL( customContextMenuRequested( QPoint ) ),
-           this, SLOT( showDictInfo( QPoint ) ) );
+  connect( ui.dictionaries, &QWidget::customContextMenuRequested, this, &Groups::showDictInfo );
 
   countChanged();
 }

--- a/groups_widgets.cc
+++ b/groups_widgets.cc
@@ -65,15 +65,12 @@ DictGroupWidget::DictGroupWidget( QWidget * parent,
 
   ui.favoritesFolder->setText( group.favoritesFolder );
 
-  connect( ui.groupIcon, SIGNAL(activated(int)),this,SLOT(groupIconActivated(int)),
-           Qt::QueuedConnection );
+  connect( ui.groupIcon, &QComboBox::activated, this, &DictGroupWidget::groupIconActivated, Qt::QueuedConnection );
 
   ui.dictionaries->setContextMenuPolicy( Qt::CustomContextMenu );
-  connect( ui.dictionaries, SIGNAL( customContextMenuRequested( QPoint ) ),
-           this, SLOT( showDictInfo( QPoint ) ) );
+  connect( ui.dictionaries, &QWidget::customContextMenuRequested, this, &DictGroupWidget::showDictInfo );
 
-  connect( ui.dictionaries, SIGNAL( doubleClicked( QModelIndex ) ),
-           this, SLOT( removeCurrentItem( QModelIndex ) ) );
+  connect( ui.dictionaries, &QAbstractItemView::doubleClicked, this, &DictGroupWidget::removeCurrentItem );
 }
 
 void DictGroupWidget::groupIconActivated( int index )
@@ -548,8 +545,7 @@ DictGroupsWidget::DictGroupsWidget( QWidget * parent ):
 {
   setMovable( true );
   setContextMenuPolicy( Qt::CustomContextMenu );
-  connect( this, SIGNAL( customContextMenuRequested( QPoint ) ),
-           this, SLOT( contextMenu( QPoint ) ) );
+  connect( this, &QWidget::customContextMenuRequested, this, &DictGroupsWidget::contextMenu );
 }
 
 namespace {
@@ -585,7 +581,7 @@ void DictGroupsWidget::populate( Config::Groups const & groups,
     DictGroupWidget *gr = new DictGroupWidget( this, *allDicts, groups[ x ] );
     addTab( gr, escapeAmps( groups[ x ].name ) );
     connect( gr, &DictGroupWidget::showDictionaryInfo,this, &DictGroupsWidget::showDictionaryInfo );
-    connect( gr->getModel(), SIGNAL( contentChanged() ), this, SLOT( tabDataChanged() ) );
+    connect( gr->getModel(), &DictListModel::contentChanged, this, &DictGroupsWidget::tabDataChanged );
 
     setCurrentIndex( x );
     QString toolTipStr = "\"" + tabText( x ) + "\"\n" + tr( "Dictionaries: " )
@@ -656,12 +652,11 @@ void DictGroupsWidget::addNewGroup( QString const & name )
 
   DictGroupWidget *gr = new DictGroupWidget( this, *allDicts, newGroup );
   insertTab( idx, gr, escapeAmps( name ) );
-  connect( gr, SIGNAL( showDictionaryInfo( QString const & ) ),
-           this, SIGNAL( showDictionaryInfo( QString const & ) ) );
+  connect( gr, &DictGroupWidget::showDictionaryInfo, this, &DictGroupsWidget::showDictionaryInfo );
 
   setCurrentIndex( idx );
 
-  connect( gr->getModel(), SIGNAL( contentChanged() ), this, SLOT( tabDataChanged() ) );
+  connect( gr->getModel(), &DictListModel::contentChanged, this, &DictGroupsWidget::tabDataChanged );
 
   QString toolTipStr = "\"" + tabText( idx ) + "\"\n" + tr( "Dictionaries: " )
                        + QString::number( getCurrentModel()->getCurrentDictionaries().size() );
@@ -829,12 +824,12 @@ void DictGroupsWidget::combineGroups( int source, int target )
   setCurrentIndex( target );
   DictListModel *model = getCurrentModel();
 
-  disconnect( model, SIGNAL( contentChanged() ), this, SLOT( tabDataChanged() ) );
+  disconnect( model, &DictListModel::contentChanged, this, &DictGroupsWidget::tabDataChanged );
 
   for( unsigned i = 0; i < dicts.size(); i++ )
     model->addRow( QModelIndex(), dicts[ i ] );
 
-  connect( model, SIGNAL( contentChanged() ), this, SLOT( tabDataChanged() ) );
+  connect( model, &DictListModel::contentChanged, this, &DictGroupsWidget::tabDataChanged );
 
   QString toolTipStr = "\"" + tabText( target ) + "\"\n" + tr( "Dictionaries: " )
                        + QString::number( model->getCurrentDictionaries().size() );
@@ -1023,8 +1018,7 @@ QuickFilterLine::QuickFilterLine( QWidget * parent ): ExtLineEdit( parent ), m_f
   setPlaceholderText( tr( "Dictionary search/filter (Ctrl+F)" ) );
 
   m_focusAction.setShortcut( QKeySequence( "Ctrl+F" ) );
-  connect( &m_focusAction, SIGNAL( triggered() ),
-           this, SLOT( focusFilterLine() ) );
+  connect( &m_focusAction, &QAction::triggered, this, &QuickFilterLine::focusFilterLine );
 
   QPixmap image(":/icons/system-search.svg");
   setButtonPixmap(ExtLineEdit::Left, image.scaled(18, 18, Qt::KeepAspectRatio, Qt::SmoothTransformation));
@@ -1036,12 +1030,11 @@ QuickFilterLine::QuickFilterLine( QWidget * parent ): ExtLineEdit( parent ), m_f
   setButtonToolTip(ExtLineEdit::Right, tr("Clear Search"));
   setButtonVisible(ExtLineEdit::Right, true);
   setButtonAutoHide(ExtLineEdit::Right, true);
-  connect( this, SIGNAL( rightButtonClicked() ), this, SLOT( clear() ) );
+  connect( this, &ExtLineEdit::rightButtonClicked, this, &QLineEdit::clear );
 
   setFocusPolicy(Qt::StrongFocus);
 
-  connect (this, SIGNAL( textChanged( QString const & ) ),
-      this, SLOT( filterChangedInternal() ) );
+  connect( this, &QLineEdit::textChanged, this, &QuickFilterLine::filterChangedInternal );
 }
 
 QuickFilterLine::~QuickFilterLine()
@@ -1070,7 +1063,7 @@ QModelIndex QuickFilterLine::mapToSource( QModelIndex const & idx )
 void QuickFilterLine::filterChangedInternal()
 {
   // emit signal in async manner, to avoid UI slowdown
-  QTimer::singleShot( 1, this, SLOT( emitFilterChanged() ) );
+  QTimer::singleShot( 1, this, &QuickFilterLine::emitFilterChanged );
 }
 
 void QuickFilterLine::emitFilterChanged()

--- a/headwordsmodel.cpp
+++ b/headwordsmodel.cpp
@@ -42,7 +42,7 @@ void HeadwordListModel::setFilter( QRegularExpression reg )
   filtering = true;
   filterWords.clear();
   auto sr = _dict->prefixMatch( gd::toWString( reg.pattern() ), 30 );
-  connect( sr.get(), SIGNAL( finished() ), this, SLOT( requestFinished() ), Qt::QueuedConnection );
+  connect( sr.get(), &Dictionary::Request::finished, this, &HeadwordListModel::requestFinished, Qt::QueuedConnection );
   queuedRequests.push_back( sr );
 }
 

--- a/helpwindow.cc
+++ b/helpwindow.cc
@@ -19,7 +19,7 @@ HelpBrowser::HelpBrowser( QHelpEngineCore * engine, QWidget *parent ) :
     QTextBrowser( parent ),
     helpEngine( engine )
 {
-  connect( this, SIGNAL( anchorClicked( QUrl ) ), this, SLOT( linkClicked( QUrl ) ) );
+  connect( this, &QTextBrowser::anchorClicked, this, &HelpBrowser::linkClicked );
 }
 
 void HelpBrowser::showHelpForKeyword( QString const & id )
@@ -143,22 +143,19 @@ HelpWindow::HelpWindow( QWidget * parent, Config::Class & cfg_ ) :
     connect( helpEngine->indexWidget(), SIGNAL( linkActivated( QUrl, QString ) ),
              helpBrowser, SLOT( setSource( QUrl ) ) );
 
-    connect( navHome, SIGNAL( triggered() ), helpBrowser, SLOT( home() ) );
-    connect( navForward, SIGNAL( triggered() ), helpBrowser, SLOT( forward() ) );
-    connect( navBack, SIGNAL( triggered() ), helpBrowser, SLOT( backward() ) );
+    connect( navHome, &QAction::triggered, helpBrowser, &QTextBrowser::home );
+    connect( navForward, &QAction::triggered, helpBrowser, &QTextBrowser::forward );
+    connect( navBack, &QAction::triggered, helpBrowser, &QTextBrowser::backward );
 
-    connect( helpBrowser, SIGNAL( forwardAvailable( bool ) ),
-             this, SLOT( forwardEnabled( bool ) ) );
+    connect( helpBrowser, &QTextBrowser::forwardAvailable, this, &HelpWindow::forwardEnabled );
 
-    connect( helpBrowser, SIGNAL( backwardAvailable( bool ) ),
-             this, SLOT( backwardEnabled( bool ) ) );
+    connect( helpBrowser, &QTextBrowser::backwardAvailable, this, &HelpWindow::backwardEnabled );
 
-    connect( helpEngine->contentWidget(), SIGNAL( clicked( QModelIndex ) ),
-             this, SLOT( contentsItemClicked( QModelIndex ) ) );
+    connect( helpEngine->contentWidget(), &QAbstractItemView::clicked, this, &HelpWindow::contentsItemClicked );
 
-    connect( zoomInAction, SIGNAL( triggered( ) ), this, SLOT( zoomIn() ) );
-    connect( zoomOutAction, SIGNAL( triggered( ) ), this, SLOT( zoomOut() ) );
-    connect( zoomBaseAction, SIGNAL( triggered( ) ), this, SLOT( zoomBase() ) );
+    connect( zoomInAction, &QAction::triggered, this, &HelpWindow::zoomIn );
+    connect( zoomOutAction, &QAction::triggered, this, &HelpWindow::zoomOut );
+    connect( zoomBaseAction, &QAction::triggered, this, &HelpWindow::zoomBase );
 
     splitter = new QSplitter( this );
     splitter->addWidget( tabWidget );

--- a/historypanewidget.cc
+++ b/historypanewidget.cc
@@ -24,8 +24,7 @@ void HistoryPaneWidget::setUp( Config::Class * cfg,  History * history, QMenu * 
   m_deleteSelectedAction->setShortcut( QKeySequence( QKeySequence::Delete ) );
   m_deleteSelectedAction->setShortcutContext( Qt::WidgetWithChildrenShortcut );
   addAction( m_deleteSelectedAction );
-  connect( m_deleteSelectedAction, SIGNAL( triggered() ),
-           this, SLOT( deleteSelectedItems() ) );
+  connect( m_deleteSelectedAction, &QAction::triggered, this, &HistoryPaneWidget::deleteSelectedItems );
 
   // Copy selected items to clipboard
   m_copySelectedToClipboard = new QAction( this );
@@ -33,8 +32,7 @@ void HistoryPaneWidget::setUp( Config::Class * cfg,  History * history, QMenu * 
   m_copySelectedToClipboard->setShortcut( QKeySequence( QKeySequence::Copy ) );
   m_copySelectedToClipboard->setShortcutContext( Qt::WidgetWithChildrenShortcut );
   addAction( m_copySelectedToClipboard );
-  connect( m_copySelectedToClipboard, SIGNAL( triggered() ),
-           this, SLOT( copySelectedItems() ) );
+  connect( m_copySelectedToClipboard, &QAction::triggered, this, &HistoryPaneWidget::copySelectedItems );
 
 
   // Handle context menu, reusing some of the top-level window's History menu
@@ -79,15 +77,12 @@ void HistoryPaneWidget::setUp( Config::Class * cfg,  History * history, QMenu * 
   m_historyList->viewport()->installEventFilter( this );
 
   // list selection and keyboard navigation
-  connect( m_historyList, SIGNAL( clicked( QModelIndex const & ) ),
-           this, SLOT( onItemClicked( QModelIndex const & ) ) );
-  connect( m_history, SIGNAL( itemsChanged() ),
-           this, SLOT( updateHistoryCounts() ) );
+  connect( m_historyList, &QAbstractItemView::clicked, this, &HistoryPaneWidget::onItemClicked );
+  connect( m_history, &History::itemsChanged, this, &HistoryPaneWidget::updateHistoryCounts );
   connect ( m_historyList->selectionModel(), SIGNAL( selectionChanged ( QItemSelection const & , QItemSelection const & ) ),
       this, SLOT( onSelectionChanged( QItemSelection const & ) ) );
 
-  connect( m_historyList, SIGNAL( customContextMenuRequested( QPoint const & ) ),
-           this, SLOT( showCustomMenu( QPoint const & ) ) );
+  connect( m_historyList, &QWidget::customContextMenuRequested, this, &HistoryPaneWidget::showCustomMenu );
 
   listItemDelegate = new WordListItemDelegate( m_historyList->itemDelegate() );
   m_historyList->setItemDelegate( listItemDelegate );
@@ -231,9 +226,7 @@ HistoryModel::HistoryModel( History * history, QObject * parent )
   : QAbstractListModel( parent ), m_history(history)
 {
 
-  connect( m_history, SIGNAL( itemsChanged() ),
-           this, SLOT( historyChanged() ) );
-
+  connect( m_history, &History::itemsChanged, this, &HistoryModel::historyChanged );
 }
 
 int HistoryModel::rowCount( QModelIndex const & /*parent*/ ) const

--- a/hotkeywrapper.cc
+++ b/hotkeywrapper.cc
@@ -21,11 +21,17 @@ QHotkeyApplication::QHotkeyApplication( int & argc, char ** argv ):
 ,  mainWindow( 0 )
 #endif
 {
-  connect( this, SIGNAL( commitDataRequest( QSessionManager& ) ),
-           this, SLOT( hotkeyAppCommitData( QSessionManager& ) ), Qt::DirectConnection );
+  connect( this,
+    &QGuiApplication::commitDataRequest,
+    this,
+    &QHotkeyApplication::hotkeyAppCommitData,
+    Qt::DirectConnection );
 
-  connect( this, SIGNAL( saveStateRequest( QSessionManager& ) ),
-           this, SLOT( hotkeyAppSaveState( QSessionManager& ) ), Qt::DirectConnection );
+  connect( this,
+    &QGuiApplication::saveStateRequest,
+    this,
+    &QHotkeyApplication::hotkeyAppSaveState,
+    Qt::DirectConnection );
 
 #if defined( Q_OS_WIN ) 
   installNativeEventFilter( this );
@@ -39,11 +45,17 @@ QHotkeyApplication::QHotkeyApplication( QString const & id,
 ,  mainWindow( 0 )
 #endif
 {
-  connect( this, SIGNAL( commitDataRequest( QSessionManager& ) ),
-           this, SLOT( hotkeyAppCommitData( QSessionManager& ) ), Qt::DirectConnection );
+  connect( this,
+    &QGuiApplication::commitDataRequest,
+    this,
+    &QHotkeyApplication::hotkeyAppCommitData,
+    Qt::DirectConnection );
 
-  connect( this, SIGNAL( saveStateRequest( QSessionManager& ) ),
-           this, SLOT( hotkeyAppSaveState( QSessionManager& ) ), Qt::DirectConnection );
+  connect( this,
+    &QGuiApplication::saveStateRequest,
+    this,
+    &QHotkeyApplication::hotkeyAppSaveState,
+    Qt::DirectConnection );
 
 #if defined( Q_OS_WIN ) 
   installNativeEventFilter( this );
@@ -250,7 +262,7 @@ bool HotkeyWrapper::checkState(quint32 vk, quint32 mod)
 
       state2 = true;
       state2waiter = hs;
-      QTimer::singleShot(500, this, SLOT(waitKey2()));
+      QTimer::singleShot( 500, this, &HotkeyWrapper::waitKey2 );
 
       #ifdef HAVE_X11
 
@@ -530,9 +542,7 @@ void HotkeyWrapper::init()
   // This is required to ensure context was indeed created
   XSync( display, False );
 
-  connect( this, SIGNAL( keyRecorded( quint32, quint32 ) ),
-           this, SLOT( checkState( quint32, quint32 ) ),
-           Qt::QueuedConnection );
+  connect( this, &HotkeyWrapper::keyRecorded, this, &HotkeyWrapper::checkState, Qt::QueuedConnection );
 
   start();
 }

--- a/loaddictionaries.cc
+++ b/loaddictionaries.cc
@@ -177,13 +177,11 @@ void loadDictionaries( QWidget * parent, bool showInitially,
 
   LoadDictionaries loadDicts( cfg );
 
-  QObject::connect( &loadDicts, SIGNAL( indexingDictionarySignal( QString const & ) ),
-                    &init, SLOT( indexing( QString const & ) ) );
+  QObject::connect( &loadDicts, &LoadDictionaries::indexingDictionarySignal, &init, &Initializing::indexing );
 
   QEventLoop localLoop;
 
-  QObject::connect( &loadDicts, SIGNAL( finished() ),
-                    &localLoop, SLOT( quit() ) );
+  QObject::connect( &loadDicts, &QThread::finished, &localLoop, &QEventLoop::quit );
 
   loadDicts.start();
 

--- a/main.cc
+++ b/main.cc
@@ -424,8 +424,7 @@ int main( int argc, char ** argv )
 
   app.addDataCommiter( m );
 
-  QObject::connect( &app, SIGNAL(messageReceived(QString)),
-    &m, SLOT(messageFromAnotherInstanceReceived(QString)));
+  QObject::connect( &app, &QtSingleApplication::messageReceived, &m, &MainWindow::messageFromAnotherInstanceReceived );
 
   if( gdcl.needSetGroup() )
     m.setGroupByName( gdcl.getGroupName(), true );

--- a/mainstatusbar.cc
+++ b/mainstatusbar.cc
@@ -38,7 +38,7 @@ MainStatusBar::MainStatusBar( QWidget *parent ) : QWidget( parent )
 
   parentWidget()->installEventFilter( this );
 
-  connect( timer, SIGNAL( timeout() ), SLOT( clearMessage() ) );
+  connect( timer, &QTimer::timeout, this, &MainStatusBar::clearMessage );
 }
 
 bool MainStatusBar::hasImage() const

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -242,8 +242,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
     enableScanningAction->setChecked( true );
   }
 
-  connect( enableScanningAction, SIGNAL( toggled( bool ) ),
-           this, SLOT( scanEnableToggled( bool ) ) );
+  connect( enableScanningAction, &QAction::toggled, this, &MainWindow::scanEnableToggled );
 
   navToolbar->addSeparator();
 
@@ -288,8 +287,8 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   addToFavorites = navToolbar->addAction( starIcon, tr( "Add current tab to Favorites" ) );
   navToolbar->widgetForAction( addToFavorites )->setObjectName( "addToFavoritesButton" );
 
-  connect( addToFavorites, SIGNAL( triggered() ), this, SLOT( handleAddToFavoritesButton() ) );
-  connect( ui.actionAddToFavorites, SIGNAL( triggered() ), this, SLOT( addCurrentTabToFavorites() ) );
+  connect( addToFavorites, &QAction::triggered, this, &MainWindow::handleAddToFavoritesButton );
+  connect( ui.actionAddToFavorites, &QAction::triggered, this, &MainWindow::addCurrentTabToFavorites );
 
   beforeOptionsSeparator = navToolbar->addSeparator();
   navToolbar->widgetForAction( beforeOptionsSeparator )->setObjectName( "beforeOptionsSeparator" );
@@ -333,8 +332,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   searchPaneTitleBar.setLayout( &searchPaneTitleBarLayout );
 
   ui.searchPane->setTitleBarWidget( &searchPaneTitleBar );
-  connect( ui.searchPane->toggleViewAction(), SIGNAL( triggered( bool ) ),
-           this, SLOT( updateSearchPaneAndBar( bool ) ) );
+  connect( ui.searchPane->toggleViewAction(), &QAction::triggered, this, &MainWindow::updateSearchPaneAndBar );
 
   if ( cfg.preferences.searchInDock )
   {
@@ -372,18 +370,13 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   connect( ui.dictsPane, SIGNAL( visibilityChanged( bool ) ),
            this, SLOT( dictsPaneVisibilityChanged ( bool ) ) );
 
-  connect( ui.dictsList, SIGNAL( itemClicked( QListWidgetItem * ) ),
-           this, SLOT( foundDictsPaneClicked( QListWidgetItem * ) ) );
+  connect( ui.dictsList, &QListWidget::itemClicked, this, &MainWindow::foundDictsPaneClicked );
 
-  connect( ui.dictsList, SIGNAL( customContextMenuRequested( const QPoint & ) ),
-           this, SLOT( foundDictsContextMenuRequested( const QPoint & ) ) );
+  connect( ui.dictsList, &QWidget::customContextMenuRequested, this, &MainWindow::foundDictsContextMenuRequested );
 
-  connect( zoomIn, SIGNAL( triggered() ),
-           this, SLOT( zoomin() ) );
-  connect( zoomOut, SIGNAL( triggered() ),
-           this, SLOT( zoomout() ) );
-  connect( zoomBase, SIGNAL( triggered() ),
-           this, SLOT( unzoom() ) );
+  connect( zoomIn, &QAction::triggered, this, &MainWindow::zoomin );
+  connect( zoomOut, &QAction::triggered, this, &MainWindow::zoomout );
+  connect( zoomBase, &QAction::triggered, this, &MainWindow::unzoom );
 
   ui.menuZoom->addAction( zoomIn );
   ui.menuZoom->addAction( zoomOut );
@@ -400,18 +393,19 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   wordsZoomBase = ui.menuZoom->addAction( QIcon( ":/icons/icon32_zoombase.png" ), tr( "Words Normal Size" ) );
   wordsZoomBase->setShortcut( QKeySequence( "Alt+0" ) );
 
-  connect( wordsZoomIn, SIGNAL(triggered()), this, SLOT(doWordsZoomIn()) );
-  connect( wordsZoomOut, SIGNAL(triggered()), this, SLOT(doWordsZoomOut()) );
-  connect( wordsZoomBase, SIGNAL(triggered()), this, SLOT(doWordsZoomBase()) );
+  connect( wordsZoomIn, &QAction::triggered, this, &MainWindow::doWordsZoomIn );
+  connect( wordsZoomOut, &QAction::triggered, this, &MainWindow::doWordsZoomOut );
+  connect( wordsZoomBase, &QAction::triggered, this, &MainWindow::doWordsZoomBase );
 
   // tray icon
-  connect( trayIconMenu.addAction( tr( "Show &Main Window" ) ), SIGNAL( triggered() ),
-           this, SLOT( showMainWindow() ) );
+  connect( trayIconMenu.addAction( tr( "Show &Main Window" ) ),
+    &QAction::triggered,
+    this,
+    &MainWindow::showMainWindow );
   trayIconMenu.addAction( enableScanningAction );
 
   trayIconMenu.addSeparator();
-  connect( trayIconMenu.addAction( tr( "&Quit" ) ), SIGNAL( triggered() ),
-           this, SLOT( quitApp() ) );
+  connect( trayIconMenu.addAction( tr( "&Quit" ) ), &QAction::triggered, this, &MainWindow::quitApp );
 
   addGlobalAction( &escAction, SLOT( handleEsc() ) );
   escAction.setShortcut( QKeySequence( "Esc" ) );
@@ -435,10 +429,9 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   // Tab management
   tabListMenu = new MRUQMenu(tr("Opened tabs"), ui.tabWidget);
 
-  connect (tabListMenu, SIGNAL(ctrlReleased()), this, SLOT(ctrlReleased()));
+  connect( tabListMenu, &MRUQMenu::ctrlReleased, this, &MainWindow::ctrlReleased );
 
-  connect( &addTabAction, SIGNAL( triggered() ),
-           this, SLOT( addNewTab() ) );
+  connect( &addTabAction, &QAction::triggered, this, &MainWindow::addNewTab );
 
   addAction( &addTabAction );
 
@@ -446,8 +439,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   closeCurrentTabAction.setShortcut( QKeySequence( "Ctrl+W" ) );
   closeCurrentTabAction.setText( tr("Close current tab") );
 
-  connect( &closeCurrentTabAction, SIGNAL( triggered() ),
-           this, SLOT( closeCurrentTab() ) );
+  connect( &closeCurrentTabAction, &QAction::triggered, this, &MainWindow::closeCurrentTab );
 
   addAction( &closeCurrentTabAction );
 
@@ -455,32 +447,28 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   closeAllTabAction.setShortcut( QKeySequence( "Ctrl+Shift+W" ) );
   closeAllTabAction.setText( tr("Close all tabs") );
 
-  connect( &closeAllTabAction, SIGNAL( triggered() ),
-           this, SLOT( closeAllTabs() ) );
+  connect( &closeAllTabAction, &QAction::triggered, this, &MainWindow::closeAllTabs );
 
   addAction( &closeAllTabAction );
 
   closeRestTabAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
   closeRestTabAction.setText( tr("Close all tabs except current") );
 
-  connect( &closeRestTabAction, SIGNAL( triggered() ),
-           this, SLOT( closeRestTabs() ) );
+  connect( &closeRestTabAction, &QAction::triggered, this, &MainWindow::closeRestTabs );
 
   addAction( &closeRestTabAction );
 
   switchToNextTabAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
   switchToNextTabAction.setShortcut( QKeySequence( "Ctrl+PgDown" ) );
 
-  connect( &switchToNextTabAction, SIGNAL( triggered() ),
-           this, SLOT( switchToNextTab() ) );
+  connect( &switchToNextTabAction, &QAction::triggered, this, &MainWindow::switchToNextTab );
 
   addAction( &switchToNextTabAction );
 
   switchToPrevTabAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
   switchToPrevTabAction.setShortcut( QKeySequence( "Ctrl+PgUp" ) );
 
-  connect( &switchToPrevTabAction, SIGNAL( triggered() ),
-           this, SLOT( switchToPrevTab() ) );
+  connect( &switchToPrevTabAction, &QAction::triggered, this, &MainWindow::switchToPrevTab );
 
   addAction( &switchToPrevTabAction );
 
@@ -490,15 +478,13 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
                                        QKeySequence( Qt::CTRL | Qt::Key_Asterisk ) <<
                                        QKeySequence( Qt::CTRL | Qt::SHIFT | Qt::Key_8 ) );
 
-  connect( &switchExpandModeAction, SIGNAL( triggered() ),
-           this, SLOT(switchExpandOptionalPartsMode() ) );
+  connect( &switchExpandModeAction, &QAction::triggered, this, &MainWindow::switchExpandOptionalPartsMode );
 
   addAction( &switchExpandModeAction );
 
   addAllTabToFavoritesAction.setText( tr( "Add all tabs to Favorites" ) );
 
-  connect( &addAllTabToFavoritesAction, SIGNAL( triggered() ),
-           this, SLOT( addAllTabsToFavorites() ) );
+  connect( &addAllTabToFavoritesAction, &QAction::triggered, this, &MainWindow::addAllTabsToFavorites );
 
   tabMenu = new QMenu(this);
   tabMenu->addAction( &closeCurrentTabAction );
@@ -514,24 +500,21 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   showDictBarNamesAction.setCheckable( true );
   showDictBarNamesAction.setChecked( cfg.showingDictBarNames );
 
-  connect( &showDictBarNamesAction, SIGNAL( triggered() ),
-           this, SLOT( showDictBarNamesTriggered() ) );
+  connect( &showDictBarNamesAction, &QAction::triggered, this, &MainWindow::showDictBarNamesTriggered );
 
   // Use small icons in toolbars
 
   useSmallIconsInToolbarsAction.setCheckable( true );
   useSmallIconsInToolbarsAction.setChecked( cfg.usingSmallIconsInToolbars );
 
-  connect( &useSmallIconsInToolbarsAction, SIGNAL( triggered() ),
-           this, SLOT( useSmallIconsInToolbarsTriggered() ) );
+  connect( &useSmallIconsInToolbarsAction, &QAction::triggered, this, &MainWindow::useSmallIconsInToolbarsTriggered );
 
   // Toggle Menubar
   toggleMenuBarAction.setCheckable( true );
   toggleMenuBarAction.setChecked( !cfg.preferences.hideMenubar );
   toggleMenuBarAction.setShortcut( QKeySequence( "Ctrl+M" ) );
 
-  connect( &toggleMenuBarAction, SIGNAL( triggered() ),
-           this, SLOT( toggleMenuBarTriggered() ) );
+  connect( &toggleMenuBarAction, &QAction::triggered, this, &MainWindow::toggleMenuBarTriggered );
 
   // Populate 'View' menu
 
@@ -583,51 +566,45 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   addToolBar( &dictionaryBar );
 
-  connect( dictionaryBar.toggleViewAction(), SIGNAL(triggered(bool)),
-           this, SLOT(dictionaryBarToggled(bool)) );
+  connect( dictionaryBar.toggleViewAction(), &QAction::triggered, this, &MainWindow::dictionaryBarToggled );
   // This one will be disconnected once the slot is activated. It exists
   // only to handle the initial appearance of the dictionary bar.
-  connect( dictionaryBar.toggleViewAction(), SIGNAL(toggled(bool)),
-           this, SLOT(dictionaryBarToggled(bool)) );
+  connect( dictionaryBar.toggleViewAction(), &QAction::toggled, this, &MainWindow::dictionaryBarToggled );
 
-  connect( &dictionaryBar, SIGNAL(editGroupRequested()),
-           this, SLOT(editCurrentGroup()) );
+  connect( &dictionaryBar, &DictionaryBar::editGroupRequested, this, &MainWindow::editCurrentGroup );
 
-  connect( &dictionaryBar, SIGNAL( showDictionaryInfo( QString const & ) ),
-           this, SLOT( showDictionaryInfo( QString const & ) ) );
+  connect( &dictionaryBar, &DictionaryBar::showDictionaryInfo, this, &MainWindow::showDictionaryInfo );
 
-  connect( &dictionaryBar, SIGNAL( showDictionaryHeadwords( QString const & ) ),
-           this, SLOT( showDictionaryHeadwords( QString const & ) ) );
+  connect( &dictionaryBar,
+    SIGNAL( showDictionaryHeadwords( QString const & ) ),
+    this,
+    SLOT( showDictionaryHeadwords( QString const & ) ) );
 
-  connect( &dictionaryBar, SIGNAL( openDictionaryFolder( QString const & ) ),
-           this, SLOT( openDictionaryFolder( QString const & ) ) );
+  connect( &dictionaryBar, &DictionaryBar::openDictionaryFolder, this, &MainWindow::openDictionaryFolder );
 
   // Favorites
 
   ui.favoritesPaneWidget->setUp( &cfg, ui.menuFavorites );
   ui.favoritesPaneWidget->setSaveInterval( cfg.preferences.favoritesStoreInterval );
 
-  connect( ui.favoritesPane, SIGNAL( visibilityChanged( bool ) ),
-           this, SLOT( updateFavoritesMenu() ) );
+  connect( ui.favoritesPane, &QDockWidget::visibilityChanged, this, &MainWindow::updateFavoritesMenu );
 
-  connect( ui.menuFavorites, SIGNAL( aboutToShow() ),
-           this, SLOT( updateFavoritesMenu() ) );
+  connect( ui.menuFavorites, &QMenu::aboutToShow, this, &MainWindow::updateFavoritesMenu );
 
-  connect( ui.favoritesPaneWidget, SIGNAL( favoritesItemRequested( QString, QString ) ),
-           this, SLOT( headwordFromFavorites( QString, QString ) ) );
+  connect( ui.favoritesPaneWidget,
+    &FavoritesPaneWidget::favoritesItemRequested,
+    this,
+    &MainWindow::headwordFromFavorites );
 
   // History
   ui.historyPaneWidget->setUp( &cfg, &history, ui.menuHistory );
   history.enableAdd( cfg.preferences.storeHistory );
 
-  connect( ui.historyPaneWidget, SIGNAL( historyItemRequested( QString const & ) ),
-           this, SLOT( showHistoryItem( QString const & ) ) );
+  connect( ui.historyPaneWidget, &HistoryPaneWidget::historyItemRequested, this, &MainWindow::showHistoryItem );
 
-  connect( ui.historyPane, SIGNAL( visibilityChanged( bool ) ),
-           this, SLOT( updateHistoryMenu() ) );
+  connect( ui.historyPane, &QDockWidget::visibilityChanged, this, &MainWindow::updateHistoryMenu );
 
-  connect( ui.menuHistory, SIGNAL( aboutToShow() ),
-           this, SLOT( updateHistoryMenu() ) );
+  connect( ui.menuHistory, &QMenu::aboutToShow, this, &MainWindow::updateHistoryMenu );
 
 #if !defined( HAVE_X11 )
   // Show tray icon early so the user would be happy. It won't be functional
@@ -643,10 +620,8 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   }
 #endif
 
-  connect( navBack, SIGNAL( triggered() ),
-           this, SLOT( backClicked() ) );
-  connect( navForward, SIGNAL( triggered() ),
-           this, SLOT( forwardClicked() ) );
+  connect( navBack, &QAction::triggered, this, &MainWindow::backClicked );
+  connect( navForward, &QAction::triggered, this, &MainWindow::forwardClicked );
 
   addTab.setAutoRaise( true );
   addTab.setToolTip( tr( "New Tab"  ) );
@@ -667,42 +642,29 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   ui.tabWidget->setContextMenuPolicy( Qt::CustomContextMenu );
 
-  connect( &addTab, SIGNAL( clicked() ),
-           this, SLOT( addNewTab() ) );
+  connect( &addTab, &QAbstractButton::clicked, this, &MainWindow::addNewTab );
 
-  connect( ui.tabWidget, SIGNAL( doubleClicked() ),
-           this, SLOT( addNewTab() ) );
+  connect( ui.tabWidget, &MainTabWidget::doubleClicked, this, &MainWindow::addNewTab );
 
-  connect( ui.tabWidget, SIGNAL( tabCloseRequested( int ) ),
-           this, SLOT( tabCloseRequested( int ) ) );
+  connect( ui.tabWidget, &QTabWidget::tabCloseRequested, this, &MainWindow::tabCloseRequested );
 
-  connect( ui.tabWidget, SIGNAL( currentChanged( int ) ),
-           this, SLOT( tabSwitched( int ) ) );
+  connect( ui.tabWidget, &QTabWidget::currentChanged, this, &MainWindow::tabSwitched );
 
-  connect( ui.tabWidget, SIGNAL( customContextMenuRequested(QPoint)) ,
-           this, SLOT( tabMenuRequested(QPoint)) );
+  connect( ui.tabWidget, &QWidget::customContextMenuRequested, this, &MainWindow::tabMenuRequested );
 
   ui.tabWidget->setTabsClosable( true );
 
-  connect( ui.quit, SIGNAL( triggered() ),
-           this, SLOT( quitApp() ) );
+  connect( ui.quit, &QAction::triggered, this, &MainWindow::quitApp );
 
-  connect( ui.dictionaries, SIGNAL( triggered() ),
-           this, SLOT( editDictionaries() ) );
+  connect( ui.dictionaries, &QAction::triggered, this, &MainWindow::editDictionaries );
 
-  connect( ui.preferences, SIGNAL( triggered() ),
-           this, SLOT( editPreferences() ) );
+  connect( ui.preferences, &QAction::triggered, this, &MainWindow::editPreferences );
 
-  connect( ui.visitHomepage, SIGNAL( triggered() ),
-           this, SLOT( visitHomepage() ) );
-  connect( ui.visitForum, SIGNAL( triggered() ),
-           this, SLOT( visitForum() ) );
-  connect( ui.openConfigFolder, SIGNAL( triggered() ),
-           this, SLOT( openConfigFolder() ) );
-  connect( ui.about, SIGNAL( triggered() ),
-           this, SLOT( showAbout() ) );
-  connect( ui.showReference, SIGNAL( triggered() ),
-           this, SLOT( showGDHelp() ) );
+  connect( ui.visitHomepage, &QAction::triggered, this, &MainWindow::visitHomepage );
+  connect( ui.visitForum, &QAction::triggered, this, &MainWindow::visitForum );
+  connect( ui.openConfigFolder, &QAction::triggered, this, &MainWindow::openConfigFolder );
+  connect( ui.about, &QAction::triggered, this, &MainWindow::showAbout );
+  connect( ui.showReference, &QAction::triggered, this, &MainWindow::showGDHelp );
 
   connect( groupListInDock, &GroupComboBox::currentIndexChanged,
            this, &MainWindow::currentGroupChanged );
@@ -710,41 +672,31 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   connect( groupListInToolbar, &GroupComboBox::currentIndexChanged,
            this, &MainWindow::currentGroupChanged );
 
-  connect( ui.translateLine, SIGNAL( textChanged( QString const & ) ),
-           this, SLOT( translateInputChanged( QString const & ) ) );
+  connect( ui.translateLine, &QLineEdit::textChanged, this, &MainWindow::translateInputChanged );
 
-  connect( translateBox->translateLine(), SIGNAL( textChanged( QString const & ) ),
-           this, SLOT( translateInputChanged( QString const & ) ) );
+  connect( translateBox->translateLine(), &QLineEdit::textChanged, this, &MainWindow::translateInputChanged );
 
-  connect( ui.translateLine, SIGNAL( returnPressed() ),
-           this, SLOT( translateInputFinished() ) );
+  connect( ui.translateLine, SIGNAL( returnPressed() ), this, SLOT( translateInputFinished() ) );
 
   connect( translateBox->translateLine(), SIGNAL( returnPressed() ),
            this, SLOT( translateInputFinished() ) );
 
-  connect( ui.wordList, SIGNAL( itemSelectionChanged() ),
-           this, SLOT( wordListSelectionChanged() ) );
+  connect( ui.wordList, &QListWidget::itemSelectionChanged, this, &MainWindow::wordListSelectionChanged );
 
   connect( translateBox->wordList(), SIGNAL( itemDoubleClicked ( QListWidgetItem * ) ),
            this, SLOT( wordListItemActivated( QListWidgetItem * ) ) );
 
-  connect( ui.wordList, SIGNAL( itemClicked( QListWidgetItem * ) ),
-           this, SLOT( wordListItemActivated( QListWidgetItem * ) ) );
+  connect( ui.wordList, &QListWidget::itemClicked, this, &MainWindow::wordListItemActivated );
 
-  connect( ui.wordList, SIGNAL( statusBarMessage( QString const &, int, QPixmap const & ) ),
-           this, SLOT( showStatusBarMessage( QString const &, int, QPixmap const & ) ) );
+  connect( ui.wordList, &WordList::statusBarMessage, this, &MainWindow::showStatusBarMessage );
 
-  connect( translateBox->wordList(), SIGNAL( statusBarMessage( QString const &, int, QPixmap const & ) ),
-           this, SLOT( showStatusBarMessage( QString const &, int, QPixmap const & ) ) );
+  connect( translateBox->wordList(), &WordList::statusBarMessage, this, &MainWindow::showStatusBarMessage );
 
-  connect( ui.dictsList, SIGNAL( itemSelectionChanged() ),
-           this, SLOT( dictsListSelectionChanged() ) );
+  connect( ui.dictsList, &QListWidget::itemSelectionChanged, this, &MainWindow::dictsListSelectionChanged );
 
-  connect( ui.dictsList, SIGNAL( itemDoubleClicked( QListWidgetItem * ) ),
-           this, SLOT( dictsListItemActivated( QListWidgetItem * ) ) );
+  connect( ui.dictsList, &QListWidget::itemDoubleClicked, this, &MainWindow::dictsListItemActivated );
 
-  connect( &configEvents, SIGNAL( mutedDictionariesChanged() ),
-           this, SLOT( mutedDictionariesChanged() ) );
+  connect( &configEvents, &Config::Events::mutedDictionariesChanged, this, &MainWindow::mutedDictionariesChanged );
 
   this->installEventFilter( this );
 
@@ -769,7 +721,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   groupListInDock->installEventFilter( this );
   groupListInToolbar->installEventFilter( this );
 
-  connect( &ftsIndexing, SIGNAL( newIndexingName( QString ) ), this, SLOT( showFTSIndexingName( QString ) ) );
+  connect( &ftsIndexing, &FTS::FtsIndexing::newIndexingName, this, &MainWindow::showFTSIndexingName );
 
 #ifndef Q_OS_MAC
   {
@@ -787,11 +739,12 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   //set  webengineview font
   changeWebEngineViewFont();
 
-  connect( &dictNetMgr, SIGNAL( proxyAuthenticationRequired( QNetworkProxy, QAuthenticator * ) ),
-           this, SLOT( proxyAuthentication( QNetworkProxy, QAuthenticator * ) ) );
+  connect( &dictNetMgr, &QNetworkAccessManager::proxyAuthenticationRequired, this, &MainWindow::proxyAuthentication );
 
-  connect( &articleNetMgr, SIGNAL( proxyAuthenticationRequired( QNetworkProxy, QAuthenticator * ) ),
-           this, SLOT( proxyAuthentication( QNetworkProxy, QAuthenticator * ) ) );
+  connect( &articleNetMgr,
+    &QNetworkAccessManager::proxyAuthenticationRequired,
+    this,
+    &MainWindow::proxyAuthentication );
 
   setupNetworkCache( cfg.preferences.maxNetworkCacheSize );
 
@@ -844,8 +797,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
     trayIcon->setContextMenu( &trayIconMenu );
     trayIcon->show();
 
-    connect( trayIcon, SIGNAL( activated( QSystemTrayIcon::ActivationReason ) ),
-             this, SLOT( trayIconActivated( QSystemTrayIcon::ActivationReason ) ) );
+    connect( trayIcon, &QSystemTrayIcon::activated, this, &MainWindow::trayIconActivated );
   }
 
   updateTrayIcon();
@@ -873,8 +825,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
     focusTranslateLine();
   }
 
-  connect( &newReleaseCheckTimer, SIGNAL( timeout() ),
-           this, SLOT( checkForNewRelease() ) );
+  connect( &newReleaseCheckTimer, &QTimer::timeout, this, &MainWindow::checkForNewRelease );
 
   if ( cfg.preferences.hideMenubar )
   {
@@ -1264,11 +1215,9 @@ void MainWindow::updateTrayIcon()
     trayIcon->setContextMenu( &trayIconMenu );
     trayIcon->show();
 
-    connect( trayIcon, SIGNAL( activated( QSystemTrayIcon::ActivationReason ) ),
-             this, SLOT( trayIconActivated( QSystemTrayIcon::ActivationReason ) ) );
+    connect( trayIcon, &QSystemTrayIcon::activated, this, &MainWindow::trayIconActivated );
   }
-  else
-  if ( trayIcon && !cfg.preferences.enableTrayIcon )
+  else if( trayIcon && !cfg.preferences.enableTrayIcon )
   {
     // Need to hide it
     delete trayIcon;
@@ -1580,37 +1529,31 @@ void MainWindow::makeScanPopup()
   connect( scanPopup.get(), SIGNAL(editGroupRequested( unsigned ) ),
            this, SLOT(editDictionaries( unsigned )), Qt::QueuedConnection );
 
-  connect( scanPopup.get(), SIGNAL(sendPhraseToMainWindow( Config::InputPhrase const & ) ),
-           this, SLOT(phraseReceived( Config::InputPhrase const & )), Qt::QueuedConnection );
+  connect( scanPopup.get(),
+    &ScanPopup::sendPhraseToMainWindow,
+    this,
+    &MainWindow::phraseReceived,
+    Qt::QueuedConnection );
 
-  connect( this, SIGNAL( setExpandOptionalParts( bool ) ),
-           scanPopup.get(), SIGNAL( setViewExpandMode( bool ) ) );
+  connect( this, &MainWindow::setExpandOptionalParts, scanPopup.get(), &ScanPopup::setViewExpandMode );
 
-  connect( scanPopup.get(), SIGNAL( setExpandMode( bool ) ),
-           this, SLOT( setExpandMode( bool ) ) );
+  connect( scanPopup.get(), &ScanPopup::setExpandMode, this, &MainWindow::setExpandMode );
 
   connect( scanPopup.get(), &ScanPopup::inspectSignal,this,&MainWindow::inspectElement );
 
-  connect( scanPopup.get(), SIGNAL( forceAddWordToHistory( const QString & ) ),
-           this, SLOT( forceAddWordToHistory( const QString & ) ) );
+  connect( scanPopup.get(), &ScanPopup::forceAddWordToHistory, this, &MainWindow::forceAddWordToHistory );
 
-  connect( scanPopup.get(), SIGNAL( showDictionaryInfo( const QString & ) ),
-           this, SLOT( showDictionaryInfo( const QString & ) ) );
+  connect( scanPopup.get(), &ScanPopup::showDictionaryInfo, this, &MainWindow::showDictionaryInfo );
 
-  connect( scanPopup.get(), SIGNAL( openDictionaryFolder( const QString & ) ),
-           this, SLOT( openDictionaryFolder( const QString & ) ) );
+  connect( scanPopup.get(), &ScanPopup::openDictionaryFolder, this, &MainWindow::openDictionaryFolder );
 
-  connect( scanPopup.get(), SIGNAL( sendWordToHistory( QString ) ),
-           this, SLOT( addWordToHistory( QString ) ) );
+  connect( scanPopup.get(), &ScanPopup::sendWordToHistory, this, &MainWindow::addWordToHistory );
 
-  connect( this, SIGNAL( setPopupGroupByName( QString ) ),
-           scanPopup.get(), SLOT( setGroupByName( QString ) ) );
+  connect( this, &MainWindow::setPopupGroupByName, scanPopup.get(), &ScanPopup::setGroupByName );
 
-  connect( scanPopup.get(), SIGNAL( sendWordToFavorites( QString, uint ) ),
-           this, SLOT( addWordToFavorites( QString, uint ) ) );
+  connect( scanPopup.get(), &ScanPopup::sendWordToFavorites, this, &MainWindow::addWordToFavorites );
 
-  connect( scanPopup.get(), SIGNAL( isWordPresentedInFavorites( QString, uint ) ),
-           this, SLOT( isWordPresentedInFavorites( QString, uint ) ) );
+  connect( scanPopup.get(), &ScanPopup::isWordPresentedInFavorites, this, &MainWindow::isWordPresentedInFavorites );
 
 #ifdef Q_OS_WIN32
   connect( scanPopup.get(), SIGNAL( isGoldenDictWindow( HWND ) ),
@@ -1657,8 +1600,8 @@ vector< sptr< Dictionary::Class > > const & MainWindow::getActiveDicts()
 void MainWindow::createTabList()
 {
   tabListMenu->setIcon(QIcon(":/icons/windows-list.svg"));
-  connect(tabListMenu, SIGNAL(aboutToShow()), this, SLOT(fillWindowsMenu()));
-  connect(tabListMenu, SIGNAL(triggered(QAction*)), this, SLOT(switchToWindow(QAction*)));
+  connect( tabListMenu, &QMenu::aboutToShow, this, &MainWindow::fillWindowsMenu );
+  connect( tabListMenu, &QMenu::triggered, this, &MainWindow::switchToWindow );
 
   tabListButton = new QToolButton(ui.tabWidget);
   tabListButton->setAutoRaise(true);
@@ -1735,55 +1678,41 @@ ArticleView * MainWindow::createNewTab( bool switchToIt,
 
   connect( view, &ArticleView::inspectSignal,this,&MainWindow::inspectElement);
 
-  connect( view, SIGNAL( titleChanged(  ArticleView *, QString const & ) ),
-           this, SLOT( titleChanged(  ArticleView *, QString const & ) ) );
+  connect( view, &ArticleView::titleChanged, this, &MainWindow::titleChanged );
 
-  connect( view, SIGNAL( iconChanged( ArticleView *, QIcon const & ) ),
-           this, SLOT( iconChanged( ArticleView *, QIcon const & ) ) );
+  connect( view, &ArticleView::iconChanged, this, &MainWindow::iconChanged );
 
-  connect( view, SIGNAL( pageLoaded( ArticleView * ) ),
-           this, SLOT( pageLoaded( ArticleView * ) ) );
+  connect( view, &ArticleView::pageLoaded, this, &MainWindow::pageLoaded );
 
-  connect( view, SIGNAL( updateFoundInDictsList( ) ),
-          this, SLOT( updateFoundInDictsList() ) );
+  connect( view, &ArticleView::updateFoundInDictsList, this, &MainWindow::updateFoundInDictsList );
 
-  connect( view, SIGNAL( openLinkInNewTab( QUrl const &, QUrl const &, QString const &, ArticleView::Contexts const & ) ),
-           this, SLOT( openLinkInNewTab( QUrl const &, QUrl const &, QString const &, ArticleView::Contexts const & ) ) );
+  connect( view, &ArticleView::openLinkInNewTab, this, &MainWindow::openLinkInNewTab );
 
-  connect( view, SIGNAL( showDefinitionInNewTab( QString const &, unsigned, QString const &, ArticleView::Contexts const & ) ),
-           this, SLOT( showDefinitionInNewTab( QString const &, unsigned, QString const &, ArticleView::Contexts const & ) ) );
+  connect( view, &ArticleView::showDefinitionInNewTab, this, &MainWindow::showDefinitionInNewTab );
 
-  connect( view, SIGNAL( typingEvent( QString const & ) ),
-           this, SLOT( typingEvent( QString const & ) ) );
+  connect( view, &ArticleView::typingEvent, this, &MainWindow::typingEvent );
 
-  connect( view, SIGNAL( activeArticleChanged( ArticleView const *, const QString & ) ),
-           this, SLOT( activeArticleChanged( ArticleView const *, const QString & ) ) );
+  connect( view, &ArticleView::activeArticleChanged, this, &MainWindow::activeArticleChanged );
 
-  connect( view, SIGNAL( statusBarMessage( QString const &, int, QPixmap const & ) ),
-           this, SLOT( showStatusBarMessage( QString const &, int, QPixmap const & ) ) );
+  connect( view, &ArticleView::statusBarMessage, this, &MainWindow::showStatusBarMessage );
 
-  connect( view, SIGNAL( showDictsPane( ) ), this, SLOT( showDictsPane( ) ) );
+  connect( view, &ArticleView::showDictsPane, this, &MainWindow::showDictsPane );
 
-  connect( view, SIGNAL( forceAddWordToHistory( const QString & ) ),
-           this, SLOT( forceAddWordToHistory( const QString & ) ) );
+  connect( view, &ArticleView::forceAddWordToHistory, this, &MainWindow::forceAddWordToHistory );
 
-  connect( this, SIGNAL( setExpandOptionalParts( bool ) ),
-           view, SLOT( receiveExpandOptionalParts( bool ) ) );
+  connect( this, &MainWindow::setExpandOptionalParts, view, &ArticleView::receiveExpandOptionalParts );
 
-  connect( view, SIGNAL( setExpandMode( bool ) ), this, SLOT( setExpandMode( bool ) ) );
+  connect( view, &ArticleView::setExpandMode, this, &MainWindow::setExpandMode );
 
-  connect( view, SIGNAL( sendWordToHistory( QString ) ),
-           this, SLOT( addWordToHistory( QString ) ) );
+  connect( view, &ArticleView::sendWordToHistory, this, &MainWindow::addWordToHistory );
 
-  connect( view, SIGNAL( sendWordToInputLine( QString const & ) ),
-           this, SLOT( sendWordToInputLine( QString const & ) ) );
+  connect( view, &ArticleView::sendWordToInputLine, this, &MainWindow::sendWordToInputLine );
 
-  connect( view, SIGNAL( storeResourceSavePath( QString const & ) ),
-           this, SLOT( storeResourceSavePath( QString const & ) ) );
+  connect( view, &ArticleView::storeResourceSavePath, this, &MainWindow::storeResourceSavePath );
 
-  connect( view, SIGNAL( zoomIn()), this, SLOT( zoomin() ) );
+  connect( view, &ArticleView::zoomIn, this, &MainWindow::zoomin );
 
-  connect( view, SIGNAL( zoomOut()), this, SLOT( zoomout() ) );
+  connect( view, &ArticleView::zoomOut, this, &MainWindow::zoomout );
   connect( view, &ArticleView::saveBookmarkSignal, this, &MainWindow::addBookmarkToFavorite );
 
   view->setSelectionBySingleClick( cfg.preferences.selectWordBySingleClick );
@@ -2051,8 +1980,7 @@ void MainWindow::tabMenuRequested(QPoint pos)
 void MainWindow::dictionaryBarToggled( bool )
 {
   // From now on, only the triggered() signal is interesting to us
-  disconnect( dictionaryBar.toggleViewAction(), SIGNAL(toggled(bool)),
-              this, SLOT(dictionaryBarToggled(bool)) );
+  disconnect( dictionaryBar.toggleViewAction(), &QAction::toggled, this, &MainWindow::dictionaryBarToggled );
 
   updateDictionaryBar(); // Updates dictionary bar contents if it's shown
   applyMutedDictionariesState(); // Visibility change affects searches and results
@@ -2172,11 +2100,12 @@ void MainWindow::editDictionaries( unsigned editDictionaryGroup )
   Config::Class newCfg = cfg;
   EditDictionaries dicts( this, newCfg, dictionaries, groupInstances, dictNetMgr );
 
-  connect( &dicts, SIGNAL( showDictionaryInfo( QString const & ) ),
-           this, SLOT( showDictionaryInfo( QString const & ) ) );
+  connect( &dicts, &EditDictionaries::showDictionaryInfo, this, &MainWindow::showDictionaryInfo );
 
-  connect( &dicts, SIGNAL( showDictionaryHeadwords( QString const & ) ),
-           this, SLOT( showDictionaryHeadwords( QString const & ) ) );
+  connect( &dicts,
+    SIGNAL( showDictionaryHeadwords( QString const & ) ),
+    this,
+    SLOT( showDictionaryHeadwords( QString const & ) ) );
 
   if ( editDictionaryGroup != Instances::Group::NoGroupId )
     dicts.editGroup( editDictionaryGroup );
@@ -2690,7 +2619,7 @@ bool MainWindow::eventFilter( QObject * obj, QEvent * ev )
 
       // select all on mouse click
       if ( focusEvent->reason() == Qt::MouseFocusReason ) {
-        QTimer::singleShot(0, this, SLOT(focusTranslateLine()));
+        QTimer::singleShot( 0, this, &MainWindow::focusTranslateLine );
       }
       return false;
     }
@@ -3062,9 +2991,11 @@ void MainWindow::installHotKeys()
                                    1 );
     }
 
-    connect( hotkeyWrapper.get(), SIGNAL( hotkeyActivated( int ) ),
-             this, SLOT( hotKeyActivated( int ) ),
-             Qt::AutoConnection );
+    connect( hotkeyWrapper.get(),
+      &HotkeyWrapper::hotkeyActivated,
+      this,
+      &MainWindow::hotKeyActivated,
+      Qt::AutoConnection );
   }
 }
 
@@ -3129,8 +3060,11 @@ void MainWindow::checkForNewRelease()
 
   latestReleaseReply = articleNetMgr.get( req );
 
-  connect( latestReleaseReply, SIGNAL( finished() ),
-           this, SLOT( latestReleaseReplyReady() ), Qt::QueuedConnection );
+  connect( latestReleaseReply,
+    &QNetworkReply::finished,
+    this,
+    &MainWindow::latestReleaseReplyReady,
+    Qt::QueuedConnection );
 }
 
 void MainWindow::latestReleaseReplyReady()
@@ -3445,8 +3379,7 @@ void MainWindow::on_printPreview_triggered()
   int index=combox->findText( "100%" );
   combox->setCurrentIndex( index );
 
-  connect( &dialog, SIGNAL( paintRequested( QPrinter * ) ),
-           this, SLOT( printPreviewPaintRequested( QPrinter * ) ) );
+  connect( &dialog, &QPrintPreviewDialog::paintRequested, this, &MainWindow::printPreviewPaintRequested );
 
   dialog.showMaximized();
   dialog.exec();
@@ -3615,7 +3548,7 @@ void MainWindow::on_saveArticle_triggered()
             if( !handler->isEmpty() )
             {
               maxVal += 1;
-              connect( handler, SIGNAL( done() ), progressDialog, SLOT( perform() ) );
+              connect( handler, &ResourceToSaveHandler::done, progressDialog, &ArticleSaveProgressDialog::perform );
             }
           }
 
@@ -3732,7 +3665,7 @@ void MainWindow::applyZoomFactor()
   // so all of them except for the first one don't change anything and run very fast.
   // In effect, some intermediate zoom factors are skipped when scaling is slow.
   // The slower the scaling, the more steps are skipped.
-  QTimer::singleShot( 0, this, SLOT( scaleArticlesByCurrentZoomFactor() ) );
+  QTimer::singleShot( 0, this, &MainWindow::scaleArticlesByCurrentZoomFactor );
 }
 
 void MainWindow::adjustCurrentZoomFactor()
@@ -4364,10 +4297,8 @@ void MainWindow::showDictionaryHeadwords( QWidget * owner, Dictionary::Class * d
     headwordsDlg = new DictHeadwords( this, cfg, dict );
     addGlobalActionsToDialog( headwordsDlg );
     addGroupComboBoxActionsToDialog( headwordsDlg, groupList );
-    connect( headwordsDlg, SIGNAL( headwordSelected( QString, QString ) ),
-             this, SLOT( headwordReceived( QString, QString ) ) );
-    connect( headwordsDlg, SIGNAL( closeDialog() ),
-             this, SLOT( closeHeadwordsDialog() ), Qt::QueuedConnection );
+    connect( headwordsDlg, &DictHeadwords::headwordSelected, this, &MainWindow::headwordReceived );
+    connect( headwordsDlg, &DictHeadwords::closeDialog, this, &MainWindow::closeHeadwordsDialog, Qt::QueuedConnection );
   }
   else
     headwordsDlg->setup( dict );
@@ -4590,8 +4521,11 @@ void MainWindow::showFullTextSearchDialog()
 
     connect( ftsDlg, SIGNAL( showTranslationFor( QString, QStringList, QRegExp, bool ) ),
              this, SLOT( showTranslationFor( QString, QStringList, QRegExp, bool ) ) );
-    connect( ftsDlg, SIGNAL( closeDialog() ),
-             this, SLOT( closeFullTextSearchDialog() ), Qt::QueuedConnection );
+    connect( ftsDlg,
+      &FTS::FullTextSearchDialog::closeDialog,
+      this,
+      &MainWindow::closeFullTextSearchDialog,
+      Qt::QueuedConnection );
     connect( &configEvents, SIGNAL( mutedDictionariesChanged() ),
              ftsDlg, SLOT( updateDictionaries() ) );
 
@@ -4628,7 +4562,7 @@ void MainWindow::showGDHelp()
 
     if( helpWindow->getHelpEngine() )
     {
-      connect( helpWindow, SIGNAL( needClose() ), this, SLOT( hideGDHelp() ) );
+      connect( helpWindow, &Help::HelpWindow::needClose, this, &MainWindow::hideGDHelp );
       helpWindow->showHelpFor( "Content" );
       helpWindow->show();
     }

--- a/orderandprops.cc
+++ b/orderandprops.cc
@@ -103,26 +103,22 @@ OrderAndProps::OrderAndProps( QWidget * parent,
   disableDictionaryDescription();
 
   ui.dictionaryOrder->setContextMenuPolicy( Qt::CustomContextMenu );
-  connect( ui.dictionaryOrder, SIGNAL( customContextMenuRequested( QPoint ) ),
-           this, SLOT( contextMenuRequested( QPoint ) ) );
+  connect( ui.dictionaryOrder, &QWidget::customContextMenuRequested, this, &OrderAndProps::contextMenuRequested );
 
-  connect( ui.dictionaryOrder, SIGNAL( gotFocus() ),
-           this, SLOT( dictListFocused() ) );
-  connect( ui.inactiveDictionaries, SIGNAL( gotFocus() ),
-           this, SLOT( inactiveDictListFocused() ) );
+  connect( ui.dictionaryOrder, &DictListWidget::gotFocus, this, &OrderAndProps::dictListFocused );
+  connect( ui.inactiveDictionaries, &DictListWidget::gotFocus, this, &OrderAndProps::inactiveDictListFocused );
 
   connect ( ui.dictionaryOrder->selectionModel(), SIGNAL( selectionChanged ( const QItemSelection & , const QItemSelection & ) ),
       this, SLOT( dictionarySelectionChanged( const QItemSelection & ) ) );
-  connect ( ui.inactiveDictionaries->selectionModel(), SIGNAL( selectionChanged( const QItemSelection &, const QItemSelection & ) ),
-      this, SLOT( inactiveDictionarySelectionChanged( QItemSelection const & ) ) );
+  connect( ui.inactiveDictionaries->selectionModel(),
+    &QItemSelectionModel::selectionChanged,
+    this,
+    &OrderAndProps::inactiveDictionarySelectionChanged );
 
-  connect (ui.searchLine, SIGNAL( filterChanged( QString const & ) ),
-      this, SLOT( filterChanged( QString const &) ) );
+  connect( ui.searchLine, &QuickFilterLine::filterChanged, this, &OrderAndProps::filterChanged );
 
-  connect( ui.dictionaryOrder->getModel(), SIGNAL( contentChanged() ),
-           this, SLOT( showDictNumbers() ) );
-  connect( ui.inactiveDictionaries->getModel(), SIGNAL( contentChanged() ),
-           this, SLOT( showDictNumbers() ) );
+  connect( ui.dictionaryOrder->getModel(), &DictListModel::contentChanged, this, &OrderAndProps::showDictNumbers );
+  connect( ui.inactiveDictionaries->getModel(), &DictListModel::contentChanged, this, &OrderAndProps::showDictNumbers );
 
   showDictNumbers();
 }

--- a/preferences.cc
+++ b/preferences.cc
@@ -16,40 +16,30 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   Config::Preferences const & p = cfg_.preferences;
   ui.setupUi( this );
 
-  connect( ui.enableScanPopupModifiers, SIGNAL( toggled( bool ) ),
-           this, SLOT( enableScanPopupModifiersToggled( bool ) ) );
+  connect( ui.enableScanPopupModifiers,
+    &QAbstractButton::toggled,
+    this,
+    &Preferences::enableScanPopupModifiersToggled );
 
-  connect( ui.showScanFlag, SIGNAL( toggled( bool ) ),
-           this, SLOT( showScanFlagToggled( bool ) ) );
+  connect( ui.showScanFlag, &QAbstractButton::toggled, this, &Preferences::showScanFlagToggled );
 
-  connect( ui.altKey, SIGNAL( clicked( bool ) ),
-           this, SLOT( wholeAltClicked( bool ) ) );
-  connect( ui.ctrlKey, SIGNAL( clicked( bool ) ),
-           this, SLOT( wholeCtrlClicked( bool ) ) );
-  connect( ui.shiftKey, SIGNAL( clicked( bool ) ),
-           this, SLOT( wholeShiftClicked( bool ) ) );
+  connect( ui.altKey, &QAbstractButton::clicked, this, &Preferences::wholeAltClicked );
+  connect( ui.ctrlKey, &QAbstractButton::clicked, this, &Preferences::wholeCtrlClicked );
+  connect( ui.shiftKey, &QAbstractButton::clicked, this, &Preferences::wholeShiftClicked );
 
-  connect( ui.leftAlt, SIGNAL( clicked( bool ) ),
-           this, SLOT( sideAltClicked( bool ) ) );
-  connect( ui.rightAlt, SIGNAL( clicked( bool ) ),
-           this, SLOT( sideAltClicked( bool ) ) );
-  connect( ui.leftCtrl, SIGNAL( clicked( bool ) ),
-           this, SLOT( sideCtrlClicked( bool ) ) );
-  connect( ui.rightCtrl, SIGNAL( clicked( bool ) ),
-           this, SLOT( sideCtrlClicked( bool ) ) );
-  connect( ui.leftShift, SIGNAL( clicked( bool ) ),
-           this, SLOT( sideShiftClicked( bool ) ) );
-  connect( ui.rightShift, SIGNAL( clicked( bool ) ),
-           this, SLOT( sideShiftClicked( bool ) ) );
+  connect( ui.leftAlt, &QAbstractButton::clicked, this, &Preferences::sideAltClicked );
+  connect( ui.rightAlt, &QAbstractButton::clicked, this, &Preferences::sideAltClicked );
+  connect( ui.leftCtrl, &QAbstractButton::clicked, this, &Preferences::sideCtrlClicked );
+  connect( ui.rightCtrl, &QAbstractButton::clicked, this, &Preferences::sideCtrlClicked );
+  connect( ui.leftShift, &QAbstractButton::clicked, this, &Preferences::sideShiftClicked );
+  connect( ui.rightShift, &QAbstractButton::clicked, this, &Preferences::sideShiftClicked );
 
-  connect( ui.buttonBox, SIGNAL( helpRequested() ),
-           this, SLOT( helpRequested() ) );
+  connect( ui.buttonBox, &QDialogButtonBox::helpRequested, this, &Preferences::helpRequested );
 
   helpAction.setShortcut( QKeySequence( "F1" ) );
   helpAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
 
-  connect( &helpAction, SIGNAL( triggered() ),
-           this, SLOT( helpRequested() ) );
+  connect( &helpAction, &QAction::triggered, this, &Preferences::helpRequested );
 
   addAction( &helpAction );
 
@@ -329,11 +319,9 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   ui.ankiModel->setText( p.ankiConnectServer.model );
   ui.ankiDeck->setText(p.ankiConnectServer.deck);
 
-  connect( ui.customProxy, SIGNAL( toggled( bool ) ),
-           this, SLOT( customProxyToggled( bool ) ) );
+  connect( ui.customProxy, &QAbstractButton::toggled, this, &Preferences::customProxyToggled );
 
-  connect( ui.useProxyServer, SIGNAL( toggled( bool ) ),
-           this, SLOT( customProxyToggled( bool ) ) );
+  connect( ui.useProxyServer, &QGroupBox::toggled, this, &Preferences::customProxyToggled );
 
   ui.checkForNewReleases->setChecked( p.checkForNewReleases );
   ui.disallowContentFromOtherSites->setChecked( p.disallowContentFromOtherSites );
@@ -709,8 +697,7 @@ void Preferences::helpRequested()
     {
       helpWindow->setWindowFlags( Qt::Window );
 
-      connect( helpWindow, SIGNAL( needClose() ),
-               this, SLOT( closeHelp() ) );
+      connect( helpWindow, &Help::HelpWindow::needClose, this, &Preferences::closeHelp );
       helpWindow->showHelpFor( "Preferences" );
       helpWindow->show();
     }

--- a/programs.cc
+++ b/programs.cc
@@ -138,11 +138,9 @@ void ProgramsDictionary::loadIcon() noexcept
 
 RunInstance::RunInstance(): process( this )
 {
-  connect( this, SIGNAL(processFinished()), this,
-           SLOT(handleProcessFinished()), Qt::QueuedConnection );
-  connect( &process, SIGNAL(finished(int)), this, SIGNAL(processFinished()));
-  connect( &process, SIGNAL(errorOccurred(QProcess::ProcessError)), this,
-           SIGNAL(processFinished()) );
+  connect( this, &RunInstance::processFinished, this, &RunInstance::handleProcessFinished, Qt::QueuedConnection );
+  connect( &process, &QProcess::finished, this, &RunInstance::processFinished );
+  connect( &process, &QProcess::errorOccurred, this, &RunInstance::processFinished );
 }
 
 bool RunInstance::start( Config::Program const & prg, QString const & word,
@@ -211,8 +209,7 @@ ProgramDataRequest::ProgramDataRequest( QString const & word,
                                         Config::Program const & prg_ ):
   prg( prg_ )
 {
-  connect( &instance, SIGNAL(finished(QByteArray,QString)),
-           this, SLOT(instanceFinished(QByteArray,QString)) );
+  connect( &instance, &RunInstance::finished, this, &ProgramDataRequest::instanceFinished );
 
   QString error;
   if ( !instance.start( prg, word, error ) )
@@ -335,8 +332,7 @@ ProgramWordSearchRequest::ProgramWordSearchRequest( QString const & word,
                                                     Config::Program const & prg_ ):
   prg( prg_ )
 {
-  connect( &instance, SIGNAL(finished(QByteArray,QString)),
-           this, SLOT(instanceFinished(QByteArray,QString)) );
+  connect( &instance, &RunInstance::finished, this, &ProgramWordSearchRequest::instanceFinished );
 
   QString error;
   if ( !instance.start( prg, word, error ) )

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -108,24 +108,16 @@ ScanPopup::ScanPopup( QWidget * parent,
                                 dictionaryBar.toggleViewAction()
                                 );
 
-  connect( this, SIGNAL(switchExpandMode() ),
-           definition, SLOT( switchExpandOptionalParts() ) );
-  connect( this, SIGNAL(setViewExpandMode( bool ) ),
-           definition, SLOT( receiveExpandOptionalParts( bool ) ) );
-  connect( definition, SIGNAL( setExpandMode( bool ) ),
-           this, SIGNAL( setExpandMode( bool ) ) );
-  connect( definition, SIGNAL( inspectSignal( QWebEnginePage* ) ),
-           this, SLOT( inspectElementWhenPinned( QWebEnginePage* ) ) );
-  connect( definition, SIGNAL( forceAddWordToHistory( QString ) ),
-           this, SIGNAL( forceAddWordToHistory( QString ) ) );
-  connect( this, SIGNAL( closeMenu() ),
-           definition, SIGNAL( closePopupMenu() ) );
-  connect( definition, SIGNAL( sendWordToHistory( QString ) ),
-           this, SIGNAL( sendWordToHistory( QString ) ) );
-  connect( definition, SIGNAL( typingEvent( QString const & ) ),
-           this, SLOT( typingEvent( QString const & ) ) );
+  connect( this, &ScanPopup::switchExpandMode, definition, &ArticleView::switchExpandOptionalParts );
+  connect( this, &ScanPopup::setViewExpandMode, definition, &ArticleView::receiveExpandOptionalParts );
+  connect( definition, &ArticleView::setExpandMode, this, &ScanPopup::setExpandMode );
+  connect( definition, &ArticleView::inspectSignal, this, &ScanPopup::inspectElementWhenPinned );
+  connect( definition, &ArticleView::forceAddWordToHistory, this, &ScanPopup::forceAddWordToHistory );
+  connect( this, &ScanPopup::closeMenu, definition, &ArticleView::closePopupMenu );
+  connect( definition, &ArticleView::sendWordToHistory, this, &ScanPopup::sendWordToHistory );
+  connect( definition, &ArticleView::typingEvent, this, &ScanPopup::typingEvent );
 
-  wordListDefaultFont = ui.translateBox->wordList()->font();
+  wordListDefaultFont      = ui.translateBox->wordList()->font();
   translateLineDefaultFont = ui.translateBox->font();
   groupListDefaultFont = ui.groupList->font();
 
@@ -135,20 +127,18 @@ ScanPopup::ScanPopup( QWidget * parent,
   ui.translateBox->wordList()->setFocusPolicy(Qt::ClickFocus);
   ui.translateBox->translateLine()->installEventFilter( this );
 
-  connect( ui.translateBox->translateLine(), SIGNAL( textChanged( QString const & ) ),
-           this, SLOT( translateInputChanged( QString const & ) ) );
+  connect( ui.translateBox->translateLine(), &QLineEdit::textChanged, this, &ScanPopup::translateInputChanged );
 
-  connect( ui.translateBox->translateLine(), SIGNAL( returnPressed() ),
-           this, SLOT( translateInputFinished() ) );
+  connect( ui.translateBox->translateLine(), &QLineEdit::returnPressed, this, &ScanPopup::translateInputFinished );
 
-  connect( ui.translateBox->wordList(), SIGNAL( itemClicked( QListWidgetItem * ) ),
-           this, SLOT( wordListItemActivated( QListWidgetItem * ) ) );
+  connect( ui.translateBox->wordList(), &QListWidget::itemClicked, this, &ScanPopup::wordListItemActivated );
 
-  connect( ui.translateBox->wordList(), SIGNAL( itemDoubleClicked ( QListWidgetItem * ) ),
-           this, SLOT( wordListItemActivated( QListWidgetItem * ) ) );
+  connect( ui.translateBox->wordList(),
+    SIGNAL( itemDoubleClicked( QListWidgetItem * ) ),
+    this,
+    SLOT( wordListItemActivated( QListWidgetItem * ) ) );
 
-  connect( ui.translateBox->wordList(), SIGNAL( statusBarMessage( QString const &, int, QPixmap const & ) ),
-           this, SLOT( showStatusBarMessage( QString const &, int, QPixmap const & ) ) );
+  connect( ui.translateBox->wordList(), &WordList::statusBarMessage, this, &ScanPopup::showStatusBarMessage );
 
   ui.pronounceButton->hide();
 
@@ -176,14 +166,11 @@ ScanPopup::ScanPopup( QWidget * parent,
 
   connect( &dictionaryBar, SIGNAL(editGroupRequested()),
            this, SLOT(editGroupRequested()) );
-  connect( this, SIGNAL( closeMenu() ),
-           &dictionaryBar, SIGNAL( closePopupMenu() ) );
-  connect( &dictionaryBar, SIGNAL( showDictionaryInfo( QString const & ) ),
-           this, SIGNAL( showDictionaryInfo( QString const & ) ) );
-  connect( &dictionaryBar, SIGNAL( openDictionaryFolder( QString const & ) ),
-           this, SIGNAL( openDictionaryFolder( QString const & ) ) );
+  connect( this, &ScanPopup::closeMenu, &dictionaryBar, &DictionaryBar::closePopupMenu );
+  connect( &dictionaryBar, &DictionaryBar::showDictionaryInfo, this, &ScanPopup::showDictionaryInfo );
+  connect( &dictionaryBar, &DictionaryBar::openDictionaryFolder, this, &ScanPopup::openDictionaryFolder );
 
-  if ( cfg.popupWindowGeometry.size() )
+  if( cfg.popupWindowGeometry.size() )
     restoreGeometry( cfg.popupWindowGeometry );
 
   if ( cfg.popupWindowState.size() )
@@ -191,7 +178,7 @@ ScanPopup::ScanPopup( QWidget * parent,
 
   ui.onTopButton->setChecked( cfg.popupWindowAlwaysOnTop );
   ui.onTopButton->setVisible( cfg.pinPopupWindow );
-  connect( ui.onTopButton, SIGNAL( clicked( bool ) ), this, SLOT( alwaysOnTopClicked( bool ) ) );
+  connect( ui.onTopButton, &QAbstractButton::clicked, this, &ScanPopup::alwaysOnTopClicked );
 
   ui.pinButton->setChecked( cfg.pinPopupWindow );
 
@@ -215,8 +202,7 @@ ScanPopup::ScanPopup( QWidget * parent,
 #endif
   }
 
-  connect( &configEvents, SIGNAL( mutedDictionariesChanged() ),
-           this, SLOT( mutedDictionariesChanged() ) );
+  connect( &configEvents, &Config::Events::mutedDictionariesChanged, this, &ScanPopup::mutedDictionariesChanged );
 
   definition->focus();
 
@@ -233,8 +219,7 @@ ScanPopup::ScanPopup( QWidget * parent,
 
   escapeAction.setShortcut( QKeySequence( "Esc" ) );
   addAction( &escapeAction );
-  connect( &escapeAction, SIGNAL( triggered() ),
-           this, SLOT( escapePressed() ) );
+  connect( &escapeAction, &QAction::triggered, this, &ScanPopup::escapePressed );
 
   focusTranslateLineAction.setShortcutContext( Qt::WidgetWithChildrenShortcut );
   addAction( &focusTranslateLineAction );
@@ -242,14 +227,13 @@ ScanPopup::ScanPopup( QWidget * parent,
                                          QKeySequence( "Alt+D" ) <<
                                          QKeySequence( "Ctrl+L" ) );
 
-  connect( &focusTranslateLineAction, SIGNAL( triggered() ),
-           this, SLOT( focusTranslateLine() ) );
+  connect( &focusTranslateLineAction, &QAction::triggered, this, &ScanPopup::focusTranslateLine );
 
   QAction * const focusArticleViewAction = new QAction( this );
   focusArticleViewAction->setShortcutContext( Qt::WidgetWithChildrenShortcut );
   focusArticleViewAction->setShortcut( QKeySequence( "Ctrl+N" ) );
   addAction( focusArticleViewAction );
-  connect( focusArticleViewAction, SIGNAL( triggered() ), definition, SLOT( focus() ) );
+  connect( focusArticleViewAction, &QAction::triggered, definition, &ArticleView::focus );
 
   switchExpandModeAction.setShortcuts( QList< QKeySequence >() <<
                                        QKeySequence( Qt::CTRL | Qt::Key_8 ) <<
@@ -257,42 +241,36 @@ ScanPopup::ScanPopup( QWidget * parent,
                                        QKeySequence( Qt::CTRL | Qt::SHIFT | Qt::Key_8 ) );
 
   addAction( &switchExpandModeAction );
-  connect( &switchExpandModeAction, SIGNAL( triggered() ),
-           this, SLOT(switchExpandOptionalPartsMode() ) );
+  connect( &switchExpandModeAction, &QAction::triggered, this, &ScanPopup::switchExpandOptionalPartsMode );
 
   connect( ui.groupList, &QComboBox::currentIndexChanged,
            this, &ScanPopup::currentGroupChanged);
 
-  connect( &wordFinder, SIGNAL( finished() ),
-           this, SLOT( prefixMatchFinished() ) );
+  connect( &wordFinder, &WordFinder::finished, this, &ScanPopup::prefixMatchFinished );
 
-  connect( ui.pinButton, SIGNAL( clicked( bool ) ),
-           this, SLOT( pinButtonClicked( bool ) ) );
+  connect( ui.pinButton, &QAbstractButton::clicked, this, &ScanPopup::pinButtonClicked );
 
-  connect( definition, SIGNAL( pageLoaded( ArticleView * ) ),
-           this, SLOT( pageLoaded( ArticleView * ) ) );
+  connect( definition, &ArticleView::pageLoaded, this, &ScanPopup::pageLoaded );
 
-  connect( definition, SIGNAL( statusBarMessage( QString const &, int, QPixmap const & ) ),
-           this, SLOT( showStatusBarMessage( QString const &, int, QPixmap const & ) ) );
+  connect( definition, &ArticleView::statusBarMessage, this, &ScanPopup::showStatusBarMessage );
 
-  connect( definition, SIGNAL( titleChanged(  ArticleView *, QString const & ) ),
-           this, SLOT( titleChanged(  ArticleView *, QString const & ) ) );
+  connect( definition, &ArticleView::titleChanged, this, &ScanPopup::titleChanged );
 
 #ifdef Q_OS_MAC
-  connect( &MouseOver::instance(), SIGNAL( hovered( QString const &, bool ) ),
-           this, SLOT( mouseHovered( QString const &, bool ) ) );
+  connect( &MouseOver::instance(),
+    SIGNAL( hovered( QString const &, bool ) ),
+    this,
+    SLOT( mouseHovered( QString const &, bool ) ) );
 #endif
 
   hideTimer.setSingleShot( true );
   hideTimer.setInterval( 400 );
 
-  connect( &hideTimer, SIGNAL( timeout() ),
-           this, SLOT( hideTimerExpired() ) );
+  connect( &hideTimer, &QTimer::timeout, this, &ScanPopup::hideTimerExpired );
 
   mouseGrabPollTimer.setSingleShot( false );
   mouseGrabPollTimer.setInterval( 10 );
-  connect( &mouseGrabPollTimer, SIGNAL( timeout() ),
-           this, SLOT(mouseGrabPoll())  );
+  connect( &mouseGrabPollTimer, &QTimer::timeout, this, &ScanPopup::mouseGrabPoll );
 #ifdef Q_OS_MAC
   MouseOver::instance().setPreferencesPtr( &( cfg.preferences ) );
 #endif
@@ -313,8 +291,7 @@ ScanPopup::ScanPopup( QWidget * parent,
   delayTimer.setSingleShot( true );
   delayTimer.setInterval( 200 );
 
-  connect( &delayTimer, SIGNAL( timeout() ),
-    this, SLOT( delayShow() ) );
+  connect( &delayTimer, &QTimer::timeout, this, &ScanPopup::delayShow );
 #endif
 
   applyZoomFactor();
@@ -823,7 +800,7 @@ bool ScanPopup::eventFilter( QObject * watched, QEvent * event )
 
       // select all on mouse click
       if ( focusEvent->reason() == Qt::MouseFocusReason ) {
-        QTimer::singleShot(0, this, SLOT(focusTranslateLine()));
+        QTimer::singleShot( 0, this, &ScanPopup::focusTranslateLine );
       }
       return false;
     }
@@ -988,7 +965,7 @@ void ScanPopup::showEvent( QShowEvent * ev )
 {
   QMainWindow::showEvent( ev );
 
-  QTimer::singleShot(100, this, SLOT( requestWindowFocus() ) );
+  QTimer::singleShot( 100, this, &ScanPopup::requestWindowFocus );
 
   if ( groups.size() <= 1 ) // Only the default group? Hide then.
     ui.groupList->hide();

--- a/thirdparty/qtsingleapplication/src/qtlocalpeer.cpp
+++ b/thirdparty/qtsingleapplication/src/qtlocalpeer.cpp
@@ -128,7 +128,7 @@ bool QtLocalPeer::isClient()
 #endif
     if (!res)
         qWarning("QtSingleCoreApplication: listen on local socket failed, %s", qPrintable(server->errorString()));
-    QObject::connect(server, SIGNAL(newConnection()), SLOT(receiveConnection()));
+    QObject::connect( server, &QLocalServer::newConnection, this, &QtLocalPeer::receiveConnection );
     return false;
 }
 

--- a/thirdparty/qtsingleapplication/src/qtsingleapplication.cpp
+++ b/thirdparty/qtsingleapplication/src/qtsingleapplication.cpp
@@ -137,7 +137,7 @@ void QtSingleApplication::sysInit(const QString &appId)
 {
     actWin = 0;
     peer = new QtLocalPeer(this, appId);
-    connect(peer, SIGNAL(messageReceived(const QString&)), SIGNAL(messageReceived(const QString&)));
+    connect( peer, &QtLocalPeer::messageReceived, this, &QtSingleApplication::messageReceived );
 }
 
 
@@ -232,9 +232,9 @@ void QtSingleApplication::setActivationWindow(QWidget* aw, bool activateOnMessag
 {
     actWin = aw;
     if (activateOnMessage)
-        connect(peer, SIGNAL(messageReceived(const QString&)), this, SLOT(activateWindow()));
+      connect( peer, &QtLocalPeer::messageReceived, this, &QtSingleApplication::activateWindow );
     else
-        disconnect(peer, SIGNAL(messageReceived(const QString&)), this, SLOT(activateWindow()));
+      disconnect( peer, &QtLocalPeer::messageReceived, this, &QtSingleApplication::activateWindow );
 }
 
 

--- a/thirdparty/qtsingleapplication/src/qtsinglecoreapplication.cpp
+++ b/thirdparty/qtsingleapplication/src/qtsinglecoreapplication.cpp
@@ -74,7 +74,7 @@ QtSingleCoreApplication::QtSingleCoreApplication(int &argc, char **argv)
     : QCoreApplication(argc, argv)
 {
     peer = new QtLocalPeer(this);
-    connect(peer, SIGNAL(messageReceived(const QString&)), SIGNAL(messageReceived(const QString&)));
+    connect( peer, &QtLocalPeer::messageReceived, this, &QtSingleCoreApplication::messageReceived );
 }
 
 
@@ -87,7 +87,7 @@ QtSingleCoreApplication::QtSingleCoreApplication(const QString &appId, int &argc
     : QCoreApplication(argc, argv)
 {
     peer = new QtLocalPeer(this, appId);
-    connect(peer, SIGNAL(messageReceived(const QString&)), SIGNAL(messageReceived(const QString&)));
+    connect( peer, &QtLocalPeer::messageReceived, this, &QtSingleCoreApplication::messageReceived );
 }
 
 

--- a/translatebox.cc
+++ b/translatebox.cc
@@ -27,11 +27,9 @@ CompletionList::CompletionList(TranslateBox * parent) : WordList(parent),
   setAutoFillBackground( true );
 #endif
 
-  connect(this, SIGNAL( activated( QModelIndex ) ),
-          this, SLOT( acceptCurrentEntry() ) );
+  connect( this, &QAbstractItemView::activated, this, &CompletionList::acceptCurrentEntry );
 
-  connect(this, SIGNAL( itemClicked( QListWidgetItem * ) ),
-          this, SLOT( acceptCurrentEntry() ) );
+  connect( this, &QListWidget::itemClicked, this, &CompletionList::acceptCurrentEntry );
 
   translateBox->window()->installEventFilter(this);
 }
@@ -134,14 +132,11 @@ TranslateBox::TranslateBox(QWidget *parent) : QWidget(parent),
   translate_line->installEventFilter( this );
   this->installEventFilter( this );
 
-  connect(translate_line, SIGNAL( textChanged( QString const & ) ),
-          this, SLOT( onTextEdit() ) );
+  connect( translate_line, &QLineEdit::textChanged, this, &TranslateBox::onTextEdit );
 
-  connect(translate_line, SIGNAL( rightButtonClicked() ),
-          this, SLOT( rightButtonClicked() ) );
+  connect( translate_line, &ExtLineEdit::rightButtonClicked, this, &TranslateBox::rightButtonClicked );
 
-  connect(word_list, SIGNAL( contentChanged() ),
-          this, SLOT( showPopup() ) );
+  connect( word_list, &WordList::contentChanged, this, &TranslateBox::showPopup );
 }
 
 bool TranslateBox::eventFilter(QObject *obj, QEvent *event)

--- a/webmultimediadownload.cc
+++ b/webmultimediadownload.cc
@@ -10,8 +10,7 @@ WebMultimediaDownload::WebMultimediaDownload( QUrl const & url,
 mgr( _mgr ),
 redirectCount( 0 )
 {
-  connect( &mgr, SIGNAL(finished(QNetworkReply*)),
-           this, SLOT(replyFinished(QNetworkReply*)), Qt::QueuedConnection );
+  connect( &mgr, &QNetworkAccessManager::finished, this, &WebMultimediaDownload::replyFinished, Qt::QueuedConnection );
 
   reply = mgr.get( QNetworkRequest( url ) );
 

--- a/wordfinder.cc
+++ b/wordfinder.cc
@@ -23,8 +23,7 @@ WordFinder::WordFinder( QObject * parent ):
   updateResultsTimer.setInterval( 1000 ); // We use a one second update timer
   updateResultsTimer.setSingleShot( true );
 
-  connect( &updateResultsTimer, SIGNAL( timeout() ),
-           this, SLOT( updateResults() ), Qt::QueuedConnection );
+  connect( &updateResultsTimer, &QTimer::timeout, this, &WordFinder::updateResults, Qt::QueuedConnection );
 }
 
 WordFinder::~WordFinder()
@@ -156,8 +155,7 @@ void WordFinder::startSearch()
             (*inputDicts)[ x ]->prefixMatch( allWordWritings[ y ], requestedMaxResults ) :
             (*inputDicts)[ x ]->stemmedMatch( allWordWritings[ y ], stemmedMinLength, stemmedMaxSuffixVariation, requestedMaxResults );
 
-        connect( sr.get(), SIGNAL( finished() ),
-                 this, SLOT( requestFinished() ), Qt::QueuedConnection );
+        connect( sr.get(), &Dictionary::Request::finished, this, &WordFinder::requestFinished, Qt::QueuedConnection );
 
         queuedRequests.push_back( sr );
       }

--- a/wordlist.cc
+++ b/wordlist.cc
@@ -22,18 +22,14 @@ void WordList::attachFinder( WordFinder * finder )
 
   if ( wordFinder )
   {
-    disconnect( wordFinder, SIGNAL( updated() ),
-             this, SLOT( prefixMatchUpdated() ) );
-    disconnect( wordFinder, SIGNAL( finished() ),
-             this, SLOT( prefixMatchFinished() ) );
+    disconnect( wordFinder, &WordFinder::updated, this, &WordList::prefixMatchUpdated );
+    disconnect( wordFinder, &WordFinder::finished, this, &WordList::prefixMatchFinished );
   }
 
   wordFinder = finder;
 
-  connect( wordFinder, SIGNAL( updated() ),
-           this, SLOT( prefixMatchUpdated() ) );
-  connect( wordFinder, SIGNAL( finished() ),
-           this, SLOT( prefixMatchFinished() ) );
+  connect( wordFinder, &WordFinder::updated, this, &WordList::prefixMatchUpdated );
+  connect( wordFinder, &WordFinder::finished, this, &WordList::prefixMatchFinished );
 }
 
 void WordList::prefixMatchUpdated()


### PR DESCRIPTION
This PR convert 346 `connect()` from macro-based syntax to the new syntax. (we have ~450 connects btw)

The changes are made by KDE's Clazy https://invent.kde.org/sdk/clazy

I checked the changes one by one. All of them are trivial ones and should be correct.

There are still a few unconverted because they are non-trivial. I will convert them manually later.

---

macro-based syntax's main problem is that the thing inside the `SINGAL( thing )` is just a string that has no meaning in the context of C++. It will go through something crazy to work with Qt's moc. If we write something wrong, the code may still compile! Also, most tools don't work with this.

The new syntax is just normal C++ templates. We get automatic compile time checks and also prevent a variety of errors that aren't obvious.

The code is much simpler and easier to read (and write):

Old code: 
```
connect( this, SIGNAL( statusBarMessage( QString, int, QPixmap ) ),
         view, SIGNAL( statusBarMessage( QString, int, QPixmap ) ) );
```
New Code:
```
connect( this, &ResourceToSaveHandler::statusBarMessage,
         view, &ArticleView::statusBarMessage)
```

https://wiki.qt.io/New_Signal_Slot_Syntax
https://woboq.com/blog/new-signals-slots-syntax-in-qt5.html
https://doc.qt.io/qt-6/signalsandslots-syntaxes.html