### PR TITLE
clang-tidy: apply modernize-use-override

### DIFF
--- a/aard.cc
+++ b/aard.cc
@@ -237,45 +237,45 @@ class AardDictionary: public BtreeIndexing::BtreeDictionary
     AardDictionary( string const & id, string const & indexFile,
                      vector< string > const & dictionaryFiles );
 
-    ~AardDictionary();
+    ~AardDictionary() override;
 
-    virtual string getName() noexcept
+    string getName() noexcept override
     { return dictionaryName; }
 
-    virtual map< Dictionary::Property, string > getProperties() noexcept
+    map< Dictionary::Property, string > getProperties() noexcept override
     { return map< Dictionary::Property, string >(); }
 
-    virtual unsigned long getArticleCount() noexcept
+    unsigned long getArticleCount() noexcept override
     { return idxHeader.articleCount; }
 
-    virtual unsigned long getWordCount() noexcept
+    unsigned long getWordCount() noexcept override
     { return idxHeader.wordCount; }
 
-    inline virtual quint32 getLangFrom() const
+    inline quint32 getLangFrom() const override
     { return idxHeader.langFrom; }
 
-    inline virtual quint32 getLangTo() const
+    inline quint32 getLangTo() const override
     { return idxHeader.langTo; }
 
-    virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+    sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                         vector< wstring > const & alts,
                                                         wstring const &,
-                                                        bool ignoreDiacritics )
+                                                        bool ignoreDiacritics ) override
       ;
 
-    virtual QString const& getDescription();
+    QString const& getDescription() override;
 
-    virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+    sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                               int searchMode, bool matchCase,
                                                               int distanceBetweenWords,
                                                               int maxResults,
                                                               bool ignoreWordsOrder,
-                                                              bool ignoreDiacritics );
-    virtual void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+                                                              bool ignoreDiacritics ) override;
+    void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
-    virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+    void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-    virtual void setFTSParameters( Config::FullTextSearch const & fts )
+    void setFTSParameters( Config::FullTextSearch const & fts ) override
     {
       can_FTS = fts.enabled
                 && !fts.disabledTypes.contains( "AARD", Qt::CaseInsensitive )
@@ -284,7 +284,7 @@ class AardDictionary: public BtreeIndexing::BtreeDictionary
 
 protected:
 
-    virtual void loadIcon() noexcept;
+    void loadIcon() noexcept override;
 
 private:
 
@@ -661,12 +661,12 @@ public:
                                                          hasExited( hasExited_ )
   {}
 
-  ~AardArticleRequestRunnable()
+  ~AardArticleRequestRunnable() override
   {
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class AardArticleRequest: public Dictionary::DataRequest
@@ -694,12 +694,12 @@ public:
 
   void run(); // Run from another thread by DslArticleRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~AardArticleRequest()
+  ~AardArticleRequest() override
   {
     isCancelled.ref();
     hasExited.acquire();

--- a/articleview.cc
+++ b/articleview.cc
@@ -122,12 +122,12 @@ class DiacriticsHandler : public AccentMarkHandler
 public:
   DiacriticsHandler()
   {}
-  ~DiacriticsHandler()
+  ~DiacriticsHandler() override
   {}
 
   /// Create text without diacriticss
   /// and store diacritic marks positions
-  virtual void setText( QString const & baseString )
+  void setText( QString const & baseString ) override
   {
     accentMarkPos.clear();
     normalizedString.clear();

--- a/bgl.cc
+++ b/bgl.cc
@@ -198,49 +198,49 @@ namespace
     BglDictionary( string const & id, string const & indexFile,
                    string const & dictionaryFile );
 
-    virtual string getName() noexcept
+    string getName() noexcept override
     { return dictionaryName; }
 
-    virtual map< Dictionary::Property, string > getProperties() noexcept
+    map< Dictionary::Property, string > getProperties() noexcept override
     { return map< Dictionary::Property, string >(); }
 
-    virtual unsigned long getArticleCount() noexcept
+    unsigned long getArticleCount() noexcept override
     { return idxHeader.articleCount; }
 
-    virtual unsigned long getWordCount() noexcept
+    unsigned long getWordCount() noexcept override
     { return idxHeader.wordCount; }
 
-    inline virtual quint32 getLangFrom() const
+    inline quint32 getLangFrom() const override
     { return idxHeader.langFrom; }
 
-    inline virtual quint32 getLangTo() const
+    inline quint32 getLangTo() const override
     { return idxHeader.langTo; }
 
-    virtual sptr< Dictionary::WordSearchRequest > findHeadwordsForSynonym( wstring const & )
+    sptr< Dictionary::WordSearchRequest > findHeadwordsForSynonym( wstring const & ) override
       ;
 
-    virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+    sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                         vector< wstring > const & alts,
                                                         wstring const &,
-                                                        bool ignoreDiacritics )
+                                                        bool ignoreDiacritics ) override
       ;
 
-    virtual sptr< Dictionary::DataRequest > getResource( string const & name )
+    sptr< Dictionary::DataRequest > getResource( string const & name ) override
       ;
 
-    virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+    sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                               int searchMode, bool matchCase,
                                                               int distanceBetweenWords,
                                                               int maxResults,
                                                               bool ignoreWordsOrder,
-                                                              bool ignoreDiacritics );
-    virtual QString const& getDescription();
+                                                              bool ignoreDiacritics ) override;
+    QString const& getDescription() override;
 
-    virtual void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+    void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
-    virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+    void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-    virtual void setFTSParameters( Config::FullTextSearch const & fts )
+    void setFTSParameters( Config::FullTextSearch const & fts ) override
     {
       can_FTS = fts.enabled
                 && !fts.disabledTypes.contains( "BGL", Qt::CaseInsensitive )
@@ -249,7 +249,7 @@ namespace
 
   protected:
 
-    virtual void loadIcon() noexcept;
+    void loadIcon() noexcept override;
 
   private:
 
@@ -504,12 +504,12 @@ public:
                                                           hasExited( hasExited_ )
   {}
 
-  ~BglHeadwordsRequestRunnable()
+  ~BglHeadwordsRequestRunnable() override
   {
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class BglHeadwordsRequest: public Dictionary::WordSearchRequest
@@ -534,12 +534,12 @@ public:
 
   void run(); // Run from another thread by BglHeadwordsRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~BglHeadwordsRequest()
+  ~BglHeadwordsRequest() override
   {
     isCancelled.ref();
     hasExited.acquire();
@@ -651,12 +651,12 @@ public:
                                                              hasExited( hasExited_ )
   {}
 
-  ~BglArticleRequestRunnable()
+  ~BglArticleRequestRunnable() override
   {
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class BglArticleRequest: public Dictionary::DataRequest
@@ -684,7 +684,7 @@ public:
 
   void run(); // Run from another thread by BglArticleRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
@@ -692,7 +692,7 @@ public:
   void fixHebString(string & hebStr); // Hebrew support
   void fixHebArticle(string & hebArticle); // Hebrew support
 
-  ~BglArticleRequest()
+  ~BglArticleRequest() override
   {
     isCancelled.ref();
     hasExited.acquire();
@@ -946,12 +946,12 @@ public:
                                                          hasExited( hasExited_ )
   {}
 
-  ~BglResourceRequestRunnable()
+  ~BglResourceRequestRunnable() override
   {
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class BglResourceRequest: public Dictionary::DataRequest
@@ -985,12 +985,12 @@ public:
 
   void run(); // Run from another thread by BglResourceRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~BglResourceRequest()
+  ~BglResourceRequest() override
   {
     isCancelled.ref();
     hasExited.acquire();
@@ -1126,8 +1126,8 @@ sptr< Dictionary::DataRequest > BglDictionary::getResource( string const & name 
     { return resources; }
 
   protected:
-    virtual void handleBabylonResource( string const & filename,
-                                        char const * data, size_t size );
+    void handleBabylonResource( string const & filename,
+                                        char const * data, size_t size ) override;
   };
 
   void ResourceHandler::handleBabylonResource( string const & filename,

--- a/btreeidx.cc
+++ b/btreeidx.cc
@@ -121,12 +121,12 @@ public:
                                                       hasExited( hasExited_ )
   {}
 
-  ~BtreeWordSearchRunnable()
+  ~BtreeWordSearchRunnable() override
   {
     hasExited.release();
   }
   
-  virtual void run();
+  void run() override;
 };
 
 void BtreeWordSearchRunnable::run()

--- a/chinese.cc
+++ b/chinese.cc
@@ -28,10 +28,10 @@ public:
 
   CharacterConversionDictionary( std::string const & id, std::string const & name,
                                  QIcon icon, QString const & openccConfig);
-  ~CharacterConversionDictionary();
+  ~CharacterConversionDictionary() override;
 
   std::vector< gd::wstring > getAlternateWritings( gd::wstring const & )
-    noexcept;
+    noexcept override;
 };
 
 CharacterConversionDictionary::CharacterConversionDictionary( std::string const & id,

--- a/dictdfiles.cc
+++ b/dictdfiles.cc
@@ -98,47 +98,47 @@ public:
   DictdDictionary( string const & id, string const & indexFile,
                    vector< string > const & dictionaryFiles );
 
-  ~DictdDictionary();
+  ~DictdDictionary() override;
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return dictionaryName; }
 
-  virtual map< Dictionary::Property, string > getProperties() noexcept
+  map< Dictionary::Property, string > getProperties() noexcept override
   { return map< Dictionary::Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return idxHeader.articleCount; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return idxHeader.wordCount; }
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 
-  inline virtual quint32 getLangFrom() const
+  inline quint32 getLangFrom() const override
   { return idxHeader.langFrom; }
 
-  inline virtual quint32 getLangTo() const
+  inline quint32 getLangTo() const override
   { return idxHeader.langTo; }
 
-  virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
-                                                      bool ignoreDiacritics )
+                                                      bool ignoreDiacritics ) override
     ;
 
-  virtual QString const& getDescription();
+  QString const& getDescription() override;
 
-  virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+  sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                             int searchMode, bool matchCase,
                                                             int distanceBetweenWords,
                                                             int maxResults,
                                                             bool ignoreWordsOrder,
-                                                            bool ignoreDiacritics );
-  void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+                                                            bool ignoreDiacritics ) override;
+  void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
-  virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+  void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-  virtual void setFTSParameters( Config::FullTextSearch const & fts )
+  void setFTSParameters( Config::FullTextSearch const & fts ) override
   {
     can_FTS = fts.enabled
               && !fts.disabledTypes.contains( "DICTD", Qt::CaseInsensitive )

--- a/dictserver.cc
+++ b/dictserver.cc
@@ -209,35 +209,35 @@ public:
       strategies.append( "prefix" );
   }
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return name; }
 
-  virtual map< Property, string > getProperties() noexcept
+  map< Property, string > getProperties() noexcept override
   { return map< Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return 0; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return 0; }
 
-  virtual sptr< WordSearchRequest > prefixMatch( wstring const &,
-                                                 unsigned long maxResults ) ;
+  sptr< WordSearchRequest > prefixMatch( wstring const &,
+                                                 unsigned long maxResults ) override ;
 
-  virtual sptr< DataRequest > getArticle( wstring const &, vector< wstring > const & alts,
-                                          wstring const &, bool )
+  sptr< DataRequest > getArticle( wstring const &, vector< wstring > const & alts,
+                                          wstring const &, bool ) override
     ;
 
-  virtual quint32 getLangFrom() const
+  quint32 getLangFrom() const override
   { return langId; }
 
-  virtual quint32 getLangTo() const
+  quint32 getLangTo() const override
   { return langId; }
 
-  virtual QString const & getDescription();
+  QString const & getDescription() override;
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 
   void getServerDatabases();
 
@@ -361,12 +361,12 @@ public:
                                        hasExited( hasExited_ )
   {}
 
-  ~DictServerWordSearchRequestRunnable()
+  ~DictServerWordSearchRequestRunnable() override
   {
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class DictServerWordSearchRequest: public Dictionary::WordSearchRequest
@@ -392,12 +392,12 @@ public:
 
   void run();
 
-  ~DictServerWordSearchRequest()
+  ~DictServerWordSearchRequest() override
   {
     hasExited.acquire();
   }
 
-  virtual void cancel();
+  void cancel() override;
 
 };
 
@@ -575,12 +575,12 @@ public:
                                     hasExited( hasExited_ )
   {}
 
-  ~DictServerArticleRequestRunnable()
+  ~DictServerArticleRequestRunnable() override
   {
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class DictServerArticleRequest: public Dictionary::DataRequest
@@ -606,12 +606,12 @@ public:
 
   void run();
 
-  ~DictServerArticleRequest()
+  ~DictServerArticleRequest() override
   {
     hasExited.acquire();
   }
 
-  virtual void cancel();
+  void cancel() override;
 
 };
 

--- a/dsl.cc
+++ b/dsl.cc
@@ -181,26 +181,26 @@ public:
                  vector< string > const & dictionaryFiles,
                  int maxPictureWidth_ );
 
-  virtual void deferredInit();
+  void deferredInit() override;
 
-  ~DslDictionary();
+  ~DslDictionary() override;
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return dictionaryName; }
 
-  virtual map< Dictionary::Property, string > getProperties() noexcept
+  map< Dictionary::Property, string > getProperties() noexcept override
   { return map< Dictionary::Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return idxHeader.articleCount; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return idxHeader.wordCount; }
 
-  inline virtual quint32 getLangFrom() const
+  inline quint32 getLangFrom() const override
   { return idxHeader.langFrom; }
 
-  inline virtual quint32 getLangTo() const
+  inline quint32 getLangTo() const override
   { return idxHeader.langTo; }
 
   inline virtual string getResourceDir1() const
@@ -211,30 +211,30 @@ public:
 
 
 
-  virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
-                                                      bool ignoreDiacritics )
+                                                      bool ignoreDiacritics ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getResource( string const & name )
+  sptr< Dictionary::DataRequest > getResource( string const & name ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+  sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                             int searchMode, bool matchCase,
                                                             int distanceBetweenWords,
                                                             int maxResults,
                                                             bool ignoreWordsOrder,
-                                                            bool ignoreDiacritics );
-  virtual QString const& getDescription();
+                                                            bool ignoreDiacritics ) override;
+  QString const& getDescription() override;
 
-  virtual QString getMainFilename();
+  QString getMainFilename() override;
 
-  virtual void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+  void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
-  virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+  void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-  virtual void setFTSParameters( Config::FullTextSearch const & fts )
+  void setFTSParameters( Config::FullTextSearch const & fts ) override
   {
     if( ensureInitDone().size() )
       return;
@@ -244,16 +244,16 @@ public:
               && ( fts.maxDictionarySize == 0 || getArticleCount() <= fts.maxDictionarySize );
   }
 
-  virtual uint32_t getFtsIndexVersion()
+  uint32_t getFtsIndexVersion() override
   { return CurrentFtsIndexVersion; }
 
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 
 private:
 
-  virtual string const & ensureInitDone();
+  string const & ensureInitDone() override;
   void doDeferredInit();
 
   /// Loads the article. Does not process the DSL language.
@@ -1588,12 +1588,12 @@ public:
 
   void run();
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~DslArticleRequest()
+  ~DslArticleRequest() override
   {
     isCancelled.ref();
     f.waitForFinished();
@@ -1763,12 +1763,12 @@ public:
 
   void run();
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~DslResourceRequest()
+  ~DslResourceRequest() override
   {
     isCancelled.ref();
     f.waitForFinished();

--- a/epwing.cc
+++ b/epwing.cc
@@ -95,48 +95,48 @@ public:
                     vector< string > const & dictionaryFiles,
                     int subBook );
 
-  ~EpwingDictionary();
+  ~EpwingDictionary() override;
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return bookName; }
 
-  virtual map< Dictionary::Property, string > getProperties() noexcept
+  map< Dictionary::Property, string > getProperties() noexcept override
   { return map< Dictionary::Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return idxHeader.articleCount; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return idxHeader.wordCount; }
 
-  inline virtual quint32 getLangFrom() const
+  inline quint32 getLangFrom() const override
   { return idxHeader.langFrom; }
 
-  inline virtual quint32 getLangTo() const
+  inline quint32 getLangTo() const override
   { return idxHeader.langTo; }
 
-  virtual QString const& getDescription();
+  QString const& getDescription() override;
 
-  virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
-                                                      bool ignoreDiacritics )
+                                                      bool ignoreDiacritics ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getResource( string const & name )
+  sptr< Dictionary::DataRequest > getResource( string const & name ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+  sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                             int searchMode, bool matchCase,
                                                             int distanceBetweenWords,
                                                             int maxResults,
                                                             bool ignoreWordsOrder,
-                                                            bool ignoreDiacritics );
-  virtual void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+                                                            bool ignoreDiacritics ) override;
+  void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
-  virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+  void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-  virtual void setFTSParameters( Config::FullTextSearch const & fts )
+  void setFTSParameters( Config::FullTextSearch const & fts ) override
   {
     if( ensureInitDone().size() )
       return;
@@ -152,19 +152,19 @@ public:
 
   static bool isJapanesePunctiation( gd::wchar ch );
 
-  virtual sptr< Dictionary::WordSearchRequest > prefixMatch( wstring const &,
-                                                             unsigned long )
+  sptr< Dictionary::WordSearchRequest > prefixMatch( wstring const &,
+                                                             unsigned long ) override
     ;
 
-  virtual sptr< Dictionary::WordSearchRequest > stemmedMatch( wstring const &,
+  sptr< Dictionary::WordSearchRequest > stemmedMatch( wstring const &,
                                                               unsigned minLength,
                                                               unsigned maxSuffixVariation,
-                                                              unsigned long maxResults )
+                                                              unsigned long maxResults ) override
     ;
 
 protected:
 
-  void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 
 private:
 
@@ -460,12 +460,12 @@ public:
                           QVector< int > & offsets,
                           multimap< wstring, pair< string, string > > & mainArticles );
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~EpwingArticleRequest()
+  ~EpwingArticleRequest() override
   {
     isCancelled.ref();
     f.waitForFinished();
@@ -672,12 +672,12 @@ public:
                                                          hasExited( hasExited_ )
   {}
 
-  ~EpwingResourceRequestRunnable()
+  ~EpwingResourceRequestRunnable() override
   {
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class EpwingResourceRequest: public Dictionary::DataRequest
@@ -704,12 +704,12 @@ public:
 
   void run(); // Run from another thread by EpwingResourceRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~EpwingResourceRequest()
+  ~EpwingResourceRequest() override
   {
     isCancelled.ref();
     hasExited.acquire();
@@ -855,12 +855,12 @@ public:
                                                        hasExited( hasExited_ )
   {}
 
-  ~EpwingWordSearchRunnable()
+  ~EpwingWordSearchRunnable() override
   {
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class EpwingWordSearchRequest: public BtreeIndexing::BtreeWordSearchRequest
@@ -884,7 +884,7 @@ public:
       new EpwingWordSearchRunnable( *this, hasExited ) );
   }
 
-  virtual void findMatches();
+  void findMatches() override;
 };
 
 void EpwingWordSearchRunnable::run()

--- a/forvo.cc
+++ b/forvo.cc
@@ -42,20 +42,20 @@ public:
   {
   }
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return name; }
 
-  virtual map< Property, string > getProperties() noexcept
+  map< Property, string > getProperties() noexcept override
   { return map< Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return 0; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return 0; }
 
-  virtual sptr< WordSearchRequest > prefixMatch( wstring const & /*word*/,
-                                                 unsigned long /*maxResults*/ ) 
+  sptr< WordSearchRequest > prefixMatch( wstring const & /*word*/,
+                                                 unsigned long /*maxResults*/ ) override 
   {
     sptr< WordSearchRequestInstant > sr =  std::make_shared<WordSearchRequestInstant>();
 
@@ -64,13 +64,13 @@ public:
     return sr;
   }
 
-  virtual sptr< DataRequest > getArticle( wstring const &, vector< wstring > const & alts,
-                                          wstring const &, bool )
+  sptr< DataRequest > getArticle( wstring const &, vector< wstring > const & alts,
+                                          wstring const &, bool ) override
     ;
 
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 
 };
 

--- a/gls.cc
+++ b/gls.cc
@@ -370,54 +370,54 @@ public:
   GlsDictionary( string const & id, string const & indexFile,
                       vector< string > const & dictionaryFiles );
 
-  ~GlsDictionary();
+  ~GlsDictionary() override;
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return dictionaryName; }
 
-  virtual map< Dictionary::Property, string > getProperties() noexcept
+  map< Dictionary::Property, string > getProperties() noexcept override
   { return map< Dictionary::Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return idxHeader.articleCount; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return idxHeader.wordCount; }
 
-  inline virtual quint32 getLangFrom() const
+  inline quint32 getLangFrom() const override
   { return idxHeader.langFrom; }
 
-  inline virtual quint32 getLangTo() const
+  inline quint32 getLangTo() const override
   { return idxHeader.langTo; }
 
-  virtual sptr< Dictionary::WordSearchRequest > findHeadwordsForSynonym( wstring const & )
+  sptr< Dictionary::WordSearchRequest > findHeadwordsForSynonym( wstring const & ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
-                                                      bool ignoreDiacritics )
+                                                      bool ignoreDiacritics ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getResource( string const & name )
+  sptr< Dictionary::DataRequest > getResource( string const & name ) override
     ;
 
-  virtual QString const& getDescription();
+  QString const& getDescription() override;
 
-  virtual QString getMainFilename();
+  QString getMainFilename() override;
 
-  virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+  sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                             int searchMode, bool matchCase,
                                                             int distanceBetweenWords,
                                                             int maxResults,
                                                             bool ignoreWordsOrder,
-                                                            bool ignoreDiacritics );
+                                                            bool ignoreDiacritics ) override;
 
-  virtual void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+  void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
-  virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+  void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-  virtual void setFTSParameters( Config::FullTextSearch const & fts )
+  void setFTSParameters( Config::FullTextSearch const & fts ) override
   {
     can_FTS = fts.enabled
               && !fts.disabledTypes.contains( "GLS", Qt::CaseInsensitive )
@@ -425,7 +425,7 @@ public:
   }
 protected:
 
-  void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 
 private:
 
@@ -881,12 +881,12 @@ public:
                                                           hasExited( hasExited_ )
   {}
 
-  ~GlsHeadwordsRequestRunnable()
+  ~GlsHeadwordsRequestRunnable() override
   {
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class GlsHeadwordsRequest: public Dictionary::WordSearchRequest
@@ -910,12 +910,12 @@ public:
 
   void run(); // Run from another thread by StardictHeadwordsRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~GlsHeadwordsRequest()
+  ~GlsHeadwordsRequest() override
   {
     isCancelled.ref();
     hasExited.acquire();
@@ -1000,12 +1000,12 @@ public:
                                                         hasExited( hasExited_ )
   {}
 
-  ~GlsArticleRequestRunnable()
+  ~GlsArticleRequestRunnable() override
   {
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class GlsArticleRequest: public Dictionary::DataRequest
@@ -1033,12 +1033,12 @@ public:
 
   void run(); // Run from another thread by GlsArticleRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~GlsArticleRequest()
+  ~GlsArticleRequest() override
   {
     isCancelled.ref();
     hasExited.acquire();
@@ -1180,12 +1180,12 @@ public:
                                                          hasExited( hasExited_ )
   {}
 
-  ~GlsResourceRequestRunnable()
+  ~GlsResourceRequestRunnable() override
   {
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class GlsResourceRequest: public Dictionary::DataRequest
@@ -1212,12 +1212,12 @@ public:
 
   void run(); // Run from another thread by GlsResourceRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~GlsResourceRequest()
+  ~GlsResourceRequest() override
   {
     isCancelled.ref();
     hasExited.acquire();

--- a/hunspell.cc
+++ b/hunspell.cc
@@ -67,39 +67,39 @@ public:
   {
   }
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return name; }
 
-  virtual map< Property, string > getProperties() noexcept
+  map< Property, string > getProperties() noexcept override
   { return map< Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return 0; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return 0; }
 
-  virtual sptr< WordSearchRequest > prefixMatch( wstring const &,
-                                                 unsigned long maxResults )
+  sptr< WordSearchRequest > prefixMatch( wstring const &,
+                                                 unsigned long maxResults ) override
     ;
 
-  virtual sptr< WordSearchRequest > findHeadwordsForSynonym( wstring const & )
+  sptr< WordSearchRequest > findHeadwordsForSynonym( wstring const & ) override
     ;
 
-  virtual sptr< DataRequest > getArticle( wstring const &,
+  sptr< DataRequest > getArticle( wstring const &,
                                           vector< wstring > const & alts,
                                           wstring const &,
-                                          bool )
+                                          bool ) override
     ;
 
-  virtual bool isLocalDictionary()
+  bool isLocalDictionary() override
   { return true; }
 
-  virtual vector< wstring > getAlternateWritings( const wstring & word ) noexcept;
+  vector< wstring > getAlternateWritings( const wstring & word ) noexcept override;
 
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 
 private:
 
@@ -194,12 +194,12 @@ public:
                                                              hasExited( hasExited_ )
   {}
 
-  ~HunspellArticleRequestRunnable()
+  ~HunspellArticleRequestRunnable() override
   {
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class HunspellArticleRequest: public Dictionary::DataRequest
@@ -228,12 +228,12 @@ public:
 
   void run(); // Run from another thread by HunspellArticleRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~HunspellArticleRequest()
+  ~HunspellArticleRequest() override
   {
     isCancelled.ref();
     hasExited.acquire();
@@ -358,12 +358,12 @@ public:
                                                              hasExited( hasExited_ )
   {}
 
-  ~HunspellHeadwordsRequestRunnable()
+  ~HunspellHeadwordsRequestRunnable() override
   {
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class HunspellHeadwordsRequest: public Dictionary::WordSearchRequest
@@ -392,12 +392,12 @@ public:
 
   void run(); // Run from another thread by HunspellHeadwordsRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~HunspellHeadwordsRequest()
+  ~HunspellHeadwordsRequest() override
   {
     isCancelled.ref();
     hasExited.acquire();
@@ -533,12 +533,12 @@ public:
                                                                  hasExited( hasExited_ )
   {}
 
-  ~HunspellPrefixMatchRequestRunnable()
+  ~HunspellPrefixMatchRequestRunnable() override
   {
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class HunspellPrefixMatchRequest: public Dictionary::WordSearchRequest
@@ -567,12 +567,12 @@ public:
 
   void run(); // Run from another thread by HunspellPrefixMatchRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~HunspellPrefixMatchRequest()
+  ~HunspellPrefixMatchRequest() override
   {
     isCancelled.ref();
     hasExited.acquire();

--- a/lsa.cc
+++ b/lsa.cc
@@ -164,29 +164,29 @@ public:
   LsaDictionary( string const & id, string const & indexFile,
                  vector< string > const & dictionaryFiles );
 
-  virtual string getName() noexcept;
+  string getName() noexcept override;
 
-  virtual map< Dictionary::Property, string > getProperties() noexcept
+  map< Dictionary::Property, string > getProperties() noexcept override
   { return map< Dictionary::Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return idxHeader.soundsCount; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return getArticleCount(); }
 
-  virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
-                                                      bool ignoreDiacritics )
+                                                      bool ignoreDiacritics ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getResource( string const & name )
+  sptr< Dictionary::DataRequest > getResource( string const & name ) override
     ;
 
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 };
 
 string LsaDictionary::getName() noexcept

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -86,7 +86,7 @@ using std::pair;
 
 class InitSSLRunnable : public QRunnable
 {
-  virtual void run()
+  void run() override
   {
     /// This action force SSL library initialisation which may continue a few seconds
     QSslConfiguration::setDefaultConfiguration( QSslConfiguration::defaultConfiguration() );

--- a/mdx.cc
+++ b/mdx.cc
@@ -223,58 +223,58 @@ public:
 
   MdxDictionary( string const & id, string const & indexFile, vector<string> const & dictionaryFiles );
 
-  ~MdxDictionary();
+  ~MdxDictionary() override;
 
-  virtual void deferredInit();
+  void deferredInit() override;
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   {
     return dictionaryName;
   }
 
-  virtual map< Dictionary::Property, string > getProperties() noexcept
+  map< Dictionary::Property, string > getProperties() noexcept override
   {
     return map< Dictionary::Property, string >();
   }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   {
     return idxHeader.articleCount;
   }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   {
     return idxHeader.wordCount;
   }
 
-  inline virtual quint32 getLangFrom() const
+  inline quint32 getLangFrom() const override
   {
     return idxHeader.langFrom;
   }
 
-  inline virtual quint32 getLangTo() const
+  inline quint32 getLangTo() const override
   {
     return idxHeader.langTo;
   }
 
-  virtual sptr< Dictionary::DataRequest > getArticle( wstring const & word,
+  sptr< Dictionary::DataRequest > getArticle( wstring const & word,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
-                                                      bool ignoreDiacritics ) ;
-  virtual sptr< Dictionary::DataRequest > getResource( string const & name ) ;
-  virtual QString const & getDescription();
+                                                      bool ignoreDiacritics ) override ;
+  sptr< Dictionary::DataRequest > getResource( string const & name ) override ;
+  QString const & getDescription() override;
 
-  virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+  sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                             int searchMode, bool matchCase,
                                                             int distanceBetweenWords,
                                                             int maxResults,
                                                             bool ignoreWordsOrder,
-                                                            bool ignoreDiacritics );
-  virtual void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+                                                            bool ignoreDiacritics ) override;
+  void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
-  virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+  void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-  virtual void setFTSParameters( Config::FullTextSearch const & fts )
+  void setFTSParameters( Config::FullTextSearch const & fts ) override
   {
     if( ensureInitDone().size() )
       return;
@@ -288,11 +288,11 @@ public:
 
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 
 private:
 
-  virtual string const & ensureInitDone();
+  string const & ensureInitDone() override;
   void doDeferredInit();
 
   /// Loads an article with the given offset, filling the given strings.
@@ -558,12 +558,12 @@ public:
 
   void run();
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~MdxArticleRequest()
+  ~MdxArticleRequest() override
   {
     isCancelled.ref();
     f.waitForFinished();
@@ -709,12 +709,12 @@ public:
 
   void run();
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~MddResourceRequest()
+  ~MddResourceRequest() override
   {
     isCancelled.ref();
     f.waitForFinished();
@@ -1338,7 +1338,7 @@ public:
   {
   }
 
-  virtual void handleRecord( QString const & headWord, MdictParser::RecordInfo const & recordInfo )
+  void handleRecord( QString const & headWord, MdictParser::RecordInfo const & recordInfo ) override
   {
     // Save the article's record info
     uint32_t articleAddress = chunks.startNewBlock();
@@ -1361,7 +1361,7 @@ public:
   {
   }
 
-  virtual void handleRecord( QString const & fileName, MdictParser::RecordInfo const & recordInfo )
+  void handleRecord( QString const & fileName, MdictParser::RecordInfo const & recordInfo ) override
   {
     uint32_t resourceInfoAddress = chunks.startNewBlock();
     chunks.addToBlock( &recordInfo, sizeof( recordInfo ) );

--- a/mediawiki.cc
+++ b/mediawiki.cc
@@ -48,33 +48,33 @@ public:
       langId = LangCoder::code2toInt( url.mid( n - 2, 2 ).toLatin1().data() );
   }
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return name; }
 
-  virtual map< Property, string > getProperties() noexcept
+  map< Property, string > getProperties() noexcept override
   { return map< Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return 0; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return 0; }
 
-  virtual sptr< WordSearchRequest > prefixMatch( wstring const &,
-                                                 unsigned long maxResults ) ;
+  sptr< WordSearchRequest > prefixMatch( wstring const &,
+                                                 unsigned long maxResults ) override ;
 
-  virtual sptr< DataRequest > getArticle( wstring const &, vector< wstring > const & alts,
-                                          wstring const &, bool );
+  sptr< DataRequest > getArticle( wstring const &, vector< wstring > const & alts,
+                                          wstring const &, bool ) override;
 
-  virtual quint32 getLangFrom() const
+  quint32 getLangFrom() const override
   { return langId; }
 
-  virtual quint32 getLangTo() const
+  quint32 getLangTo() const override
   { return langId; }
 
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 
 };
 
@@ -109,13 +109,13 @@ public:
   MediaWikiWordSearchRequest( wstring const &,
                               QString const & url, QNetworkAccessManager & mgr );
 
-  ~MediaWikiWordSearchRequest();
+  ~MediaWikiWordSearchRequest() override;
 
-  virtual void cancel();
+  void cancel() override;
 
 private:
 
-  virtual void downloadFinished();
+  void downloadFinished() override;
 };
 
 MediaWikiWordSearchRequest::MediaWikiWordSearchRequest( wstring const & str,
@@ -212,13 +212,13 @@ public:
                            QString const & url, QNetworkAccessManager & mgr,
                            Class * dictPtr_ );
 
-  virtual void cancel();
+  void cancel() override;
 
 private:
 
   void addQuery( QNetworkAccessManager & mgr, wstring const & word );
 
-  virtual void requestFinished( QNetworkReply * );
+  void requestFinished( QNetworkReply * ) override;
 
   /// This simple set implementation should be much more efficient than tree-
   /// and hash-based standard/Qt containers when there are very few elements.

--- a/programs.cc
+++ b/programs.cc
@@ -30,30 +30,30 @@ public:
   {
   }
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return prg.name.toUtf8().data(); }
 
-  virtual map< Property, string > getProperties() noexcept
+  map< Property, string > getProperties() noexcept override
   { return map< Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return 0; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return 0; }
 
-  virtual sptr< WordSearchRequest > prefixMatch( wstring const & word,
-                                                 unsigned long maxResults )
+  sptr< WordSearchRequest > prefixMatch( wstring const & word,
+                                                 unsigned long maxResults ) override
     ;
 
-  virtual sptr< DataRequest > getArticle( wstring const &,
+  sptr< DataRequest > getArticle( wstring const &,
                                           vector< wstring > const & alts,
-                                          wstring const &, bool )
+                                          wstring const &, bool ) override
     ;
 
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 };
 
 sptr< WordSearchRequest > ProgramsDictionary::prefixMatch( wstring const & word,

--- a/sdict.cc
+++ b/sdict.cc
@@ -141,45 +141,45 @@ class SdictDictionary: public BtreeIndexing::BtreeDictionary
     SdictDictionary( string const & id, string const & indexFile,
                      vector< string > const & dictionaryFiles );
 
-    ~SdictDictionary();
+    ~SdictDictionary() override;
 
-    virtual string getName() noexcept
+    string getName() noexcept override
     { return dictionaryName; }
 
-    virtual map< Dictionary::Property, string > getProperties() noexcept
+    map< Dictionary::Property, string > getProperties() noexcept override
     { return map< Dictionary::Property, string >(); }
 
-    virtual unsigned long getArticleCount() noexcept
+    unsigned long getArticleCount() noexcept override
     { return idxHeader.articleCount; }
 
-    virtual unsigned long getWordCount() noexcept
+    unsigned long getWordCount() noexcept override
     { return idxHeader.wordCount; }
 
-    inline virtual quint32 getLangFrom() const
+    inline quint32 getLangFrom() const override
     { return idxHeader.langFrom; }
 
-    inline virtual quint32 getLangTo() const
+    inline quint32 getLangTo() const override
     { return idxHeader.langTo; }
 
-    virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+    sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                         vector< wstring > const & alts,
                                                         wstring const &,
-                                                        bool ignoreDiacritics )
+                                                        bool ignoreDiacritics ) override
       ;
 
-    virtual QString const & getDescription();
+    QString const & getDescription() override;
 
-    virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+    sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                               int searchMode, bool matchCase,
                                                               int distanceBetweenWords,
                                                               int maxResults,
                                                               bool ignoreWordsOrder,
-                                                              bool ignoreDiacritics );
-    virtual void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+                                                              bool ignoreDiacritics ) override;
+    void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
-    virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+    void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-    virtual void setFTSParameters( Config::FullTextSearch const & fts )
+    void setFTSParameters( Config::FullTextSearch const & fts ) override
     {
       can_FTS = fts.enabled
                 && !fts.disabledTypes.contains( "SDICT", Qt::CaseInsensitive )
@@ -187,7 +187,7 @@ class SdictDictionary: public BtreeIndexing::BtreeDictionary
     }
 protected:
 
-    void loadIcon() noexcept;
+    void loadIcon() noexcept override;
 
 private:
 
@@ -495,12 +495,12 @@ public:
                                                           hasExited( hasExited_ )
   {}
 
-  ~SdictArticleRequestRunnable()
+  ~SdictArticleRequestRunnable() override
   {
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class SdictArticleRequest: public Dictionary::DataRequest
@@ -528,12 +528,12 @@ public:
 
   void run(); // Run from another thread by DslArticleRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~SdictArticleRequest()
+  ~SdictArticleRequest() override
   {
     isCancelled.ref();
     hasExited.acquire();

--- a/slob.cc
+++ b/slob.cc
@@ -585,65 +585,65 @@ class SlobDictionary: public BtreeIndexing::BtreeDictionary
     SlobDictionary( string const & id, string const & indexFile,
                     vector< string > const & dictionaryFiles );
 
-    ~SlobDictionary();
+    ~SlobDictionary() override;
 
-    virtual string getName() noexcept
+    string getName() noexcept override
     { return dictionaryName; }
 
-    virtual map< Dictionary::Property, string > getProperties() noexcept
+    map< Dictionary::Property, string > getProperties() noexcept override
     { return map< Dictionary::Property, string >(); }
 
-    virtual unsigned long getArticleCount() noexcept
+    unsigned long getArticleCount() noexcept override
     { return idxHeader.articleCount; }
 
-    virtual unsigned long getWordCount() noexcept
+    unsigned long getWordCount() noexcept override
     { return idxHeader.wordCount; }
 
-    inline virtual quint32 getLangFrom() const
+    inline quint32 getLangFrom() const override
     { return idxHeader.langFrom; }
 
-    inline virtual quint32 getLangTo() const
+    inline quint32 getLangTo() const override
     { return idxHeader.langTo; }
 
-    virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+    sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                         vector< wstring > const & alts,
                                                         wstring const &,
-                                                        bool ignoreDiacritics )
+                                                        bool ignoreDiacritics ) override
       ;
 
-    virtual sptr< Dictionary::DataRequest > getResource( string const & name )
+    sptr< Dictionary::DataRequest > getResource( string const & name ) override
       ;
 
-    virtual QString const& getDescription();
+    QString const& getDescription() override;
 
     /// Loads the resource.
     void loadResource( std::string &resourceName, string & data );
 
-    virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+    sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                               int searchMode, bool matchCase,
                                                               int distanceBetweenWords,
                                                               int maxResults,
                                                               bool ignoreWordsOrder,
-                                                              bool ignoreDiacritics );
-    virtual void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+                                                              bool ignoreDiacritics ) override;
+    void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
     quint64 getArticlePos(uint32_t articleNumber );
 
-    virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+    void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-    virtual void setFTSParameters( Config::FullTextSearch const & fts )
+    void setFTSParameters( Config::FullTextSearch const & fts ) override
     {
       can_FTS = fts.enabled
                 && !fts.disabledTypes.contains( "SLOB", Qt::CaseInsensitive )
                 && ( fts.maxDictionarySize == 0 || getArticleCount() <= fts.maxDictionarySize );
     }
 
-    virtual uint32_t getFtsIndexVersion()
+    uint32_t getFtsIndexVersion() override
     { return 2; }
 
 protected:
 
-    virtual void loadIcon() noexcept;
+    void loadIcon() noexcept override;
 
 private:
 
@@ -1324,12 +1324,12 @@ public:
                                                          hasExited( hasExited_ )
   {}
 
-  ~SlobArticleRequestRunnable()
+  ~SlobArticleRequestRunnable() override
   {
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class SlobArticleRequest: public Dictionary::DataRequest
@@ -1357,12 +1357,12 @@ public:
 
   void run(); // Run from another thread by DslArticleRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~SlobArticleRequest()
+  ~SlobArticleRequest() override
   {
     isCancelled.ref();
     hasExited.acquire();
@@ -1513,12 +1513,12 @@ public:
                                                           hasExited( hasExited_ )
   {}
 
-  ~SlobResourceRequestRunnable()
+  ~SlobResourceRequestRunnable() override
   {
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class SlobResourceRequest: public Dictionary::DataRequest
@@ -1545,12 +1545,12 @@ public:
 
   void run(); // Run from another thread by ZimResourceRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~SlobResourceRequest()
+  ~SlobResourceRequest() override
   {
     isCancelled.ref();
     hasExited.acquire();

--- a/sounddir.cc
+++ b/sounddir.cc
@@ -79,30 +79,30 @@ public:
                       vector< string > const & dictionaryFiles,
                       QString const & iconFilename_ );
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return name; }
 
-  virtual map< Dictionary::Property, string > getProperties() noexcept
+  map< Dictionary::Property, string > getProperties() noexcept override
   { return map< Dictionary::Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return idxHeader.soundsCount; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return getArticleCount(); }
 
-  virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
-                                                      bool ignoreDiacritics )
+                                                      bool ignoreDiacritics ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getResource( string const & name )
+  sptr< Dictionary::DataRequest > getResource( string const & name ) override
     ;
 
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 };
 
 SoundDirDictionary::SoundDirDictionary( string const & id,

--- a/stardict.cc
+++ b/stardict.cc
@@ -156,53 +156,53 @@ public:
   StardictDictionary( string const & id, string const & indexFile,
                       vector< string > const & dictionaryFiles );
 
-  ~StardictDictionary();
+  ~StardictDictionary() override;
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return bookName; }
 
-  virtual map< Dictionary::Property, string > getProperties() noexcept
+  map< Dictionary::Property, string > getProperties() noexcept override
   { return map< Dictionary::Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return idxHeader.wordCount; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return idxHeader.wordCount + idxHeader.synWordCount; }
 
-  inline virtual quint32 getLangFrom() const
+  inline quint32 getLangFrom() const override
   { return idxHeader.langFrom; }
 
-  inline virtual quint32 getLangTo() const
+  inline quint32 getLangTo() const override
   { return idxHeader.langTo; }
 
-  virtual sptr< Dictionary::WordSearchRequest > findHeadwordsForSynonym( wstring const & )
+  sptr< Dictionary::WordSearchRequest > findHeadwordsForSynonym( wstring const & ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
-                                                      bool ignoreDiacritics )
+                                                      bool ignoreDiacritics ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getResource( string const & name )
+  sptr< Dictionary::DataRequest > getResource( string const & name ) override
     ;
 
-  virtual QString const& getDescription();
+  QString const& getDescription() override;
 
-  virtual QString getMainFilename();
+  QString getMainFilename() override;
 
-  virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+  sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                             int searchMode, bool matchCase,
                                                             int distanceBetweenWords,
                                                             int maxResults,
                                                             bool ignoreWordsOrder,
-                                                            bool ignoreDiacritics );
-  virtual void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+                                                            bool ignoreDiacritics ) override;
+  void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
-  virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+  void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-  virtual void setFTSParameters( Config::FullTextSearch const & fts )
+  void setFTSParameters( Config::FullTextSearch const & fts ) override
   {
     can_FTS = fts.enabled
               && !fts.disabledTypes.contains( "STARDICT", Qt::CaseInsensitive )
@@ -210,7 +210,7 @@ public:
   }
 protected:
 
-  void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 
 private:
 
@@ -1221,12 +1221,12 @@ public:
                                                                hasExited( hasExited_ )
   {}
 
-  ~StardictHeadwordsRequestRunnable()
+  ~StardictHeadwordsRequestRunnable() override
   {
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class StardictHeadwordsRequest: public Dictionary::WordSearchRequest
@@ -1251,12 +1251,12 @@ public:
 
   void run(); // Run from another thread by StardictHeadwordsRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~StardictHeadwordsRequest()
+  ~StardictHeadwordsRequest() override
   {
     isCancelled.ref();
     hasExited.acquire();
@@ -1340,12 +1340,12 @@ public:
                                                              hasExited( hasExited_ )
   {}
 
-  ~StardictArticleRequestRunnable()
+  ~StardictArticleRequestRunnable() override
   {
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class StardictArticleRequest: public Dictionary::DataRequest
@@ -1374,12 +1374,12 @@ public:
 
   void run(); // Run from another thread by StardictArticleRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~StardictArticleRequest()
+  ~StardictArticleRequest() override
   {
     isCancelled.ref();
     hasExited.acquire();
@@ -1634,12 +1634,12 @@ public:
                                                           hasExited( hasExited_ )
   {}
 
-  ~StardictResourceRequestRunnable()
+  ~StardictResourceRequestRunnable() override
   {
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class StardictResourceRequest: public Dictionary::DataRequest
@@ -1666,12 +1666,12 @@ public:
 
   void run(); // Run from another thread by StardictResourceRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~StardictResourceRequest()
+  ~StardictResourceRequest() override
   {
     isCancelled.ref();
     hasExited.acquire();

--- a/voiceengines.cc
+++ b/voiceengines.cc
@@ -44,30 +44,30 @@ public:
   {
   }
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return voiceEngine.name.toUtf8().data(); }
 
-  virtual map< Property, string > getProperties() noexcept
+  map< Property, string > getProperties() noexcept override
   { return map< Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return 0; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return 0; }
 
-  virtual sptr< WordSearchRequest > prefixMatch( wstring const & word,
-                                                 unsigned long maxResults )
+  sptr< WordSearchRequest > prefixMatch( wstring const & word,
+                                                 unsigned long maxResults ) override
     ;
 
-  virtual sptr< DataRequest > getArticle( wstring const &,
+  sptr< DataRequest > getArticle( wstring const &,
                                           vector< wstring > const & alts,
-                                          wstring const &, bool )
+                                          wstring const &, bool ) override
     ;
 
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 };
 
 sptr< WordSearchRequest > VoiceEnginesDictionary::prefixMatch( wstring const & /*word*/,

--- a/website.cc
+++ b/website.cc
@@ -54,33 +54,33 @@ public:
     dictionaryDescription = temp;
   }
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return name; }
 
-  virtual map< Property, string > getProperties() noexcept
+  map< Property, string > getProperties() noexcept override
   { return map< Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return 0; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return 0; }
 
-  virtual sptr< WordSearchRequest > prefixMatch( wstring const & word,
-                                                 unsigned long ) ;
+  sptr< WordSearchRequest > prefixMatch( wstring const & word,
+                                                 unsigned long ) override ;
 
-  virtual sptr< DataRequest > getArticle( wstring const &,
+  sptr< DataRequest > getArticle( wstring const &,
                                           vector< wstring > const & alts,
-                                          wstring const & context, bool )
+                                          wstring const & context, bool ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getResource( string const & name ) ;
+  sptr< Dictionary::DataRequest > getResource( string const & name ) override ;
 
   void isolateWebCSS( QString & css );
 
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 };
 
 sptr< WordSearchRequest > WebSiteDictionary::prefixMatch( wstring const & /*word*/,
@@ -109,14 +109,14 @@ public:
 
   WebSiteArticleRequest( QString const & url, QNetworkAccessManager & _mgr,
                          Class * dictPtr_ );
-  ~WebSiteArticleRequest()
+  ~WebSiteArticleRequest() override
   {}
 
-  virtual void cancel();
+  void cancel() override;
 
 private:
 
-  virtual void requestFinished( QNetworkReply * );
+  void requestFinished( QNetworkReply * ) override;
   static QTextCodec * codecForHtml( QByteArray const & ba );
 };
 
@@ -426,14 +426,14 @@ public:
 
   WebSiteResourceRequest( QString const & url_, QNetworkAccessManager & _mgr,
                           WebSiteDictionary * dictPtr_ );
-  ~WebSiteResourceRequest()
+  ~WebSiteResourceRequest() override
   {}
 
-  virtual void cancel();
+  void cancel() override;
 
 private:
 
-  virtual void requestFinished( QNetworkReply * );
+  void requestFinished( QNetworkReply * ) override;
 };
 
 WebSiteResourceRequest::WebSiteResourceRequest( QString const & url_,

--- a/xdxf.cc
+++ b/xdxf.cc
@@ -145,62 +145,62 @@ public:
   XdxfDictionary( string const & id, string const & indexFile,
                    vector< string > const & dictionaryFiles );
 
-  ~XdxfDictionary();
+  ~XdxfDictionary() override;
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return dictionaryName; }
 
-  virtual map< Dictionary::Property, string > getProperties() noexcept
+  map< Dictionary::Property, string > getProperties() noexcept override
   { return map< Dictionary::Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return idxHeader.articleCount; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return idxHeader.wordCount; }
 
-  inline virtual quint32 getLangFrom() const
+  inline quint32 getLangFrom() const override
   { return idxHeader.langFrom; }
 
-  inline virtual quint32 getLangTo() const
+  inline quint32 getLangTo() const override
   { return idxHeader.langTo; }
 
-  virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
-                                                      bool ignoreDiacritics )
+                                                      bool ignoreDiacritics ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getResource( string const & name )
+  sptr< Dictionary::DataRequest > getResource( string const & name ) override
     ;
 
-  virtual QString const& getDescription();
+  QString const& getDescription() override;
 
-  virtual QString getMainFilename();
+  QString getMainFilename() override;
 
-  virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+  sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                             int searchMode, bool matchCase,
                                                             int distanceBetweenWords,
                                                             int maxResults,
                                                             bool ignoreWordsOrder,
-                                                            bool ignoreDiacritics );
-  virtual void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+                                                            bool ignoreDiacritics ) override;
+  void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
-  virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+  void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-  virtual void setFTSParameters( Config::FullTextSearch const & fts )
+  void setFTSParameters( Config::FullTextSearch const & fts ) override
   {
     can_FTS = fts.enabled
               && !fts.disabledTypes.contains( "XDXF", Qt::CaseInsensitive )
               && ( fts.maxDictionarySize == 0 || getArticleCount() <= fts.maxDictionarySize );
   }
 
-  virtual uint32_t getFtsIndexVersion()
+  uint32_t getFtsIndexVersion() override
   { return 1; }
 
 protected:
 
-  void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 
 private:
 
@@ -449,12 +449,12 @@ public:
                                                              hasExited( hasExited_ )
   {}
 
-  ~XdxfArticleRequestRunnable()
+  ~XdxfArticleRequestRunnable() override
   {
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class XdxfArticleRequest: public Dictionary::DataRequest
@@ -482,12 +482,12 @@ public:
 
   void run(); // Run from another thread by XdxfArticleRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~XdxfArticleRequest()
+  ~XdxfArticleRequest() override
   {
     isCancelled.ref();
     hasExited.acquire();
@@ -690,7 +690,7 @@ public:
 
   GzippedFile( char const * fileName ) ;
 
-  ~GzippedFile();
+  ~GzippedFile() override;
 
 //  size_t gzTell();
 
@@ -700,22 +700,22 @@ protected:
 
   dictData *dz;
 
-  virtual bool isSequential () const
+  bool isSequential () const override
   { return false; } // Which is a lie, but else pos() won't work
 
-  bool waitForReadyRead ( int )
+  bool waitForReadyRead ( int ) override
   { return !gzeof( gz ); }
 
-  qint64 bytesAvailable() const
+  qint64 bytesAvailable() const override
   {
      return ( gzeof( gz ) ? 0 : 1 ) + QIODevice::bytesAvailable();
   }
 
-  virtual qint64 readData( char * data, qint64 maxSize );
+  qint64 readData( char * data, qint64 maxSize ) override;
 
-  virtual bool atEnd() const;
+  bool atEnd() const override;
 
-  virtual qint64 writeData ( const char * /*data*/, qint64 /*maxSize*/ )
+  qint64 writeData ( const char * /*data*/, qint64 /*maxSize*/ ) override
   { return -1; }
 };
 
@@ -978,12 +978,12 @@ public:
                                                           hasExited( hasExited_ )
   {}
 
-  ~XdxfResourceRequestRunnable()
+  ~XdxfResourceRequestRunnable() override
   {
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class XdxfResourceRequest: public Dictionary::DataRequest
@@ -1010,12 +1010,12 @@ public:
 
   void run(); // Run from another thread by XdxfResourceRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~XdxfResourceRequest()
+  ~XdxfResourceRequest() override
   {
     isCancelled.ref();
     hasExited.acquire();

--- a/zim.cc
+++ b/zim.cc
@@ -180,7 +180,7 @@ public:
   ZimFile( const QString & name );
   ~ZimFile();
 
-  virtual void setFileName( const QString & name );
+  void setFileName( const QString & name ) override;
   bool open();
   void close()
   {
@@ -669,65 +669,65 @@ class ZimDictionary: public BtreeIndexing::BtreeDictionary
     ZimDictionary( string const & id, string const & indexFile,
                      vector< string > const & dictionaryFiles );
 
-    ~ZimDictionary();
+    ~ZimDictionary() override;
 
-    virtual string getName() noexcept
+    string getName() noexcept override
     { return dictionaryName; }
 
-    virtual map< Dictionary::Property, string > getProperties() noexcept
+    map< Dictionary::Property, string > getProperties() noexcept override
     { return map< Dictionary::Property, string >(); }
 
-    virtual unsigned long getArticleCount() noexcept
+    unsigned long getArticleCount() noexcept override
     { return idxHeader.articleCount; }
 
-    virtual unsigned long getWordCount() noexcept
+    unsigned long getWordCount() noexcept override
     { return idxHeader.wordCount; }
 
-    inline virtual quint32 getLangFrom() const
+    inline quint32 getLangFrom() const override
     { return idxHeader.langFrom; }
 
-    inline virtual quint32 getLangTo() const
+    inline quint32 getLangTo() const override
     { return idxHeader.langTo; }
 
-    virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+    sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                         vector< wstring > const & alts,
                                                         wstring const &,
-                                                        bool ignoreDiacritics )
+                                                        bool ignoreDiacritics ) override
       ;
 
-    virtual sptr< Dictionary::DataRequest > getResource( string const & name )
+    sptr< Dictionary::DataRequest > getResource( string const & name ) override
       ;
 
-    virtual QString const& getDescription();
+    QString const& getDescription() override;
 
     /// Loads the resource.
     void loadResource( std::string &resourceName, string & data );
 
-    virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+    sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                               int searchMode, bool matchCase,
                                                               int distanceBetweenWords,
                                                               int maxResults,
                                                               bool ignoreWordsOrder,
-                                                              bool ignoreDiacritics );
-    virtual void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+                                                              bool ignoreDiacritics ) override;
+    void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
     quint32 getArticleText( uint32_t articleAddress, QString & headword, QString & text,
                             set< quint32 > * loadedArticles );
 
-    virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+    void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-    virtual void setFTSParameters( Config::FullTextSearch const & fts )
+    void setFTSParameters( Config::FullTextSearch const & fts ) override
     {
       can_FTS = fts.enabled
                 && !fts.disabledTypes.contains( "ZIM", Qt::CaseInsensitive )
                 && ( fts.maxDictionarySize == 0 || getArticleCount() <= fts.maxDictionarySize );
     }
 
-    virtual void sortArticlesOffsetsForFTS( QVector< uint32_t > & offsets, QAtomicInt & isCancelled );
+    void sortArticlesOffsetsForFTS( QVector< uint32_t > & offsets, QAtomicInt & isCancelled ) override;
 
 protected:
 
-    virtual void loadIcon() noexcept;
+    void loadIcon() noexcept override;
 
 private:
 
@@ -1280,12 +1280,12 @@ public:
 
   void run();
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~ZimArticleRequest()
+  ~ZimArticleRequest() override
   {
     isCancelled.ref();
     f.waitForFinished();
@@ -1452,12 +1452,12 @@ public:
 
   void run();
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
 
-  ~ZimResourceRequest()
+  ~ZimResourceRequest() override
   {
     isCancelled.ref();
     f.waitForFinished();

--- a/zipsounds.cc
+++ b/zipsounds.cc
@@ -114,29 +114,29 @@ public:
   ZipSoundsDictionary( string const & id, string const & indexFile,
                        vector< string > const & dictionaryFiles );
 
-  virtual string getName() noexcept;
+  string getName() noexcept override;
 
-  virtual map< Dictionary::Property, string > getProperties() noexcept
+  map< Dictionary::Property, string > getProperties() noexcept override
   { return map< Dictionary::Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return idxHeader.soundsCount; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return getArticleCount(); }
 
-  virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
-                                                      bool ignoreDiacritics )
+                                                      bool ignoreDiacritics ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getResource( string const & name )
+  sptr< Dictionary::DataRequest > getResource( string const & name ) override
     ;
 
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 };
 
 ZipSoundsDictionary::ZipSoundsDictionary( string const & id,


### PR DESCRIPTION
use the same technique as https://github.com/xiaoyifang/goldendict/pull/270

https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-override.html

https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c128-virtual-functions-should-specify-exactly-one-of-virtual-override-or-final