### PR TITLE
fix: 'equals' built-in test function block

### DIFF
--- a/goldendict.pro
+++ b/goldendict.pro
@@ -673,8 +673,7 @@ TS_OUT = $$TRANSLATIONS
 TS_OUT ~= s/.ts/.qm/g
 PRE_TARGETDEPS += $$TS_OUT
 
-equals(QT_VERSION,6.4.0)
-{
+equals(QT_VERSION,6.4.0) {
     #QTBUG-105984
     multimedia.files = $$[QT_PLUGIN_PATH]/multimedia/*
     multimedia.path = plugins/multimedia

--- a/goldendict.pro
+++ b/goldendict.pro
@@ -62,6 +62,11 @@ DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x050F00
   DEFINES += MAKE_FFMPEG_PLAYER
 }
 
+contains(DEFINES, MAKE_QTMULTIMEDIA_PLAYER|MAKE_FFMPEG_PLAYER) {
+  HEADERS += audiooutput.h
+  SOURCES += audiooutput.cpp
+}
+
 # on windows platform ,only works in release build
 CONFIG( use_xapian ) {
   DEFINES += USE_XAPIAN
@@ -267,7 +272,6 @@ HEADERS += folding.hh \
     ankiconnector.h \
     article_inspect.h \
     articlewebpage.h \
-    audiooutput.h \
     base/globalregex.hh \
     base_type.h \
     globalbroadcaster.h \
@@ -413,7 +417,6 @@ SOURCES += folding.cc \
     ankiconnector.cpp \
     article_inspect.cpp \
     articlewebpage.cpp \
-    audiooutput.cpp \
     base/globalregex.cc \
     globalbroadcaster.cpp \
     headwordsmodel.cpp \


### PR DESCRIPTION
the opening brace must stand on the same line as the condition, otherwise the condition will be invalid.

---

and fix qtmultimedia dependency

audiooutput.cpp includes the QAudioFormat unconditionally, but it looks
like this file is only used by ffmpeg_player and qtmultimedia_player,
so add an extra condition to append this file and its header.