### PR TITLE
fix: set initial background as black for dark reader mode

### DIFF
--- a/article_maker.cc
+++ b/article_maker.cc
@@ -151,8 +151,13 @@ std::string ArticleMaker::makeHtmlHeader( QString const & word,
 
   if( GlobalBroadcaster::instance()->getPreference()->darkReaderMode )
   {
+    // #242525 because Darkreader will invert pure white to this value
     result += R"(
 <script src="qrc:///scripts/darkreader.js"></script>
+<style>
+body { background: #242525; }
+.gdarticle { background: initial;}
+</style>
 <script>
   DarkReader.enable({
     brightness: 100,
@@ -160,11 +165,6 @@ std::string ArticleMaker::makeHtmlHeader( QString const & word,
     sepia: 10
   });
 </script>
-<style>
-body , .gdarticle {
-  background: white;
-}
-</style>
 )";
   }
   result += "</head><body>";


### PR DESCRIPTION
fix https://github.com/xiaoyifang/goldendict/issues/357

darkreader.js is not a simple colour inverter. Setting the initial background to Black instead of White should fix the problem.

(the value must be almost black, because darkreader.js won't adjust pure black.)

.gdarticle will be reset to no background (transparent)

![image](https://user-images.githubusercontent.com/20123683/221946376-8e8cec47-dfb0-4312-b444-cd5b2cce92a8.png)
