### PR TITLE
clang-tidy: apply modernize-use-override

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -29,7 +29,11 @@ Checks: >
   -readability-identifier-length,
   -readability-function-cognitive-complexity,
 CheckOptions:
-  - key:             modernize-loop-convert.MinConfidence
-    value:           reasonable
+  - key: modernize-loop-convert.MinConfidence
+    value: reasonable
+  - key: modernize-use-override.IgnoreDestructors
+    value: 1
+  - key: cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value: 1
 ...
 

--- a/aard.cc
+++ b/aard.cc
@@ -239,43 +239,43 @@ class AardDictionary: public BtreeIndexing::BtreeDictionary
 
     ~AardDictionary();
 
-    virtual string getName() noexcept
+    string getName() noexcept override
     { return dictionaryName; }
 
-    virtual map< Dictionary::Property, string > getProperties() noexcept
+    map< Dictionary::Property, string > getProperties() noexcept override
     { return map< Dictionary::Property, string >(); }
 
-    virtual unsigned long getArticleCount() noexcept
+    unsigned long getArticleCount() noexcept override
     { return idxHeader.articleCount; }
 
-    virtual unsigned long getWordCount() noexcept
+    unsigned long getWordCount() noexcept override
     { return idxHeader.wordCount; }
 
-    inline virtual quint32 getLangFrom() const
+    inline quint32 getLangFrom() const override
     { return idxHeader.langFrom; }
 
-    inline virtual quint32 getLangTo() const
+    inline quint32 getLangTo() const override
     { return idxHeader.langTo; }
 
-    virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+    sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                         vector< wstring > const & alts,
                                                         wstring const &,
-                                                        bool ignoreDiacritics )
+                                                        bool ignoreDiacritics ) override
       ;
 
-    virtual QString const& getDescription();
+    QString const& getDescription() override;
 
-    virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+    sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                               int searchMode, bool matchCase,
                                                               int distanceBetweenWords,
                                                               int maxResults,
                                                               bool ignoreWordsOrder,
-                                                              bool ignoreDiacritics );
-    virtual void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+                                                              bool ignoreDiacritics ) override;
+    void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
-    virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+    void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-    virtual void setFTSParameters( Config::FullTextSearch const & fts )
+    void setFTSParameters( Config::FullTextSearch const & fts ) override
     {
       can_FTS = fts.enabled
                 && !fts.disabledTypes.contains( "AARD", Qt::CaseInsensitive )
@@ -284,7 +284,7 @@ class AardDictionary: public BtreeIndexing::BtreeDictionary
 
 protected:
 
-    virtual void loadIcon() noexcept;
+    void loadIcon() noexcept override;
 
 private:
 
@@ -666,7 +666,7 @@ public:
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class AardArticleRequest: public Dictionary::DataRequest
@@ -694,7 +694,7 @@ public:
 
   void run(); // Run from another thread by DslArticleRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }

--- a/articleview.cc
+++ b/articleview.cc
@@ -127,7 +127,7 @@ public:
 
   /// Create text without diacriticss
   /// and store diacritic marks positions
-  virtual void setText( QString const & baseString )
+  void setText( QString const & baseString ) override
   {
     accentMarkPos.clear();
     normalizedString.clear();

--- a/bgl.cc
+++ b/bgl.cc
@@ -198,49 +198,49 @@ namespace
     BglDictionary( string const & id, string const & indexFile,
                    string const & dictionaryFile );
 
-    virtual string getName() noexcept
+    string getName() noexcept override
     { return dictionaryName; }
 
-    virtual map< Dictionary::Property, string > getProperties() noexcept
+    map< Dictionary::Property, string > getProperties() noexcept override
     { return map< Dictionary::Property, string >(); }
 
-    virtual unsigned long getArticleCount() noexcept
+    unsigned long getArticleCount() noexcept override
     { return idxHeader.articleCount; }
 
-    virtual unsigned long getWordCount() noexcept
+    unsigned long getWordCount() noexcept override
     { return idxHeader.wordCount; }
 
-    inline virtual quint32 getLangFrom() const
+    inline quint32 getLangFrom() const override
     { return idxHeader.langFrom; }
 
-    inline virtual quint32 getLangTo() const
+    inline quint32 getLangTo() const override
     { return idxHeader.langTo; }
 
-    virtual sptr< Dictionary::WordSearchRequest > findHeadwordsForSynonym( wstring const & )
+    sptr< Dictionary::WordSearchRequest > findHeadwordsForSynonym( wstring const & ) override
       ;
 
-    virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+    sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                         vector< wstring > const & alts,
                                                         wstring const &,
-                                                        bool ignoreDiacritics )
+                                                        bool ignoreDiacritics ) override
       ;
 
-    virtual sptr< Dictionary::DataRequest > getResource( string const & name )
+    sptr< Dictionary::DataRequest > getResource( string const & name ) override
       ;
 
-    virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+    sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                               int searchMode, bool matchCase,
                                                               int distanceBetweenWords,
                                                               int maxResults,
                                                               bool ignoreWordsOrder,
-                                                              bool ignoreDiacritics );
-    virtual QString const& getDescription();
+                                                              bool ignoreDiacritics ) override;
+    QString const& getDescription() override;
 
-    virtual void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+    void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
-    virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+    void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-    virtual void setFTSParameters( Config::FullTextSearch const & fts )
+    void setFTSParameters( Config::FullTextSearch const & fts ) override
     {
       can_FTS = fts.enabled
                 && !fts.disabledTypes.contains( "BGL", Qt::CaseInsensitive )
@@ -249,7 +249,7 @@ namespace
 
   protected:
 
-    virtual void loadIcon() noexcept;
+    void loadIcon() noexcept override;
 
   private:
 
@@ -509,7 +509,7 @@ public:
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class BglHeadwordsRequest: public Dictionary::WordSearchRequest
@@ -534,7 +534,7 @@ public:
 
   void run(); // Run from another thread by BglHeadwordsRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
@@ -656,7 +656,7 @@ public:
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class BglArticleRequest: public Dictionary::DataRequest
@@ -684,7 +684,7 @@ public:
 
   void run(); // Run from another thread by BglArticleRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
@@ -951,7 +951,7 @@ public:
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class BglResourceRequest: public Dictionary::DataRequest
@@ -985,7 +985,7 @@ public:
 
   void run(); // Run from another thread by BglResourceRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
@@ -1126,8 +1126,8 @@ sptr< Dictionary::DataRequest > BglDictionary::getResource( string const & name 
     { return resources; }
 
   protected:
-    virtual void handleBabylonResource( string const & filename,
-                                        char const * data, size_t size );
+    void handleBabylonResource( string const & filename,
+                                        char const * data, size_t size ) override;
   };
 
   void ResourceHandler::handleBabylonResource( string const & filename,

--- a/btreeidx.cc
+++ b/btreeidx.cc
@@ -126,7 +126,7 @@ public:
     hasExited.release();
   }
   
-  virtual void run();
+  void run() override;
 };
 
 void BtreeWordSearchRunnable::run()

--- a/chinese.cc
+++ b/chinese.cc
@@ -31,7 +31,7 @@ public:
   ~CharacterConversionDictionary();
 
   std::vector< gd::wstring > getAlternateWritings( gd::wstring const & )
-    noexcept;
+    noexcept override;
 };
 
 CharacterConversionDictionary::CharacterConversionDictionary( std::string const & id,

--- a/dictdfiles.cc
+++ b/dictdfiles.cc
@@ -100,45 +100,45 @@ public:
 
   ~DictdDictionary();
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return dictionaryName; }
 
-  virtual map< Dictionary::Property, string > getProperties() noexcept
+  map< Dictionary::Property, string > getProperties() noexcept override
   { return map< Dictionary::Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return idxHeader.articleCount; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return idxHeader.wordCount; }
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 
-  inline virtual quint32 getLangFrom() const
+  inline quint32 getLangFrom() const override
   { return idxHeader.langFrom; }
 
-  inline virtual quint32 getLangTo() const
+  inline quint32 getLangTo() const override
   { return idxHeader.langTo; }
 
-  virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
-                                                      bool ignoreDiacritics )
+                                                      bool ignoreDiacritics ) override
     ;
 
-  virtual QString const& getDescription();
+  QString const& getDescription() override;
 
-  virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+  sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                             int searchMode, bool matchCase,
                                                             int distanceBetweenWords,
                                                             int maxResults,
                                                             bool ignoreWordsOrder,
-                                                            bool ignoreDiacritics );
-  void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+                                                            bool ignoreDiacritics ) override;
+  void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
-  virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+  void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-  virtual void setFTSParameters( Config::FullTextSearch const & fts )
+  void setFTSParameters( Config::FullTextSearch const & fts ) override
   {
     can_FTS = fts.enabled
               && !fts.disabledTypes.contains( "DICTD", Qt::CaseInsensitive )

--- a/dictserver.cc
+++ b/dictserver.cc
@@ -209,35 +209,35 @@ public:
       strategies.append( "prefix" );
   }
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return name; }
 
-  virtual map< Property, string > getProperties() noexcept
+  map< Property, string > getProperties() noexcept override
   { return map< Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return 0; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return 0; }
 
-  virtual sptr< WordSearchRequest > prefixMatch( wstring const &,
-                                                 unsigned long maxResults ) ;
+  sptr< WordSearchRequest > prefixMatch( wstring const &,
+                                                 unsigned long maxResults ) override ;
 
-  virtual sptr< DataRequest > getArticle( wstring const &, vector< wstring > const & alts,
-                                          wstring const &, bool )
+  sptr< DataRequest > getArticle( wstring const &, vector< wstring > const & alts,
+                                          wstring const &, bool ) override
     ;
 
-  virtual quint32 getLangFrom() const
+  quint32 getLangFrom() const override
   { return langId; }
 
-  virtual quint32 getLangTo() const
+  quint32 getLangTo() const override
   { return langId; }
 
-  virtual QString const & getDescription();
+  QString const & getDescription() override;
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 
   void getServerDatabases();
 
@@ -366,7 +366,7 @@ public:
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class DictServerWordSearchRequest: public Dictionary::WordSearchRequest
@@ -397,7 +397,7 @@ public:
     hasExited.acquire();
   }
 
-  virtual void cancel();
+  void cancel() override;
 
 };
 
@@ -580,7 +580,7 @@ public:
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class DictServerArticleRequest: public Dictionary::DataRequest
@@ -611,7 +611,7 @@ public:
     hasExited.acquire();
   }
 
-  virtual void cancel();
+  void cancel() override;
 
 };
 

--- a/dsl.cc
+++ b/dsl.cc
@@ -181,26 +181,26 @@ public:
                  vector< string > const & dictionaryFiles,
                  int maxPictureWidth_ );
 
-  virtual void deferredInit();
+  void deferredInit() override;
 
   ~DslDictionary();
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return dictionaryName; }
 
-  virtual map< Dictionary::Property, string > getProperties() noexcept
+  map< Dictionary::Property, string > getProperties() noexcept override
   { return map< Dictionary::Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return idxHeader.articleCount; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return idxHeader.wordCount; }
 
-  inline virtual quint32 getLangFrom() const
+  inline quint32 getLangFrom() const override
   { return idxHeader.langFrom; }
 
-  inline virtual quint32 getLangTo() const
+  inline quint32 getLangTo() const override
   { return idxHeader.langTo; }
 
   inline virtual string getResourceDir1() const
@@ -211,30 +211,30 @@ public:
 
 
 
-  virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
-                                                      bool ignoreDiacritics )
+                                                      bool ignoreDiacritics ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getResource( string const & name )
+  sptr< Dictionary::DataRequest > getResource( string const & name ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+  sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                             int searchMode, bool matchCase,
                                                             int distanceBetweenWords,
                                                             int maxResults,
                                                             bool ignoreWordsOrder,
-                                                            bool ignoreDiacritics );
-  virtual QString const& getDescription();
+                                                            bool ignoreDiacritics ) override;
+  QString const& getDescription() override;
 
-  virtual QString getMainFilename();
+  QString getMainFilename() override;
 
-  virtual void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+  void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
-  virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+  void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-  virtual void setFTSParameters( Config::FullTextSearch const & fts )
+  void setFTSParameters( Config::FullTextSearch const & fts ) override
   {
     if( ensureInitDone().size() )
       return;
@@ -244,16 +244,16 @@ public:
               && ( fts.maxDictionarySize == 0 || getArticleCount() <= fts.maxDictionarySize );
   }
 
-  virtual uint32_t getFtsIndexVersion()
+  uint32_t getFtsIndexVersion() override
   { return CurrentFtsIndexVersion; }
 
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 
 private:
 
-  virtual string const & ensureInitDone();
+  string const & ensureInitDone() override;
   void doDeferredInit();
 
   /// Loads the article. Does not process the DSL language.
@@ -1588,7 +1588,7 @@ public:
 
   void run();
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
@@ -1763,7 +1763,7 @@ public:
 
   void run();
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }

--- a/epwing.cc
+++ b/epwing.cc
@@ -97,46 +97,46 @@ public:
 
   ~EpwingDictionary();
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return bookName; }
 
-  virtual map< Dictionary::Property, string > getProperties() noexcept
+  map< Dictionary::Property, string > getProperties() noexcept override
   { return map< Dictionary::Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return idxHeader.articleCount; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return idxHeader.wordCount; }
 
-  inline virtual quint32 getLangFrom() const
+  inline quint32 getLangFrom() const override
   { return idxHeader.langFrom; }
 
-  inline virtual quint32 getLangTo() const
+  inline quint32 getLangTo() const override
   { return idxHeader.langTo; }
 
-  virtual QString const& getDescription();
+  QString const& getDescription() override;
 
-  virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
-                                                      bool ignoreDiacritics )
+                                                      bool ignoreDiacritics ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getResource( string const & name )
+  sptr< Dictionary::DataRequest > getResource( string const & name ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+  sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                             int searchMode, bool matchCase,
                                                             int distanceBetweenWords,
                                                             int maxResults,
                                                             bool ignoreWordsOrder,
-                                                            bool ignoreDiacritics );
-  virtual void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+                                                            bool ignoreDiacritics ) override;
+  void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
-  virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+  void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-  virtual void setFTSParameters( Config::FullTextSearch const & fts )
+  void setFTSParameters( Config::FullTextSearch const & fts ) override
   {
     if( ensureInitDone().size() )
       return;
@@ -152,19 +152,19 @@ public:
 
   static bool isJapanesePunctiation( gd::wchar ch );
 
-  virtual sptr< Dictionary::WordSearchRequest > prefixMatch( wstring const &,
-                                                             unsigned long )
+  sptr< Dictionary::WordSearchRequest > prefixMatch( wstring const &,
+                                                             unsigned long ) override
     ;
 
-  virtual sptr< Dictionary::WordSearchRequest > stemmedMatch( wstring const &,
+  sptr< Dictionary::WordSearchRequest > stemmedMatch( wstring const &,
                                                               unsigned minLength,
                                                               unsigned maxSuffixVariation,
-                                                              unsigned long maxResults )
+                                                              unsigned long maxResults ) override
     ;
 
 protected:
 
-  void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 
 private:
 
@@ -460,7 +460,7 @@ public:
                           QVector< int > & offsets,
                           multimap< wstring, pair< string, string > > & mainArticles );
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
@@ -677,7 +677,7 @@ public:
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class EpwingResourceRequest: public Dictionary::DataRequest
@@ -704,7 +704,7 @@ public:
 
   void run(); // Run from another thread by EpwingResourceRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
@@ -860,7 +860,7 @@ public:
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class EpwingWordSearchRequest: public BtreeIndexing::BtreeWordSearchRequest
@@ -884,7 +884,7 @@ public:
       new EpwingWordSearchRunnable( *this, hasExited ) );
   }
 
-  virtual void findMatches();
+  void findMatches() override;
 };
 
 void EpwingWordSearchRunnable::run()

--- a/forvo.cc
+++ b/forvo.cc
@@ -42,20 +42,20 @@ public:
   {
   }
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return name; }
 
-  virtual map< Property, string > getProperties() noexcept
+  map< Property, string > getProperties() noexcept override
   { return map< Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return 0; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return 0; }
 
-  virtual sptr< WordSearchRequest > prefixMatch( wstring const & /*word*/,
-                                                 unsigned long /*maxResults*/ ) 
+  sptr< WordSearchRequest > prefixMatch( wstring const & /*word*/,
+                                                 unsigned long /*maxResults*/ ) override 
   {
     sptr< WordSearchRequestInstant > sr =  std::make_shared<WordSearchRequestInstant>();
 
@@ -64,13 +64,13 @@ public:
     return sr;
   }
 
-  virtual sptr< DataRequest > getArticle( wstring const &, vector< wstring > const & alts,
-                                          wstring const &, bool )
+  sptr< DataRequest > getArticle( wstring const &, vector< wstring > const & alts,
+                                          wstring const &, bool ) override
     ;
 
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 
 };
 

--- a/gls.cc
+++ b/gls.cc
@@ -372,52 +372,52 @@ public:
 
   ~GlsDictionary();
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return dictionaryName; }
 
-  virtual map< Dictionary::Property, string > getProperties() noexcept
+  map< Dictionary::Property, string > getProperties() noexcept override
   { return map< Dictionary::Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return idxHeader.articleCount; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return idxHeader.wordCount; }
 
-  inline virtual quint32 getLangFrom() const
+  inline quint32 getLangFrom() const override
   { return idxHeader.langFrom; }
 
-  inline virtual quint32 getLangTo() const
+  inline quint32 getLangTo() const override
   { return idxHeader.langTo; }
 
-  virtual sptr< Dictionary::WordSearchRequest > findHeadwordsForSynonym( wstring const & )
+  sptr< Dictionary::WordSearchRequest > findHeadwordsForSynonym( wstring const & ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
-                                                      bool ignoreDiacritics )
+                                                      bool ignoreDiacritics ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getResource( string const & name )
+  sptr< Dictionary::DataRequest > getResource( string const & name ) override
     ;
 
-  virtual QString const& getDescription();
+  QString const& getDescription() override;
 
-  virtual QString getMainFilename();
+  QString getMainFilename() override;
 
-  virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+  sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                             int searchMode, bool matchCase,
                                                             int distanceBetweenWords,
                                                             int maxResults,
                                                             bool ignoreWordsOrder,
-                                                            bool ignoreDiacritics );
+                                                            bool ignoreDiacritics ) override;
 
-  virtual void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+  void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
-  virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+  void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-  virtual void setFTSParameters( Config::FullTextSearch const & fts )
+  void setFTSParameters( Config::FullTextSearch const & fts ) override
   {
     can_FTS = fts.enabled
               && !fts.disabledTypes.contains( "GLS", Qt::CaseInsensitive )
@@ -425,7 +425,7 @@ public:
   }
 protected:
 
-  void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 
 private:
 
@@ -886,7 +886,7 @@ public:
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class GlsHeadwordsRequest: public Dictionary::WordSearchRequest
@@ -910,7 +910,7 @@ public:
 
   void run(); // Run from another thread by StardictHeadwordsRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
@@ -1005,7 +1005,7 @@ public:
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class GlsArticleRequest: public Dictionary::DataRequest
@@ -1033,7 +1033,7 @@ public:
 
   void run(); // Run from another thread by GlsArticleRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
@@ -1185,7 +1185,7 @@ public:
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class GlsResourceRequest: public Dictionary::DataRequest
@@ -1212,7 +1212,7 @@ public:
 
   void run(); // Run from another thread by GlsResourceRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }

--- a/hunspell.cc
+++ b/hunspell.cc
@@ -67,39 +67,39 @@ public:
   {
   }
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return name; }
 
-  virtual map< Property, string > getProperties() noexcept
+  map< Property, string > getProperties() noexcept override
   { return map< Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return 0; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return 0; }
 
-  virtual sptr< WordSearchRequest > prefixMatch( wstring const &,
-                                                 unsigned long maxResults )
+  sptr< WordSearchRequest > prefixMatch( wstring const &,
+                                                 unsigned long maxResults ) override
     ;
 
-  virtual sptr< WordSearchRequest > findHeadwordsForSynonym( wstring const & )
+  sptr< WordSearchRequest > findHeadwordsForSynonym( wstring const & ) override
     ;
 
-  virtual sptr< DataRequest > getArticle( wstring const &,
+  sptr< DataRequest > getArticle( wstring const &,
                                           vector< wstring > const & alts,
                                           wstring const &,
-                                          bool )
+                                          bool ) override
     ;
 
-  virtual bool isLocalDictionary()
+  bool isLocalDictionary() override
   { return true; }
 
-  virtual vector< wstring > getAlternateWritings( const wstring & word ) noexcept;
+  vector< wstring > getAlternateWritings( const wstring & word ) noexcept override;
 
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 
 private:
 
@@ -199,7 +199,7 @@ public:
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class HunspellArticleRequest: public Dictionary::DataRequest
@@ -228,7 +228,7 @@ public:
 
   void run(); // Run from another thread by HunspellArticleRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
@@ -363,7 +363,7 @@ public:
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class HunspellHeadwordsRequest: public Dictionary::WordSearchRequest
@@ -392,7 +392,7 @@ public:
 
   void run(); // Run from another thread by HunspellHeadwordsRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
@@ -538,7 +538,7 @@ public:
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class HunspellPrefixMatchRequest: public Dictionary::WordSearchRequest
@@ -567,7 +567,7 @@ public:
 
   void run(); // Run from another thread by HunspellPrefixMatchRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }

--- a/lsa.cc
+++ b/lsa.cc
@@ -164,29 +164,29 @@ public:
   LsaDictionary( string const & id, string const & indexFile,
                  vector< string > const & dictionaryFiles );
 
-  virtual string getName() noexcept;
+  string getName() noexcept override;
 
-  virtual map< Dictionary::Property, string > getProperties() noexcept
+  map< Dictionary::Property, string > getProperties() noexcept override
   { return map< Dictionary::Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return idxHeader.soundsCount; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return getArticleCount(); }
 
-  virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
-                                                      bool ignoreDiacritics )
+                                                      bool ignoreDiacritics ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getResource( string const & name )
+  sptr< Dictionary::DataRequest > getResource( string const & name ) override
     ;
 
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 };
 
 string LsaDictionary::getName() noexcept

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -86,7 +86,7 @@ using std::pair;
 
 class InitSSLRunnable : public QRunnable
 {
-  virtual void run()
+  void run() override
   {
     /// This action force SSL library initialisation which may continue a few seconds
     QSslConfiguration::setDefaultConfiguration( QSslConfiguration::defaultConfiguration() );

--- a/mdx.cc
+++ b/mdx.cc
@@ -225,56 +225,56 @@ public:
 
   ~MdxDictionary();
 
-  virtual void deferredInit();
+  void deferredInit() override;
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   {
     return dictionaryName;
   }
 
-  virtual map< Dictionary::Property, string > getProperties() noexcept
+  map< Dictionary::Property, string > getProperties() noexcept override
   {
     return map< Dictionary::Property, string >();
   }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   {
     return idxHeader.articleCount;
   }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   {
     return idxHeader.wordCount;
   }
 
-  inline virtual quint32 getLangFrom() const
+  inline quint32 getLangFrom() const override
   {
     return idxHeader.langFrom;
   }
 
-  inline virtual quint32 getLangTo() const
+  inline quint32 getLangTo() const override
   {
     return idxHeader.langTo;
   }
 
-  virtual sptr< Dictionary::DataRequest > getArticle( wstring const & word,
+  sptr< Dictionary::DataRequest > getArticle( wstring const & word,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
-                                                      bool ignoreDiacritics ) ;
-  virtual sptr< Dictionary::DataRequest > getResource( string const & name ) ;
-  virtual QString const & getDescription();
+                                                      bool ignoreDiacritics ) override ;
+  sptr< Dictionary::DataRequest > getResource( string const & name ) override ;
+  QString const & getDescription() override;
 
-  virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+  sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                             int searchMode, bool matchCase,
                                                             int distanceBetweenWords,
                                                             int maxResults,
                                                             bool ignoreWordsOrder,
-                                                            bool ignoreDiacritics );
-  virtual void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+                                                            bool ignoreDiacritics ) override;
+  void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
-  virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+  void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-  virtual void setFTSParameters( Config::FullTextSearch const & fts )
+  void setFTSParameters( Config::FullTextSearch const & fts ) override
   {
     if( ensureInitDone().size() )
       return;
@@ -288,11 +288,11 @@ public:
 
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 
 private:
 
-  virtual string const & ensureInitDone();
+  string const & ensureInitDone() override;
   void doDeferredInit();
 
   /// Loads an article with the given offset, filling the given strings.
@@ -558,7 +558,7 @@ public:
 
   void run();
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
@@ -709,7 +709,7 @@ public:
 
   void run();
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
@@ -1338,7 +1338,7 @@ public:
   {
   }
 
-  virtual void handleRecord( QString const & headWord, MdictParser::RecordInfo const & recordInfo )
+  void handleRecord( QString const & headWord, MdictParser::RecordInfo const & recordInfo ) override
   {
     // Save the article's record info
     uint32_t articleAddress = chunks.startNewBlock();
@@ -1361,7 +1361,7 @@ public:
   {
   }
 
-  virtual void handleRecord( QString const & fileName, MdictParser::RecordInfo const & recordInfo )
+  void handleRecord( QString const & fileName, MdictParser::RecordInfo const & recordInfo ) override
   {
     uint32_t resourceInfoAddress = chunks.startNewBlock();
     chunks.addToBlock( &recordInfo, sizeof( recordInfo ) );

--- a/mediawiki.cc
+++ b/mediawiki.cc
@@ -48,33 +48,33 @@ public:
       langId = LangCoder::code2toInt( url.mid( n - 2, 2 ).toLatin1().data() );
   }
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return name; }
 
-  virtual map< Property, string > getProperties() noexcept
+  map< Property, string > getProperties() noexcept override
   { return map< Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return 0; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return 0; }
 
-  virtual sptr< WordSearchRequest > prefixMatch( wstring const &,
-                                                 unsigned long maxResults ) ;
+  sptr< WordSearchRequest > prefixMatch( wstring const &,
+                                                 unsigned long maxResults ) override ;
 
-  virtual sptr< DataRequest > getArticle( wstring const &, vector< wstring > const & alts,
-                                          wstring const &, bool );
+  sptr< DataRequest > getArticle( wstring const &, vector< wstring > const & alts,
+                                          wstring const &, bool ) override;
 
-  virtual quint32 getLangFrom() const
+  quint32 getLangFrom() const override
   { return langId; }
 
-  virtual quint32 getLangTo() const
+  quint32 getLangTo() const override
   { return langId; }
 
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 
 };
 
@@ -111,11 +111,11 @@ public:
 
   ~MediaWikiWordSearchRequest();
 
-  virtual void cancel();
+  void cancel() override;
 
 private:
 
-  virtual void downloadFinished();
+  void downloadFinished() override;
 };
 
 MediaWikiWordSearchRequest::MediaWikiWordSearchRequest( wstring const & str,
@@ -212,13 +212,13 @@ public:
                            QString const & url, QNetworkAccessManager & mgr,
                            Class * dictPtr_ );
 
-  virtual void cancel();
+  void cancel() override;
 
 private:
 
   void addQuery( QNetworkAccessManager & mgr, wstring const & word );
 
-  virtual void requestFinished( QNetworkReply * );
+  void requestFinished( QNetworkReply * ) override;
 
   /// This simple set implementation should be much more efficient than tree-
   /// and hash-based standard/Qt containers when there are very few elements.

--- a/programs.cc
+++ b/programs.cc
@@ -30,30 +30,30 @@ public:
   {
   }
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return prg.name.toUtf8().data(); }
 
-  virtual map< Property, string > getProperties() noexcept
+  map< Property, string > getProperties() noexcept override
   { return map< Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return 0; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return 0; }
 
-  virtual sptr< WordSearchRequest > prefixMatch( wstring const & word,
-                                                 unsigned long maxResults )
+  sptr< WordSearchRequest > prefixMatch( wstring const & word,
+                                                 unsigned long maxResults ) override
     ;
 
-  virtual sptr< DataRequest > getArticle( wstring const &,
+  sptr< DataRequest > getArticle( wstring const &,
                                           vector< wstring > const & alts,
-                                          wstring const &, bool )
+                                          wstring const &, bool ) override
     ;
 
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 };
 
 sptr< WordSearchRequest > ProgramsDictionary::prefixMatch( wstring const & word,

--- a/sdict.cc
+++ b/sdict.cc
@@ -143,43 +143,43 @@ class SdictDictionary: public BtreeIndexing::BtreeDictionary
 
     ~SdictDictionary();
 
-    virtual string getName() noexcept
+    string getName() noexcept override
     { return dictionaryName; }
 
-    virtual map< Dictionary::Property, string > getProperties() noexcept
+    map< Dictionary::Property, string > getProperties() noexcept override
     { return map< Dictionary::Property, string >(); }
 
-    virtual unsigned long getArticleCount() noexcept
+    unsigned long getArticleCount() noexcept override
     { return idxHeader.articleCount; }
 
-    virtual unsigned long getWordCount() noexcept
+    unsigned long getWordCount() noexcept override
     { return idxHeader.wordCount; }
 
-    inline virtual quint32 getLangFrom() const
+    inline quint32 getLangFrom() const override
     { return idxHeader.langFrom; }
 
-    inline virtual quint32 getLangTo() const
+    inline quint32 getLangTo() const override
     { return idxHeader.langTo; }
 
-    virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+    sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                         vector< wstring > const & alts,
                                                         wstring const &,
-                                                        bool ignoreDiacritics )
+                                                        bool ignoreDiacritics ) override
       ;
 
-    virtual QString const & getDescription();
+    QString const & getDescription() override;
 
-    virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+    sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                               int searchMode, bool matchCase,
                                                               int distanceBetweenWords,
                                                               int maxResults,
                                                               bool ignoreWordsOrder,
-                                                              bool ignoreDiacritics );
-    virtual void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+                                                              bool ignoreDiacritics ) override;
+    void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
-    virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+    void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-    virtual void setFTSParameters( Config::FullTextSearch const & fts )
+    void setFTSParameters( Config::FullTextSearch const & fts ) override
     {
       can_FTS = fts.enabled
                 && !fts.disabledTypes.contains( "SDICT", Qt::CaseInsensitive )
@@ -187,7 +187,7 @@ class SdictDictionary: public BtreeIndexing::BtreeDictionary
     }
 protected:
 
-    void loadIcon() noexcept;
+    void loadIcon() noexcept override;
 
 private:
 
@@ -500,7 +500,7 @@ public:
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class SdictArticleRequest: public Dictionary::DataRequest
@@ -528,7 +528,7 @@ public:
 
   void run(); // Run from another thread by DslArticleRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }

--- a/slob.cc
+++ b/slob.cc
@@ -587,63 +587,63 @@ class SlobDictionary: public BtreeIndexing::BtreeDictionary
 
     ~SlobDictionary();
 
-    virtual string getName() noexcept
+    string getName() noexcept override
     { return dictionaryName; }
 
-    virtual map< Dictionary::Property, string > getProperties() noexcept
+    map< Dictionary::Property, string > getProperties() noexcept override
     { return map< Dictionary::Property, string >(); }
 
-    virtual unsigned long getArticleCount() noexcept
+    unsigned long getArticleCount() noexcept override
     { return idxHeader.articleCount; }
 
-    virtual unsigned long getWordCount() noexcept
+    unsigned long getWordCount() noexcept override
     { return idxHeader.wordCount; }
 
-    inline virtual quint32 getLangFrom() const
+    inline quint32 getLangFrom() const override
     { return idxHeader.langFrom; }
 
-    inline virtual quint32 getLangTo() const
+    inline quint32 getLangTo() const override
     { return idxHeader.langTo; }
 
-    virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+    sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                         vector< wstring > const & alts,
                                                         wstring const &,
-                                                        bool ignoreDiacritics )
+                                                        bool ignoreDiacritics ) override
       ;
 
-    virtual sptr< Dictionary::DataRequest > getResource( string const & name )
+    sptr< Dictionary::DataRequest > getResource( string const & name ) override
       ;
 
-    virtual QString const& getDescription();
+    QString const& getDescription() override;
 
     /// Loads the resource.
     void loadResource( std::string &resourceName, string & data );
 
-    virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+    sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                               int searchMode, bool matchCase,
                                                               int distanceBetweenWords,
                                                               int maxResults,
                                                               bool ignoreWordsOrder,
-                                                              bool ignoreDiacritics );
-    virtual void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+                                                              bool ignoreDiacritics ) override;
+    void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
     quint64 getArticlePos(uint32_t articleNumber );
 
-    virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+    void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-    virtual void setFTSParameters( Config::FullTextSearch const & fts )
+    void setFTSParameters( Config::FullTextSearch const & fts ) override
     {
       can_FTS = fts.enabled
                 && !fts.disabledTypes.contains( "SLOB", Qt::CaseInsensitive )
                 && ( fts.maxDictionarySize == 0 || getArticleCount() <= fts.maxDictionarySize );
     }
 
-    virtual uint32_t getFtsIndexVersion()
+    uint32_t getFtsIndexVersion() override
     { return 2; }
 
 protected:
 
-    virtual void loadIcon() noexcept;
+    void loadIcon() noexcept override;
 
 private:
 
@@ -1329,7 +1329,7 @@ public:
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class SlobArticleRequest: public Dictionary::DataRequest
@@ -1357,7 +1357,7 @@ public:
 
   void run(); // Run from another thread by DslArticleRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
@@ -1518,7 +1518,7 @@ public:
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class SlobResourceRequest: public Dictionary::DataRequest
@@ -1545,7 +1545,7 @@ public:
 
   void run(); // Run from another thread by ZimResourceRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }

--- a/sounddir.cc
+++ b/sounddir.cc
@@ -79,30 +79,30 @@ public:
                       vector< string > const & dictionaryFiles,
                       QString const & iconFilename_ );
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return name; }
 
-  virtual map< Dictionary::Property, string > getProperties() noexcept
+  map< Dictionary::Property, string > getProperties() noexcept override
   { return map< Dictionary::Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return idxHeader.soundsCount; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return getArticleCount(); }
 
-  virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
-                                                      bool ignoreDiacritics )
+                                                      bool ignoreDiacritics ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getResource( string const & name )
+  sptr< Dictionary::DataRequest > getResource( string const & name ) override
     ;
 
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 };
 
 SoundDirDictionary::SoundDirDictionary( string const & id,

--- a/stardict.cc
+++ b/stardict.cc
@@ -158,51 +158,51 @@ public:
 
   ~StardictDictionary();
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return bookName; }
 
-  virtual map< Dictionary::Property, string > getProperties() noexcept
+  map< Dictionary::Property, string > getProperties() noexcept override
   { return map< Dictionary::Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return idxHeader.wordCount; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return idxHeader.wordCount + idxHeader.synWordCount; }
 
-  inline virtual quint32 getLangFrom() const
+  inline quint32 getLangFrom() const override
   { return idxHeader.langFrom; }
 
-  inline virtual quint32 getLangTo() const
+  inline quint32 getLangTo() const override
   { return idxHeader.langTo; }
 
-  virtual sptr< Dictionary::WordSearchRequest > findHeadwordsForSynonym( wstring const & )
+  sptr< Dictionary::WordSearchRequest > findHeadwordsForSynonym( wstring const & ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
-                                                      bool ignoreDiacritics )
+                                                      bool ignoreDiacritics ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getResource( string const & name )
+  sptr< Dictionary::DataRequest > getResource( string const & name ) override
     ;
 
-  virtual QString const& getDescription();
+  QString const& getDescription() override;
 
-  virtual QString getMainFilename();
+  QString getMainFilename() override;
 
-  virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+  sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                             int searchMode, bool matchCase,
                                                             int distanceBetweenWords,
                                                             int maxResults,
                                                             bool ignoreWordsOrder,
-                                                            bool ignoreDiacritics );
-  virtual void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+                                                            bool ignoreDiacritics ) override;
+  void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
-  virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+  void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-  virtual void setFTSParameters( Config::FullTextSearch const & fts )
+  void setFTSParameters( Config::FullTextSearch const & fts ) override
   {
     can_FTS = fts.enabled
               && !fts.disabledTypes.contains( "STARDICT", Qt::CaseInsensitive )
@@ -210,7 +210,7 @@ public:
   }
 protected:
 
-  void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 
 private:
 
@@ -1226,7 +1226,7 @@ public:
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class StardictHeadwordsRequest: public Dictionary::WordSearchRequest
@@ -1251,7 +1251,7 @@ public:
 
   void run(); // Run from another thread by StardictHeadwordsRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
@@ -1345,7 +1345,7 @@ public:
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class StardictArticleRequest: public Dictionary::DataRequest
@@ -1374,7 +1374,7 @@ public:
 
   void run(); // Run from another thread by StardictArticleRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
@@ -1639,7 +1639,7 @@ public:
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class StardictResourceRequest: public Dictionary::DataRequest
@@ -1666,7 +1666,7 @@ public:
 
   void run(); // Run from another thread by StardictResourceRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }

--- a/voiceengines.cc
+++ b/voiceengines.cc
@@ -44,30 +44,30 @@ public:
   {
   }
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return voiceEngine.name.toUtf8().data(); }
 
-  virtual map< Property, string > getProperties() noexcept
+  map< Property, string > getProperties() noexcept override
   { return map< Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return 0; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return 0; }
 
-  virtual sptr< WordSearchRequest > prefixMatch( wstring const & word,
-                                                 unsigned long maxResults )
+  sptr< WordSearchRequest > prefixMatch( wstring const & word,
+                                                 unsigned long maxResults ) override
     ;
 
-  virtual sptr< DataRequest > getArticle( wstring const &,
+  sptr< DataRequest > getArticle( wstring const &,
                                           vector< wstring > const & alts,
-                                          wstring const &, bool )
+                                          wstring const &, bool ) override
     ;
 
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 };
 
 sptr< WordSearchRequest > VoiceEnginesDictionary::prefixMatch( wstring const & /*word*/,

--- a/website.cc
+++ b/website.cc
@@ -54,33 +54,33 @@ public:
     dictionaryDescription = temp;
   }
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return name; }
 
-  virtual map< Property, string > getProperties() noexcept
+  map< Property, string > getProperties() noexcept override
   { return map< Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return 0; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return 0; }
 
-  virtual sptr< WordSearchRequest > prefixMatch( wstring const & word,
-                                                 unsigned long ) ;
+  sptr< WordSearchRequest > prefixMatch( wstring const & word,
+                                                 unsigned long ) override ;
 
-  virtual sptr< DataRequest > getArticle( wstring const &,
+  sptr< DataRequest > getArticle( wstring const &,
                                           vector< wstring > const & alts,
-                                          wstring const & context, bool )
+                                          wstring const & context, bool ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getResource( string const & name ) ;
+  sptr< Dictionary::DataRequest > getResource( string const & name ) override ;
 
   void isolateWebCSS( QString & css );
 
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 };
 
 sptr< WordSearchRequest > WebSiteDictionary::prefixMatch( wstring const & /*word*/,
@@ -112,11 +112,11 @@ public:
   ~WebSiteArticleRequest()
   {}
 
-  virtual void cancel();
+  void cancel() override;
 
 private:
 
-  virtual void requestFinished( QNetworkReply * );
+  void requestFinished( QNetworkReply * ) override;
   static QTextCodec * codecForHtml( QByteArray const & ba );
 };
 
@@ -429,11 +429,11 @@ public:
   ~WebSiteResourceRequest()
   {}
 
-  virtual void cancel();
+  void cancel() override;
 
 private:
 
-  virtual void requestFinished( QNetworkReply * );
+  void requestFinished( QNetworkReply * ) override;
 };
 
 WebSiteResourceRequest::WebSiteResourceRequest( QString const & url_,

--- a/xdxf.cc
+++ b/xdxf.cc
@@ -147,60 +147,60 @@ public:
 
   ~XdxfDictionary();
 
-  virtual string getName() noexcept
+  string getName() noexcept override
   { return dictionaryName; }
 
-  virtual map< Dictionary::Property, string > getProperties() noexcept
+  map< Dictionary::Property, string > getProperties() noexcept override
   { return map< Dictionary::Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return idxHeader.articleCount; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return idxHeader.wordCount; }
 
-  inline virtual quint32 getLangFrom() const
+  inline quint32 getLangFrom() const override
   { return idxHeader.langFrom; }
 
-  inline virtual quint32 getLangTo() const
+  inline quint32 getLangTo() const override
   { return idxHeader.langTo; }
 
-  virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
-                                                      bool ignoreDiacritics )
+                                                      bool ignoreDiacritics ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getResource( string const & name )
+  sptr< Dictionary::DataRequest > getResource( string const & name ) override
     ;
 
-  virtual QString const& getDescription();
+  QString const& getDescription() override;
 
-  virtual QString getMainFilename();
+  QString getMainFilename() override;
 
-  virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+  sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                             int searchMode, bool matchCase,
                                                             int distanceBetweenWords,
                                                             int maxResults,
                                                             bool ignoreWordsOrder,
-                                                            bool ignoreDiacritics );
-  virtual void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+                                                            bool ignoreDiacritics ) override;
+  void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
-  virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+  void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-  virtual void setFTSParameters( Config::FullTextSearch const & fts )
+  void setFTSParameters( Config::FullTextSearch const & fts ) override
   {
     can_FTS = fts.enabled
               && !fts.disabledTypes.contains( "XDXF", Qt::CaseInsensitive )
               && ( fts.maxDictionarySize == 0 || getArticleCount() <= fts.maxDictionarySize );
   }
 
-  virtual uint32_t getFtsIndexVersion()
+  uint32_t getFtsIndexVersion() override
   { return 1; }
 
 protected:
 
-  void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 
 private:
 
@@ -454,7 +454,7 @@ public:
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class XdxfArticleRequest: public Dictionary::DataRequest
@@ -482,7 +482,7 @@ public:
 
   void run(); // Run from another thread by XdxfArticleRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
@@ -700,22 +700,22 @@ protected:
 
   dictData *dz;
 
-  virtual bool isSequential () const
+  bool isSequential () const override
   { return false; } // Which is a lie, but else pos() won't work
 
-  bool waitForReadyRead ( int )
+  bool waitForReadyRead ( int ) override
   { return !gzeof( gz ); }
 
-  qint64 bytesAvailable() const
+  qint64 bytesAvailable() const override
   {
      return ( gzeof( gz ) ? 0 : 1 ) + QIODevice::bytesAvailable();
   }
 
-  virtual qint64 readData( char * data, qint64 maxSize );
+  qint64 readData( char * data, qint64 maxSize ) override;
 
-  virtual bool atEnd() const;
+  bool atEnd() const override;
 
-  virtual qint64 writeData ( const char * /*data*/, qint64 /*maxSize*/ )
+  qint64 writeData ( const char * /*data*/, qint64 /*maxSize*/ ) override
   { return -1; }
 };
 
@@ -983,7 +983,7 @@ public:
     hasExited.release();
   }
 
-  virtual void run();
+  void run() override;
 };
 
 class XdxfResourceRequest: public Dictionary::DataRequest
@@ -1010,7 +1010,7 @@ public:
 
   void run(); // Run from another thread by XdxfResourceRequestRunnable
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }

--- a/zim.cc
+++ b/zim.cc
@@ -180,7 +180,7 @@ public:
   ZimFile( const QString & name );
   ~ZimFile();
 
-  virtual void setFileName( const QString & name );
+  void setFileName( const QString & name ) override;
   bool open();
   void close()
   {
@@ -671,63 +671,63 @@ class ZimDictionary: public BtreeIndexing::BtreeDictionary
 
     ~ZimDictionary();
 
-    virtual string getName() noexcept
+    string getName() noexcept override
     { return dictionaryName; }
 
-    virtual map< Dictionary::Property, string > getProperties() noexcept
+    map< Dictionary::Property, string > getProperties() noexcept override
     { return map< Dictionary::Property, string >(); }
 
-    virtual unsigned long getArticleCount() noexcept
+    unsigned long getArticleCount() noexcept override
     { return idxHeader.articleCount; }
 
-    virtual unsigned long getWordCount() noexcept
+    unsigned long getWordCount() noexcept override
     { return idxHeader.wordCount; }
 
-    inline virtual quint32 getLangFrom() const
+    inline quint32 getLangFrom() const override
     { return idxHeader.langFrom; }
 
-    inline virtual quint32 getLangTo() const
+    inline quint32 getLangTo() const override
     { return idxHeader.langTo; }
 
-    virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+    sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                         vector< wstring > const & alts,
                                                         wstring const &,
-                                                        bool ignoreDiacritics )
+                                                        bool ignoreDiacritics ) override
       ;
 
-    virtual sptr< Dictionary::DataRequest > getResource( string const & name )
+    sptr< Dictionary::DataRequest > getResource( string const & name ) override
       ;
 
-    virtual QString const& getDescription();
+    QString const& getDescription() override;
 
     /// Loads the resource.
     void loadResource( std::string &resourceName, string & data );
 
-    virtual sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
+    sptr< Dictionary::DataRequest > getSearchResults( QString const & searchString,
                                                               int searchMode, bool matchCase,
                                                               int distanceBetweenWords,
                                                               int maxResults,
                                                               bool ignoreWordsOrder,
-                                                              bool ignoreDiacritics );
-    virtual void getArticleText( uint32_t articleAddress, QString & headword, QString & text );
+                                                              bool ignoreDiacritics ) override;
+    void getArticleText( uint32_t articleAddress, QString & headword, QString & text ) override;
 
     quint32 getArticleText( uint32_t articleAddress, QString & headword, QString & text,
                             set< quint32 > * loadedArticles );
 
-    virtual void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration );
+    void makeFTSIndex(QAtomicInt & isCancelled, bool firstIteration ) override;
 
-    virtual void setFTSParameters( Config::FullTextSearch const & fts )
+    void setFTSParameters( Config::FullTextSearch const & fts ) override
     {
       can_FTS = fts.enabled
                 && !fts.disabledTypes.contains( "ZIM", Qt::CaseInsensitive )
                 && ( fts.maxDictionarySize == 0 || getArticleCount() <= fts.maxDictionarySize );
     }
 
-    virtual void sortArticlesOffsetsForFTS( QVector< uint32_t > & offsets, QAtomicInt & isCancelled );
+    void sortArticlesOffsetsForFTS( QVector< uint32_t > & offsets, QAtomicInt & isCancelled ) override;
 
 protected:
 
-    virtual void loadIcon() noexcept;
+    void loadIcon() noexcept override;
 
 private:
 
@@ -1280,7 +1280,7 @@ public:
 
   void run();
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }
@@ -1452,7 +1452,7 @@ public:
 
   void run();
 
-  virtual void cancel()
+  void cancel() override
   {
     isCancelled.ref();
   }

--- a/zipsounds.cc
+++ b/zipsounds.cc
@@ -114,29 +114,29 @@ public:
   ZipSoundsDictionary( string const & id, string const & indexFile,
                        vector< string > const & dictionaryFiles );
 
-  virtual string getName() noexcept;
+  string getName() noexcept override;
 
-  virtual map< Dictionary::Property, string > getProperties() noexcept
+  map< Dictionary::Property, string > getProperties() noexcept override
   { return map< Dictionary::Property, string >(); }
 
-  virtual unsigned long getArticleCount() noexcept
+  unsigned long getArticleCount() noexcept override
   { return idxHeader.soundsCount; }
 
-  virtual unsigned long getWordCount() noexcept
+  unsigned long getWordCount() noexcept override
   { return getArticleCount(); }
 
-  virtual sptr< Dictionary::DataRequest > getArticle( wstring const &,
+  sptr< Dictionary::DataRequest > getArticle( wstring const &,
                                                       vector< wstring > const & alts,
                                                       wstring const &,
-                                                      bool ignoreDiacritics )
+                                                      bool ignoreDiacritics ) override
     ;
 
-  virtual sptr< Dictionary::DataRequest > getResource( string const & name )
+  sptr< Dictionary::DataRequest > getResource( string const & name ) override
     ;
 
 protected:
 
-  virtual void loadIcon() noexcept;
+  void loadIcon() noexcept override;
 };
 
 ZipSoundsDictionary::ZipSoundsDictionary( string const & id,


### PR DESCRIPTION
use the same technique as https://github.com/xiaoyifang/goldendict/pull/270

If the base class method is set to `virtual`, then the derived class should be `override`.

Using `virtual` for both the base class and derived class is a design flaw of C++98, however, switching to override won't change anything if they are already correct.

https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-override.html

https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c128-virtual-functions-should-specify-exactly-one-of-virtual-override-or-final