### PR TITLE
fix remaining problems of scanpop clipboard on linux

### DIFF
--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -1529,9 +1529,6 @@ void MainWindow::makeScanPopup()
 
   scanPopup->setStyleSheet( styleSheet() );
 
-  if ( enableScanningAction->isChecked() )
-    scanPopup->enableScanning();
-
   connect( scanPopup.get(), SIGNAL(editGroupRequested( unsigned ) ),
            this, SLOT(editDictionaries( unsigned )), Qt::QueuedConnection );
 
@@ -3176,7 +3173,6 @@ void MainWindow::scanEnableToggled( bool on )
   {
     if ( on )
     {
-      scanPopup->enableScanning();
 #ifdef Q_OS_MAC
       if( !MacMouseOver::isAXAPIEnabled() )
           mainStatusBar->showMessage( tr( "Accessibility API is not enabled" ), 10000,
@@ -3186,7 +3182,6 @@ void MainWindow::scanEnableToggled( bool on )
     }
     else
     {
-      scanPopup->disableScanning();
       enableScanningAction->setIcon(QIcon(":/icons/wizard.svg"));
     }
   }

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -890,10 +890,17 @@ void MainWindow::clipboardChange( QClipboard::Mode m)
 
       if(m == QClipboard::Selection){
 
-        // Multiple ways to stoping a word from showing up when selecting
+        // Multiple ways to stopping a word from showing up when selecting
 
-        // Explictly disabled on preferences
+        // Explicitly disabled on preferences
         if(!cfg.preferences.trackSelectionScan) return;
+
+        // Explicitly disabled on preferences to ignore gd's own selection
+
+        if( cfg.preferences.ignoreOwnClipboardChanges
+          && QApplication::clipboard()->ownsSelection() ){
+          return ;
+        }
 
         // Keyboard Modifier
         if(cfg.preferences.enableScanPopupModifiers &&

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -915,7 +915,8 @@ void MainWindow::clipboardChange( QClipboard::Mode m)
           return;
         }
 
-        scanPopup->translateWordFromSelection();
+        // Use delay show to prevent multiple popups while selection in progress
+        scanPopup->selectionDelayTimer.start();
       }
 #else
     scanPopup ->translateWordFromClipboard();

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -458,38 +458,6 @@ void ScanPopup::translateWord( QString const & word )
       );
 }
 
-[[deprecated("Favor the mainWindow's clipboardChanged ones")]]
-void ScanPopup::clipboardChanged( QClipboard::Mode m )
-{
-
-  if( !isScanningEnabled )
-    return;
-
-#ifdef HAVE_X11
-  if( cfg.preferences.ignoreOwnClipboardChanges && ownsClipboardMode( m ) )
-    return;
-
-  if(m == QClipboard::Clipboard && !cfg.preferences.trackClipboardScan){
-    return;
-  }
-
-  if(m == QClipboard::Selection && !cfg.preferences.trackSelectionScan){
-    return;
-  }
-
-  if( m == QClipboard::Selection )
-  {
-    // Use delay show to prevent multiple popups while selection in progress
-    selectionDelayTimer.start();
-    return;
-  }
-#endif
-
-  QString subtype = "plain";
-
-  handleInputWord( QApplication::clipboard()->text( subtype, m ) );
-}
-
 void ScanPopup::mouseHovered( QString const & str, bool forcePopup )
 {
   handleInputWord( str, forcePopup );

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -288,10 +288,11 @@ ScanPopup::ScanPopup( QWidget * parent,
     translateWordFromSelection();
   });
 
-  delayTimer.setSingleShot( true );
-  delayTimer.setInterval( 200 );
+  // Use delay show to prevent multiple popups while selection in progress
+  selectionDelayTimer.setSingleShot( true );
+  selectionDelayTimer.setInterval( 200 );
 
-  connect( &delayTimer, &QTimer::timeout, this, &ScanPopup::delayShow );
+  connect( &selectionDelayTimer, &QTimer::timeout, this, &ScanPopup::translateWordFromSelection );
 #endif
 
   applyZoomFactor();
@@ -457,14 +458,6 @@ void ScanPopup::translateWord( QString const & word )
       );
 }
 
-#ifdef HAVE_X11
-void ScanPopup::delayShow()
-{
-  QString subtype = "plain";
-  handleInputWord( QApplication::clipboard()->text( subtype, QClipboard::Selection ) );
-}
-#endif
-
 [[deprecated("Favor the mainWindow's clipboardChanged ones")]]
 void ScanPopup::clipboardChanged( QClipboard::Mode m )
 {
@@ -487,7 +480,7 @@ void ScanPopup::clipboardChanged( QClipboard::Mode m )
   if( m == QClipboard::Selection )
   {
     // Use delay show to prevent multiple popups while selection in progress
-    delayTimer.start();
+    selectionDelayTimer.start();
     return;
   }
 #endif

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -71,7 +71,6 @@ ScanPopup::ScanPopup( QWidget * parent,
                       History & history_ ):
   QMainWindow( parent ),
   cfg( cfg_ ),
-  isScanningEnabled( false ),
   allDictionaries( allDictionaries_ ),
   groups( groups_ ),
   history( history_ ),
@@ -303,8 +302,6 @@ ScanPopup::~ScanPopup()
 {
   saveConfigData();
 
-  disableScanning();
-
   ungrabGesture( Gestures::GDPinchGestureType );
   ungrabGesture( Gestures::GDSwipeGestureType );
 }
@@ -316,22 +313,6 @@ void ScanPopup::saveConfigData()
   cfg.popupWindowGeometry = saveGeometry();
   cfg.pinPopupWindow = ui.pinButton->isChecked();
   cfg.popupWindowAlwaysOnTop = ui.onTopButton->isChecked();
-}
-
-void ScanPopup::enableScanning()
-{
-  if ( !isScanningEnabled )
-  {
-    isScanningEnabled = true;
-  }
-}
-
-void ScanPopup::disableScanning()
-{
-  if ( isScanningEnabled )
-  {
-    isScanningEnabled = false;
-  }
 }
 
 void ScanPopup::inspectElementWhenPinned( QWebEnginePage * page ){

--- a/scanpopup.hh
+++ b/scanpopup.hh
@@ -58,6 +58,8 @@ public:
   /// Interaction with scan flag window
   void showScanFlag();
   void hideScanFlag();
+
+  QTimer selectionDelayTimer;
 #endif
 
 signals:
@@ -146,7 +148,6 @@ private:
 
 #ifdef HAVE_X11
   ScanFlag * scanFlag;
-  QTimer delayTimer;
 #endif
 
   bool mouseEnteredOnce;
@@ -235,9 +236,6 @@ private slots:
 
   void titleChanged( ArticleView *, QString const & title );
 
-#ifdef HAVE_X11
-  void delayShow();
-#endif
 };
 
 #endif

--- a/scanpopup.hh
+++ b/scanpopup.hh
@@ -36,12 +36,6 @@ public:
              History & );
 
   ~ScanPopup();
-  
-  /// Enables scanning. When the object is created, the scanning is disabled
-  /// initially.
-  void enableScanning();
-  /// Disables scanning.
-  void disableScanning();
 
   /// Applies current zoom factor to the popup's view. Should be called when
   /// it's changed.
@@ -128,7 +122,6 @@ private:
   void updateDictionaryBar();
 
   Config::Class & cfg;
-  bool isScanningEnabled;
   std::vector< sptr< Dictionary::Class > > const & allDictionaries;
   std::vector< sptr< Dictionary::Class > > dictionariesUnmuted;
   Instances::Groups const & groups;
@@ -195,7 +188,6 @@ private:
   void updateSuggestionList();
   void updateSuggestionList( QString const & text );
 private slots:
-  void clipboardChanged( QClipboard::Mode );
   void mouseHovered( QString const & , bool forcePopup);
   void currentGroupChanged( int );
   void prefixMatchFinished();


### PR DESCRIPTION
ScanPopup::clipboardChanged isn't used (I put a [[deprecated]] a month ago).

Now all the remaining functionalities are moved to Mainwindow::clipboardChanged

* ignoreOwnClipboardChanges -> ignore change if app owns the clipboard change
* delay timer to prevent slow selection -> frequent refreshing

Thus it is removed.

---

The reason why we bloat Mainwindow with yet another method is:

to access the 💡 enableScanningAction.ischecked() :facepalm:

We can move those lines away from MainWindow by just adding a variable -> isScanningActionChecked plus two methods of `scanpopup.enable()/disable()`

---

Actually, the original design is using a var inside `scanpopup.cc`, but handling logic all in mainwindow::clipboardChanged() also makes scene since all codes are in one place without the need to enable/disable here and there.

The original design is indeed following the OOP principles, but putting them in 1 method is just simple.

So the unused variable is removed and the relevant methods that do nothing.

This single line is equal to `isScanningEnabled` + `enableScanpop()` + `disableScanpop()`
https://github.com/xiaoyifang/goldendict/blob/c1902b29c8cd5d12f5e4fab1c08e6a50380aabe1/mainwindow.cc#L882