### PR TITLE
replace dict group's hotkeyedit with qKeySequenceEdit

### DIFF
--- a/config.hh
+++ b/config.hh
@@ -157,8 +157,12 @@ struct HotKey
 
   HotKey();
 
-  /// We use the first two keys of QKeySequence, with modifiers being stored
-  /// in the first one.
+  /// Hotkey's constructor, take a QKeySequence's first two keys
+  /// 1st key's modifier will be the `modifiers` above
+  /// 1st key without modifier will becomes `key1`
+  /// 2nd key without modifier will becomes `key2`
+  /// The relation between the int and qt's KeyCode should consult qt's doc
+
   HotKey( QKeySequence const & );
 
   QKeySequence toKeySequence() const;

--- a/dictgroupwidget.ui
+++ b/dictgroupwidget.ui
@@ -19,6 +19,9 @@
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="spacing">
+      <number>3</number>
+     </property>
      <item>
       <widget class="QLabel" name="label">
        <property name="text">
@@ -75,7 +78,37 @@
       </widget>
      </item>
      <item>
-      <widget class="HotKeyEdit" name="shortcut"/>
+      <widget class="QKeySequenceEdit" name="shortcut">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>80</width>
+         <height>0</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="clearShortCut">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="icon">
+        <iconset resource="resources.qrc">
+         <normaloff>:/icons/clear.png</normaloff>:/icons/clear.png</iconset>
+       </property>
+       <property name="shortcut">
+        <string notr="true"/>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
@@ -101,14 +134,16 @@
    <extends>QListWidget</extends>
    <header>groups_widgets.hh</header>
   </customwidget>
-  <customwidget>
-   <class>HotKeyEdit</class>
-   <extends>QLineEdit</extends>
-   <header>hotkeyedit.hh</header>
-  </customwidget>
  </customwidgets>
  <resources>
   <include location="resources.qrc"/>
  </resources>
- <connections/>
+ <connections>
+  <connection>
+   <sender>clearShortCut</sender>
+   <signal>clicked()</signal>
+   <receiver>shortcut</receiver>
+   <slot>clear()</slot>
+  </connection>
+ </connections>
 </ui>

--- a/groups_widgets.cc
+++ b/groups_widgets.cc
@@ -33,6 +33,11 @@ DictGroupWidget::DictGroupWidget( QWidget * parent,
   ui.setupUi( this );
   ui.dictionaries->populate( Instances::Group( group, dicts, Config::Group() ).dictionaries, dicts );
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
+  ui.shortcut->setClearButtonEnabled(true);
+  ui.clearShortCut->hide();
+#endif
+
   // Populate icons' list
 
   QStringList icons = QDir( ":/flags/" ).entryList( QDir::Files, QDir::NoSort );
@@ -61,7 +66,7 @@ DictGroupWidget::DictGroupWidget( QWidget * parent,
   if ( usesIconData )
     ui.groupIcon->setCurrentIndex( 1 );
 
-  ui.shortcut->setHotKey( Config::HotKey( group.shortcut ) );
+  ui.shortcut->setKeySequence( group.shortcut );
 
   ui.favoritesFolder->setText( group.favoritesFolder );
 
@@ -126,7 +131,7 @@ Config::Group DictGroupWidget::makeGroup() const
 
   g.icon = ui.groupIcon->itemData( currentIndex ).toString();
 
-  g.shortcut = ui.shortcut->getHotKey().toKeySequence();
+  g.shortcut = ui.shortcut->keySequence();
 
   g.favoritesFolder = ui.favoritesFolder->text().replace( '\\', '/' );
 


### PR DESCRIPTION
Users can now set absurd shortcuts for group switching like this and it works.

![image](https://user-images.githubusercontent.com/20123683/209950014-4136809b-e96d-4694-9254-1b4846585869.png)

for qt6.4+
![image](https://user-images.githubusercontent.com/20123683/209951926-6a594727-da4f-4494-a85d-16d54896b12d.png)


see https://github.com/xiaoyifang/goldendict/issues/291
