### PR TITLE
Add option to enable Dark Reader mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ GoldenDict.xcodeproj/
 /cmake-build-**/
 /build**/
 CMakeLists.txt.user
+
+# kdevelop
+.kdev4/
+*.kdev4

--- a/article_maker.cc
+++ b/article_maker.cc
@@ -149,20 +149,19 @@ std::string ArticleMaker::makeHtmlHeader( QString const & word,
             "</script>";
   result+= R"(<script type="text/javascript" src="qrc:///scripts/gd-builtin.js"></script>)";
 
-#ifdef Q_OS_WIN32
-  if( GlobalBroadcaster::instance()->getPreference()->darkMode )
+  if( GlobalBroadcaster::instance()->getPreference()->darkReaderMode )
   {
-    result += "<script type=\"text/javascript\" src=\"qrc:///scripts/darkreader.js\"></script>";
-    result +=
-      "<script type=\"text/javascript\">"
-      "DarkReader.enable({"
-      "    brightness: 100,"
-      "    contrast: 90,"
-      "    sepia: 10"
-      "});"
-      "</script>";
+    result += R"(
+<script src="qrc:///scripts/darkreader.js"></script>
+<script>
+  DarkReader.enable({
+    brightness: 100,
+    contrast: 90,
+    sepia: 10
+  });
+</script>
+)";
   }
-#endif
   result += "</head><body>";
 
   return result;

--- a/config.cc
+++ b/config.cc
@@ -230,6 +230,7 @@ Preferences::Preferences():
   autoScrollToTargetArticle( true ),
   escKeyHidesMainWindow( false ),
   darkMode( false ),
+  darkReaderMode ( false ),
   alwaysOnTop ( false ),
   searchInDock ( false ),
 
@@ -891,6 +892,9 @@ Class load()
 
     if ( !preferences.namedItem( "darkMode" ).isNull() )
       c.preferences.darkMode = ( preferences.namedItem( "darkMode" ).toElement().text() == "1" );
+
+    if ( !preferences.namedItem("darkReaderMode").isNull())
+      c.preferences.darkReaderMode = (preferences.namedItem("darkReaderMode").toElement().text() == "1");
 
     if ( !preferences.namedItem( "zoomFactor" ).isNull() )
       c.preferences.zoomFactor = preferences.namedItem( "zoomFactor" ).toElement().text().toDouble();
@@ -1755,6 +1759,10 @@ void save( Class const & c )
 
     opt = dd.createElement( "darkMode" );
     opt.appendChild( dd.createTextNode( c.preferences.darkMode ? "1":"0" ) );
+    preferences.appendChild( opt );
+
+    opt = dd.createElement( "darkReaderMode" );
+    opt.appendChild( dd.createTextNode( c.preferences.darkReaderMode ? "1":"0" ) );
     preferences.appendChild( opt );
 
     opt = dd.createElement( "zoomFactor" );

--- a/config.hh
+++ b/config.hh
@@ -308,6 +308,7 @@ struct Preferences
   bool autoScrollToTargetArticle;
   bool escKeyHidesMainWindow;
   bool darkMode;
+  bool darkReaderMode;
   bool alwaysOnTop;
 
   /// An old UI mode when tranlateLine and wordList

--- a/locale/zh_CN.ts
+++ b/locale/zh_CN.ts
@@ -3947,9 +3947,29 @@ however, the article from the topmost dictionary is shown.</source>
         <translation>设置词典的备用字体</translation>
     </message>
     <message>
-        <location filename="../preferences.ui" line="418"/>
-        <source>dark mode</source>
-        <translation>深色模式</translation>
+        <location filename="../preferences.ui" line="126"/>
+        <source>Article Display style:</source>
+        <translation type="unfinished">文章显示风格</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="161"/>
+        <source>Turn the UI to dark.</source>
+        <translation type="unfinished">启用暗色界面</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="164"/>
+        <source>Dark Mode</source>
+        <translation type="unfinished">深色模式</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="171"/>
+        <source>Turn the article display style to dark.</source>
+        <translation type="unfinished">将文章以暗色风格显示</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="174"/>
+        <source>Dark Reader Mode</source>
+        <translation type="unfinished">深色阅读模式</translation>
     </message>
     <message>
         <location filename="../preferences.ui" line="457"/>

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -786,7 +786,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   translateLine->setFocus();
 
-  applyQtStyleSheet( cfg.preferences.displayStyle, cfg.preferences.addonStyle, cfg.preferences.darkMode );
+  applyQtStyleSheet( cfg.preferences.addonStyle, cfg.preferences.darkMode );
 
   makeScanPopup();
 
@@ -1125,7 +1125,7 @@ QPrinter & MainWindow::getPrinter()
   return *printer;
 }
 
-void MainWindow::applyQtStyleSheet( QString const & displayStyle, QString const & addonStyle, bool const & darkMode )
+void MainWindow::applyQtStyleSheet( QString const & addonStyle, bool const & darkMode )
 {
   #ifdef Q_OS_WIN32
   if( darkMode )
@@ -2207,10 +2207,10 @@ void MainWindow::editPreferences()
 
     bool needReload = false;
 
-    // See if we need to reapply stylesheets
-    if ( cfg.preferences.displayStyle != p.displayStyle || cfg.preferences.addonStyle != p.addonStyle || cfg.preferences.darkMode != p.darkMode)
+    // See if we need to reapply Qt stylesheets
+    if ( cfg.preferences.addonStyle != p.addonStyle || cfg.preferences.darkMode != p.darkMode)
     {
-      applyQtStyleSheet( p.displayStyle, p.addonStyle, p.darkMode );
+      applyQtStyleSheet( p.addonStyle, p.darkMode );
       articleMaker.setDisplayStyle( p.displayStyle, p.addonStyle );
       needReload = true;
     }

--- a/mainwindow.hh
+++ b/mainwindow.hh
@@ -181,8 +181,8 @@ private:
   IframeSchemeHandler * iframeSchemeHandler;
   ResourceSchemeHandler * resourceSchemeHandler;
 
-  /// Applies the qt's stylesheet, given the style's name.
-  void applyQtStyleSheet( QString const & displayStyle, QString const & addonStyle, bool const & darkMode );
+  /// Applies the custom Qt stylesheet
+  void applyQtStyleSheet( QString const & addonStyle, bool const & darkMode );
 
   /// Creates, destroys or otherwise updates tray icon, according to the
   /// current configuration and situation.

--- a/preferences.cc
+++ b/preferences.cc
@@ -172,6 +172,7 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   ui.autoScrollToTargetArticle->setChecked( p.autoScrollToTargetArticle );
   ui.escKeyHidesMainWindow->setChecked( p.escKeyHidesMainWindow );
   ui.darkMode->setChecked(p.darkMode);
+  ui.darkReaderMode -> setChecked(p.darkReaderMode);
 #ifndef Q_OS_WIN32
   ui.darkMode->hide();
 #endif
@@ -395,6 +396,7 @@ Config::Preferences Preferences::getPreferences()
   p.escKeyHidesMainWindow = ui.escKeyHidesMainWindow->isChecked();
 
   p.darkMode = ui.darkMode->isChecked();
+  p.darkReaderMode = ui.darkReaderMode->isChecked();
   p.enableMainWindowHotkey = ui.enableMainWindowHotkey->isChecked();
   p.mainWindowHotkey = ui.mainWindowHotkey->getHotKey();
   p.enableClipboardHotkey = ui.enableClipboardHotkey->isChecked();

--- a/preferences.ui
+++ b/preferences.ui
@@ -123,7 +123,7 @@
            <item>
             <widget class="QLabel" name="label_9">
              <property name="text">
-              <string>Display style:</string>
+              <string>Article Display style:</string>
              </property>
             </widget>
            </item>
@@ -157,8 +157,21 @@
          </item>
          <item>
           <widget class="QCheckBox" name="darkMode">
+           <property name="toolTip">
+            <string>Turn the UI to dark.</string>
+           </property>
            <property name="text">
-            <string>dark mode</string>
+            <string>Dark Mode</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="darkReaderMode">
+           <property name="toolTip">
+            <string>Turn the article display style to dark.</string>
+           </property>
+           <property name="text">
+            <string>Dark Reader Mode</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
For Linux & mac users and also for users who don't like white text on dark

`applyQtStyleSheet`'s 1st parameter is removed because we don't do Qt styling based on article view's style anymore.

The `type` in <script> is useless since we use webengine and html5. HTML5 formally recognizes javascript as the one true script for the web, so I deleted it as recommended by the standard.

![image](https://user-images.githubusercontent.com/20123683/209572067-93384d31-ed5d-4869-a2ff-0185262c71ec.png)
https://html.spec.whatwg.org/#the-script-element

---
Possible further improvements,

The preference dialog could use some reorganization, but that belongs to another PR.

The ceremony of adding a new option is insane. The `config.cc` should get a cleanup.

close https://github.com/xiaoyifang/goldendict/issues/271