### PR TITLE
fix: delete scanPopup before others

### DIFF
--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -1101,6 +1101,7 @@ MainWindow::~MainWindow()
 #ifndef NO_EPWING_SUPPORT
   Epwing::finalize();
 #endif
+  delete scanPopup;
 }
 
 void MainWindow::addGlobalAction( QAction * action, const char * slot )


### PR DESCRIPTION
After yesterday's change, the scanPopup will be deleted when destroying Mainwindow (when quitting the app). However, the ordering of deletion seems undefined. The `audioPlayer` is gone before `scanPopup`. The app will quit, but with `Process finished with exit code 139 (interrupted by signal 11: SIGSEGV)
`.

I marked important lines with `>`

```
> ArticleView::~ArticleView articleview.cc:384
ArticleView::~ArticleView articleview.cc:388
QObjectPrivate::deleteChildren() 0x00007fffec1716fa
QWidget::~QWidget() 0x00007fffecfa3851
QFrame::~QFrame() 0x00007fffed041c1e
QObjectPrivate::deleteChildren() 0x00007fffec1716fa
QWidget::~QWidget() 0x00007fffecfa3851
QWidget::~QWidget() 0x00007fffecfa389e
QObjectPrivate::deleteChildren() 0x00007fffec1716fa
QWidget::~QWidget() 0x00007fffecfa3851
> ScanPopup::~ScanPopup scanpopup.cc:329
ScanPopup::~ScanPopup scanpopup.cc:329
QObjectPrivate::deleteChildren() 0x00007fffec1716fa
QWidget::~QWidget() 0x00007fffecfa3851
> MainWindow::~MainWindow mainwindow.cc:1104
main main.cc:446
<unknown> 0x00007fffea43c790
__libc_start_main 0x00007fffea43c84a
_start 0x00005555555c9795
```

https://github.com/xiaoyifang/goldendict/issues/371