### PR TITLE
fix: reload all pages when articleview style changes

### DIFF
--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -2211,14 +2211,17 @@ void MainWindow::editPreferences()
     bool needReload = false;
 
     // See if we need to reapply Qt stylesheets
-    if ( cfg.preferences.addonStyle != p.addonStyle || cfg.preferences.darkMode != p.darkMode)
+    if( cfg.preferences.darkMode != p.darkMode )
     {
       applyQtStyleSheet( p.addonStyle, p.darkMode );
-      articleMaker.setDisplayStyle( p.displayStyle, p.addonStyle );
-      needReload = true;
     }
 
-    if (cfg.preferences.darkReaderMode != p.darkReaderMode) {
+    // see if we need to reapply articleview style
+    if( cfg.preferences.displayStyle != p.displayStyle ||
+      cfg.preferences.addonStyle != p.addonStyle ||
+      cfg.preferences.darkReaderMode != p.darkReaderMode )
+    {
+      articleMaker.setDisplayStyle( p.displayStyle, p.addonStyle );
       needReload = true;
     }
 


### PR DESCRIPTION
The previous code is broken because `articleMaker.setDisplayStyle` and `applyQtStyleSheet` used to be the bundled together. 

https://github.com/xiaoyifang/goldendict/pull/288 only fixes half of the problem 