### PR TITLE
cleanup: Replace all usages of qrcx://localhost with qrc://

### DIFF
--- a/article-style-st-babylon.css
+++ b/article-style-st-babylon.css
@@ -73,19 +73,19 @@ h3 {
 }
 
 .gdexpandicon {
-    background-image: url('qrcx://localhost/icons/expand_article.png');
+    background-image: url('qrc:///icons/expand_article.png');
 }
 
 .gdexpandicon:hover {
-    background-image: url('qrcx://localhost/icons/expand_article_hovered.png');
+    background-image: url('qrc:///icons/expand_article_hovered.png');
 }
 
 .gdcollapseicon {
-    background-image: url('qrcx://localhost/icons/collapse_article.png');
+    background-image: url('qrc:///icons/collapse_article.png');
 }
 
 .gdcollapseicon:hover {
-    background-image: url('qrcx://localhost/icons/collapse_article_hovered.png');
+    background-image: url('qrc:///icons/collapse_article_hovered.png');
 }
 
 .bglpos { color: black; font-weight: bold; font-size: 11px; background: #F0EDED; display: inline; }

--- a/article-style-st-classic.css
+++ b/article-style-st-classic.css
@@ -93,7 +93,7 @@ pre
 .gderrordesc
 {
   font-style: italic;
-  background: url("qrcx://localhost/icons/warning.png") center left no-repeat !important;
+  background: url("qrc:///icons/warning.png") center left no-repeat !important;
   padding-left: 22px !important;
   margin: 1em;
 }
@@ -516,7 +516,7 @@ div.xdxf
 .dsl_video .img
 {
   display: inline-block;
-  background: url('qrcx://localhost/icons/video.png');
+  background: url('qrc:///icons/video.png');
   background-repeat: no-repeat;
   /* Ugly hack since "vertical-align: middle;" looks _terrible_ in Qt4's webkit: */
   vertical-align: -30%;
@@ -2909,7 +2909,7 @@ in bg url to hide it from iemac */
     width:16px;
     height:16px;
     vertical-align: text-bottom;
-    background-image:url('qrcx://localhost/icons/old-arrow.png');
+    background-image:url('qrc:///icons/old-arrow.png');
 }
 
 .gdcollapseicon {
@@ -2917,7 +2917,7 @@ in bg url to hide it from iemac */
     width:16px;
     height:16px;
     vertical-align: text-bottom;
-    background-image:url('qrcx://localhost/icons/old-downarrow.png');
+    background-image:url('qrc:///icons/old-downarrow.png');
 }
 
 /********** Slob dictionaries ***********/

--- a/article-style-st-lingoes-blue.css
+++ b/article-style-st-lingoes-blue.css
@@ -108,19 +108,19 @@ a:hover {
 }
 
 .gdexpandicon {
-    background-image: url('qrcx://localhost/icons/expand_article.png');
+    background-image: url('qrc:///icons/expand_article.png');
 }
 
 .gdexpandicon:hover {
-    background-image: url('qrcx://localhost/icons/expand_article_hovered.png');
+    background-image: url('qrc:///icons/expand_article_hovered.png');
 }
 
 .gdcollapseicon {
-    background-image: url('qrcx://localhost/icons/collapse_article.png');
+    background-image: url('qrc:///icons/collapse_article.png');
 }
 
 .gdcollapseicon:hover {
-    background-image: url('qrcx://localhost/icons/collapse_article_hovered.png');
+    background-image: url('qrc:///icons/collapse_article_hovered.png');
 }
 
 .gdarticleseparator {

--- a/article-style-st-lingoes.css
+++ b/article-style-st-lingoes.css
@@ -78,19 +78,19 @@ body
 
 
 .gdexpandicon {
-  background-image: url('qrcx://localhost/icons/expand_article.png');
+  background-image: url('qrc:///icons/expand_article.png');
 }
 
 .gdexpandicon:hover {
-  background-image: url('qrcx://localhost/icons/expand_article_hovered.png');
+  background-image: url('qrc:///icons/expand_article_hovered.png');
 }
 
 .gdcollapseicon {
-  background-image: url('qrcx://localhost/icons/collapse_article.png');
+  background-image: url('qrc:///icons/collapse_article.png');
 }
 
 .gdcollapseicon:hover {
-  background-image: url('qrcx://localhost/icons/collapse_article_hovered.png');
+  background-image: url('qrc:///icons/collapse_article_hovered.png');
 }
 
 .gddictnamebodyseparator

--- a/article-style-st-modern.css
+++ b/article-style-st-modern.css
@@ -138,19 +138,19 @@ a:hover
 }
 
 .gdexpandicon {
-    background-image: url('qrcx://localhost/icons/expand_article.png');
+    background-image: url('qrc:///icons/expand_article.png');
 }
 
 .gdexpandicon:hover {
-    background-image: url('qrcx://localhost/icons/expand_article_hovered.png');
+    background-image: url('qrc:///icons/expand_article_hovered.png');
 }
 
 .gdcollapseicon {
-    background-image: url('qrcx://localhost/icons/collapse_article.png');
+    background-image: url('qrc:///icons/collapse_article.png');
 }
 
 .gdcollapseicon:hover {
-    background-image: url('qrcx://localhost/icons/collapse_article_hovered.png');
+    background-image: url('qrc:///icons/collapse_article_hovered.png');
 }
 
 /* The first headword in a (possibly) multi-headword DSL article */

--- a/article-style.css
+++ b/article-style.css
@@ -98,7 +98,7 @@ pre
 .gderrordesc
 {
   font-style: italic;
-  background: url("qrcx://localhost/icons/warning.png") center left no-repeat !important;
+  background: url("qrc:///icons/warning.png") center left no-repeat !important;
   padding-left: 22px !important;
   margin: 1em;
 }
@@ -522,7 +522,7 @@ div.xdxf
 .dsl_video .img
 {
   display: inline-block;
-  background: url('qrcx://localhost/icons/video.png');
+  background: url('qrc:///icons/video.png');
   background-repeat: no-repeat;
   /* Ugly hack since "vertical-align: middle;" looks _terrible_ in Qt4's webkit: */
   vertical-align: -30%;

--- a/article_maker.cc
+++ b/article_maker.cc
@@ -134,7 +134,7 @@ std::string ArticleMaker::makeHtmlHeader( QString const & word,
   // This doesn't seem to be much of influence right now, but we'll keep
   // it anyway.
   if ( icon.size() )
-    result += R"(<link rel="icon" type="image/png" href="qrcx://localhost/flags/)" + Html::escape( icon.toUtf8().data() ) + "\" />\n";
+    result += R"(<link rel="icon" type="image/png" href="qrc:///flags/)" + Html::escape( icon.toUtf8().data() ) + "\" />\n";
 
   result += "<script type=\"text/javascript\">"
             "function tr(key) {"
@@ -676,7 +676,7 @@ void ArticleRequest::bodyFinished()
           + R"(/dicticon.png"></span><span class="gdfromprefix">)"  +
           Html::escape( tr( "From " ).toUtf8().data() ) + "</span><span class=\"gddicttitle\">" +
           Html::escape( activeDict->getName().c_str() ) + "</span>"
-          + R"(<span class="collapse_expand_area"><img src="qrcx://localhost/icons/blank.png" class=")"
+          + R"(<span class="collapse_expand_area"><img src="qrc:///icons/blank.png" class=")"
           + ( collapse ? "gdexpandicon" : "gdcollapseicon" )
           + "\" id=\"expandicon-" + Html::escape( dictId ) + "\""
           + ( collapse ? "" : string( " title=\"" ) + tr( "Collapse article" ).toUtf8().data() + "\"" )

--- a/article_netmgr.cc
+++ b/article_netmgr.cc
@@ -146,8 +146,13 @@ QNetworkReply * ArticleNetworkAccessManager::getArticleReply( QNetworkRequest co
   {
     if ( req.url().scheme() == "qrcx" )
     {
-      // We have to override the local load policy for the qrc scheme, hence
-      // we use qrcx and redirect it here back to qrc
+    // We had to override the local load policy for the qrc URL scheme until QWebSecurityOrigin::addLocalScheme() was
+    // introduced in Qt 4.6. Hence we used a custom qrcx URL scheme and redirected it here back to qrc. Qt versions
+    // older than 4.6 are no longer supported, so GoldenDict itself no longer uses the qrcx scheme. However, qrcx has
+    // been used for many years in our built-in article styles, and so may appear in user-defined article styles.
+    // TODO: deprecate (print a warning or show a warning message box) and eventually remove support for the obsolete
+    // qrcx URL scheme. A recent commit "Add support for qrc:// URL scheme" is the first one where the qrc scheme
+    // works correctly. So the deprecation has to wait until older GoldenDict versions become rarely used.
       QUrl newUrl( req.url() );
 
       newUrl.setScheme( "qrc" );

--- a/dsl.cc
+++ b/dsl.cc
@@ -869,7 +869,7 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
 
       result += addAudioLink( ref, getId() );
 
-      result += "<span class=\"dsl_s_wav\"><a href=" + ref + R"(><img src="qrcx://localhost/icons/playsound.png" border="0" align="absmiddle" alt="Play"/></a></span>)";
+      result += "<span class=\"dsl_s_wav\"><a href=" + ref + R"(><img src="qrc:///icons/playsound.png" border="0" align="absmiddle" alt="Play"/></a></span>)";
     }
     else
     if ( Filetype::isNameOfPicture( filename ) )
@@ -1698,7 +1698,7 @@ void DslArticleRequest::run()
         string prefix = "O" + dict.getId().substr( 0, 7 ) + "_" + QString::number( dict.articleNom ).toStdString();
         string id1 = prefix + "_expand";
         string id2 = prefix + "_opt_";
-        string button = R"( <img src="qrcx://localhost/icons/expand_opt.png" class="hidden_expand_opt" id=")" + id1 +
+        string button = R"( <img src="qrc:///icons/expand_opt.png" class="hidden_expand_opt" id=")" + id1 +
                         "\" onclick=\"gdExpandOptPart('" + id1 + "','" + id2 +"')\" alt=\"[+]\"/>";
         if( articleText.compare( articleText.size() - 4, 4, "</p>" ) == 0 )
           articleText.insert( articleText.size() - 4, " " + button );

--- a/epwing_book.cc
+++ b/epwing_book.cc
@@ -1451,7 +1451,7 @@ QByteArray EpwingBook::handleWave( EB_Hook_Code code, const unsigned int * argv 
 {
 
   if( code == EB_HOOK_END_WAVE )
-    return QByteArray( R"(<img src="qrcx://localhost/icons/playsound.png" border="0" align="absmiddle" alt="Play"/></a></span>)" );
+    return QByteArray( R"(<img src="qrc:///icons/playsound.png" border="0" align="absmiddle" alt="Play"/></a></span>)" );
 
   // Handle EB_HOOK_BEGIN_WAVE
 

--- a/forvo.cc
+++ b/forvo.cc
@@ -269,7 +269,7 @@ void ForvoArticleRequest::requestFinished( QNetworkReply * r )
                 string addTime =
                     tr( "Added %1" ).arg( item.namedItem( "addtime" ).toElement().text() ).toUtf8().data();
 
-                articleBody += "<td><a href=" + ref + " title=\"" + Html::escape( addTime ) + R"("><img src="qrcx://localhost/icons/playsound.png" border="0" alt="Play"/></a></td>)";
+                articleBody += "<td><a href=" + ref + " title=\"" + Html::escape( addTime ) + R"("><img src="qrc:///icons/playsound.png" border="0" alt="Play"/></a></td>)";
                 articleBody += string( "<td>" ) + tr( "by" ).toUtf8().data() + " <a class='forvo_user' href='"
                                + userProfile + "'>"
                                + Html::escape( user.toUtf8().data() )
@@ -278,7 +278,7 @@ void ForvoArticleRequest::requestFinished( QNetworkReply * r )
                                + " "
                                + tr( "from" ).toUtf8().data()
                                + " "
-                               + "<img src='qrcx://localhost/flags/" + Country::englishNametoIso2( country ).toUtf8().data()
+                               + "<img src='qrc:///flags/" + Country::englishNametoIso2( country ).toUtf8().data()
                                + ".png'/> "
                                + Html::escape( country.toUtf8().data() )
                                + ")</span>"

--- a/gls.cc
+++ b/gls.cc
@@ -828,7 +828,7 @@ QString & GlsDictionary::filterResource( QString & article )
       QString newTag = QString::fromUtf8( ( addAudioLink( href, getId() ) + "<span class=\"gls_wav\"><a href=" + href + ">" ).c_str() );
       newTag += match.captured( 4 );
       if( match.captured( 4 ).indexOf( "<img " ) < 0 )
-        newTag += R"( <img src="qrcx://localhost/icons/playsound.png" border="0" alt="Play">)";
+        newTag += R"( <img src="qrc:///icons/playsound.png" border="0" alt="Play">)";
       newTag += "</a></span>";
 
       articleNewText += newTag;

--- a/lsa.cc
+++ b/lsa.cc
@@ -286,7 +286,7 @@ sptr< Dictionary::DataRequest > LsaDictionary::getArticle( wstring const & word,
 
     result += addAudioLink( ref, getId() );
 
-    result += "<td><a href=" + ref + R"(><img src="qrcx://localhost/icons/playsound.png" border="0" alt="Play"/></a></td>)";
+    result += "<td><a href=" + ref + R"(><img src="qrc:///icons/playsound.png" border="0" alt="Play"/></a></td>)";
     result += "<td><a href=" + ref + ">" + i->second + "</a></td>";
     result += "</tr>";
   }
@@ -304,7 +304,7 @@ sptr< Dictionary::DataRequest > LsaDictionary::getArticle( wstring const & word,
 
     result += addAudioLink( ref, getId() );
 
-    result += "<td><a href=" + ref + R"(><img src="qrcx://localhost/icons/playsound.png" border="0" alt="Play"/></a></td>)";
+    result += "<td><a href=" + ref + R"(><img src="qrc:///icons/playsound.png" border="0" alt="Play"/></a></td>)";
     result += "<td><a href=" + ref + ">" + i->second + "</a></td>";
     result += "</tr>";
   }

--- a/mediawiki.cc
+++ b/mediawiki.cc
@@ -570,7 +570,7 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
               {
                 QString ref = match2.captured( 1 );
                 QString audio_url = "<a href=\"" + ref
-                                    + R"("><img src="qrcx://localhost/icons/playsound.png" border="0" align="absmiddle" alt="Play"/></a>)";
+                                    + R"("><img src="qrc:///icons/playsound.png" border="0" align="absmiddle" alt="Play"/></a>)";
                 articleNewString += audio_url;
               }
               else

--- a/programs.cc
+++ b/programs.cc
@@ -96,7 +96,7 @@ sptr< Dictionary::DataRequest > ProgramsDictionary::getArticle(
 
       result += addAudioLink( ref, getId() );
 
-      result += "<td><a href=" + ref + R"(><img src="qrcx://localhost/icons/playsound.png" border="0" alt="Play"/></a></td>)";
+      result += "<td><a href=" + ref + R"(><img src="qrc:///icons/playsound.png" border="0" alt="Play"/></a></td>)";
       result += "<td><a href=" + ref + ">" +
                 Html::escape( wordUtf8 ) + "</a></td>";
       result += "</tr></table>";

--- a/scripts/gd-builtin.js
+++ b/scripts/gd-builtin.js
@@ -53,7 +53,7 @@ function gdExpandOptPart(expanderId, optionalId) {
     var i = 0
     if (d1.alt == '[+]') {
         d1.alt = '[-]'
-        d1.src = 'qrcx://localhost/icons/collapse_opt.png'
+        d1.src = 'qrc:///icons/collapse_opt.png'
         for (i = 0; i < 1000; i++) {
             var d2 = document.getElementById(optionalId + i)
             if (!d2)
@@ -62,7 +62,7 @@ function gdExpandOptPart(expanderId, optionalId) {
         }
     } else {
         d1.alt = '[+]'
-        d1.src = 'qrcx://localhost/icons/expand_opt.png'
+        d1.src = 'qrc:///icons/expand_opt.png'
         for (i = 0; i < 1000; i++) {
             var d2 = document.getElementById(optionalId + i)
             if (!d2)

--- a/sounddir.cc
+++ b/sounddir.cc
@@ -228,7 +228,7 @@ sptr< Dictionary::DataRequest > SoundDirDictionary::getArticle( wstring const & 
 
     result += addAudioLink( ref, getId() );
 
-    result += "<td><a href=" + ref + R"(><img src="qrcx://localhost/icons/playsound.png" border="0" alt="Play"/></a></td>)";
+    result += "<td><a href=" + ref + R"(><img src="qrc:///icons/playsound.png" border="0" alt="Play"/></a></td>)";
     result += "<td><a href=" + ref + ">" + Html::escape( displayedName ) + "</a></td>";
     result += "</tr>";
   }
@@ -272,7 +272,7 @@ sptr< Dictionary::DataRequest > SoundDirDictionary::getArticle( wstring const & 
 
     result += addAudioLink( ref, getId() );
 
-    result += "<td><a href=" + ref + R"(><img src="qrcx://localhost/icons/playsound.png" border="0" alt="Play"/></a></td>)";
+    result += "<td><a href=" + ref + R"(><img src="qrc:///icons/playsound.png" border="0" alt="Play"/></a></td>)";
     result += "<td><a href=" + ref + ">" + Html::escape( displayedName ) + "</a></td>";
     result += "</tr>";
   }

--- a/src/dict/lingualibre.cpp
+++ b/src/dict/lingualibre.cpp
@@ -474,7 +474,7 @@ void LinguaArticleRequest::requestFinished( QNetworkReply * r )
       articleBody += R"(<a href=")";
       articleBody += audiolink;
       articleBody += R"(">)";
-      articleBody += R"(<img src="qrcx://localhost/icons/playsound.png" border="0" alt="Play"/>)";
+      articleBody += R"(<img src="qrc:///icons/playsound.png" border="0" alt="Play"/>)";
       articleBody += title;
       articleBody += "</a><br>";
     }

--- a/stardict.cc
+++ b/stardict.cc
@@ -549,7 +549,7 @@ string StardictDictionary::handleResource( char type, char const * resource, siz
           newTag += match.captured( 4 );
           if( match.captured( 4 ).indexOf( "<img " ) < 0 )
 
-            newTag += R"( <img src="qrcx://localhost/icons/playsound.png" border="0" alt="Play">)";
+            newTag += R"( <img src="qrc:///icons/playsound.png" border="0" alt="Play">)";
           newTag += "</a></span>";
 
           articleNewText += newTag;

--- a/voiceengines.cc
+++ b/voiceengines.cc
@@ -100,7 +100,7 @@ sptr< Dictionary::DataRequest > VoiceEnginesDictionary::getArticle(
   string ref = string( "\"" ) + encodedUrl + "\"";
   result += addAudioLink( ref, getId() );
 
-  result += "<td><a href=" + ref + R"(><img src="qrcx://localhost/icons/playsound.png" border="0" alt="Play"/></a></td>)";
+  result += "<td><a href=" + ref + R"(><img src="qrc:///icons/playsound.png" border="0" alt="Play"/></a></td>)";
   result += "<td><a href=" + ref + ">" + Html::escape( wordUtf8 ) + "</a></td>";
   result += "</tr></table>";
 

--- a/xdxf2html.cc
+++ b/xdxf2html.cc
@@ -693,7 +693,7 @@ string convert( string const & in, DICT_TYPE type, map < string, string > const 
             el_span.appendChild( el_a );
 
             QDomElement el_img = dd.createElement( "img");
-            el_img.setAttribute( "src", "qrcx://localhost/icons/playsound.png" );
+            el_img.setAttribute( "src", "qrc:///icons/playsound.png" );
             el_img.setAttribute( "border", "0" );
             el_img.setAttribute( "align", "absmiddle" );
             el_img.setAttribute( "alt", "Play" );

--- a/zipsounds.cc
+++ b/zipsounds.cc
@@ -279,7 +279,7 @@ sptr< Dictionary::DataRequest > ZipSoundsDictionary::getArticle( wstring const &
 
     result += addAudioLink( ref, getId() );
 
-    result += "<td><a href=" + ref + R"(><img src="qrcx://localhost/icons/playsound.png" border="0" alt="Play"/></a></td>)";
+    result += "<td><a href=" + ref + R"(><img src="qrc:///icons/playsound.png" border="0" alt="Play"/></a></td>)";
     result += "<td><a href=" + ref + ">" + Html::escape( displayedName ) + "</a></td>";
     result += "</tr>";
   }
@@ -325,7 +325,7 @@ sptr< Dictionary::DataRequest > ZipSoundsDictionary::getArticle( wstring const &
 
     result += addAudioLink( ref, getId() );
 
-    result += "<td><a href=" + ref + R"(><img src="qrcx://localhost/icons/playsound.png" border="0" alt="Play"/></a></td>)";
+    result += "<td><a href=" + ref + R"(><img src="qrc:///icons/playsound.png" border="0" alt="Play"/></a></td>)";
     result += "<td><a href=" + ref + ">" + Html::escape( displayedName ) + "</a></td>";
     result += "</tr>";
   }


### PR DESCRIPTION
Mostly from @vedgy's fork

https://github.com/goldendict/goldendict/commit/c415cede8509b1bc431fbda81f681c95be0281e0
https://github.com/goldendict/goldendict/commit/bb06509582c9a1ab342f5b79c85c3e28a26b19bc

ALL qrcx://localhost were used to fetch some pictures. 

The `qrcx` is just `qrc` but with extra steps

https://github.com/xiaoyifang/goldendict/blob/2404a5d34118b47eb3b8ca6fe0828305f697c1c3/article_netmgr.cc#L147-L159