### PR TITLE
fix: reset background to white when darkreader mode is used

### DIFF
--- a/article_maker.cc
+++ b/article_maker.cc
@@ -160,6 +160,11 @@ std::string ArticleMaker::makeHtmlHeader( QString const & word,
     sepia: 10
   });
 </script>
+<style>
+body , .gdarticle {
+  background: white;
+}
+</style>
 )";
   }
   result += "</head><body>";


### PR DESCRIPTION
Fix one problem discussed at https://github.com/xiaoyifang/goldendict/issues/339

When dark reader is enabled:

Before:
![image](https://user-images.githubusercontent.com/20123683/218298352-2a62e141-be7e-466e-b7bb-1e71451426ee.png)
After:
![image](https://user-images.githubusercontent.com/20123683/218298364-3387d363-5b27-440b-89b0-e62fd759dc44.png)


