### PR TITLE
fix: shortcut conflict

### DIFF
--- a/articleview.cc
+++ b/articleview.cc
@@ -1752,7 +1752,7 @@ void ArticleView::contextMenuRequested( QPoint const & pos )
   {
     if ( !isExternalLink( targetUrl ) )
     {
-      followLink = new QAction( tr( "&Open Link" ), &menu );
+      followLink = new QAction( tr( "Op&en Link" ), &menu );
       menu.addAction( followLink );
 
       if( !popupView && !isAudioLink( targetUrl ) )


### PR DESCRIPTION
For local sound files, the O is in conflict
Related
https://forum.freemdict.com/t/topic/14791/12
https://github.com/xiaoyifang/goldendict/issues/282

After:

![image](https://user-images.githubusercontent.com/20123683/209649322-7d44f702-6d00-45d9-bb68-b9bd45c2b33b.png)

The E is chosen because

For external links, the shortcut is E

![image](https://user-images.githubusercontent.com/20123683/209648725-84c52a22-79ec-475e-9251-082af2acabda.png)

