### PR TITLE
fix: ensure #translateLine always have left border

### DIFF
--- a/src/qtstyle/qt-style.css
+++ b/src/qtstyle/qt-style.css
@@ -22,7 +22,6 @@
     padding: 1px 3px 1px 3px;
 
     border: 1px solid gray;
-    border-left: 0; /* When not in #searchPane the border-left is provided by GroupComboBox */
 
     border-radius: 3px;
     border-top-left-radius: 0;
@@ -44,6 +43,10 @@ GroupComboBox {
 
     background: palette(window); /* Distinguish the combobox from the translate line by make it darker*/
     color: palette(Text);
+}
+
+#navToolbar GroupComboBox {
+    border-right: 0; /* The right border is provided by translateLine when they are together */
 }
 
 #searchPane GroupComboBox{


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/20123683/220806071-709f0b2b-c693-49c5-8b5d-4609d18177dc.png)

After:

![image](https://user-images.githubusercontent.com/20123683/220806293-83cfb8da-286b-4a8f-aa1f-ab9533f4e8b5.png)

