### PR TITLE
fix: enabled scanpopup at startup doesn't work

### DIFF
--- a/mainwindow.hh
+++ b/mainwindow.hh
@@ -415,8 +415,6 @@ private slots:
 
   void trayIconActivated( QSystemTrayIcon::ActivationReason );
 
-  void scanEnableToggled( bool );
-
   void setAutostart( bool );
 
   void showMainWindow();


### PR DESCRIPTION
fix https://github.com/xiaoyifang/goldendict/issues/361

main change:

From this line that only change UI widget's state:
```
enableScanningAction->setChecked( true );
```


to this that activate the action which change Both UI widget's state and setup scanning :
```
enableScanningAction->trigger();
```

