### PR TITLE
elimate makeScanPopup()

### DIFF
--- a/mainwindow.hh
+++ b/mainwindow.hh
@@ -154,7 +154,7 @@ private:
 
   WordFinder wordFinder;
 
-  sptr< ScanPopup > scanPopup;
+  ScanPopup * scanPopup;
 
   sptr< HotkeyWrapper > hotkeyWrapper;
 
@@ -206,7 +206,6 @@ private:
   void updateStatusLine();
   void updateGroupList();
   void updateDictionaryBar();
-  void makeScanPopup();
 
   void updatePronounceAvailability();
 
@@ -511,9 +510,6 @@ protected:
   unsigned gdAskMessage;
 public:
 
-private slots:
-  /// Return true while scanning GoldenDict window
-  bool isGoldenDictWindow( HWND hwnd );
 #endif
 };
 

--- a/scanpopup.hh
+++ b/scanpopup.hh
@@ -37,6 +37,9 @@ public:
 
   ~ScanPopup();
 
+  // update dictionary bar, group data and possibly other data
+  void refresh();
+
   /// Applies current zoom factor to the popup's view. Should be called when
   /// it's changed.
   void applyZoomFactor();


### PR DESCRIPTION
This PR is supposed to have absolutely no behaviour change.

Why?

In the original GD, the existence of object `ScanPopup` is a convoluted mess. It checks multiple factors, including `enable ScanPopup`, `toolbar's Scanpopup action checked`. `scanpopup hotkey enabled`.....

And it is OK to do so, but the later code is a mix of checking scanpop's existence `if(ScanPopup)` and other factors. If data related to ScanPopup changed, the old code just `reset()` ScanPopup then rebuild it with `makeScanPopup()`.

As a result, the old code goes insane, and I have no idea what's going on with the scanpopup, so during https://github.com/xiaoyifang/goldendict/pull/207 , the ScanPopup is changed to be a persist object that always exist (the memory consumption isn't increased noticeably).

---

This PR removes `makeScanPopup()` which is a code smell.

Main difference: ScanPopup is constructed only 1 time.
