### PR TITLE
fix: better QObject hierarchy

### DIFF
--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -770,7 +770,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   applyQtStyleSheet( cfg.preferences.addonStyle, cfg.preferences.displayStyle, cfg.preferences.darkMode );
 
   // Scanpopup related
-  scanPopup = new ScanPopup(this, cfg, articleNetMgr, audioPlayerFactory.player(),
+  scanPopup = new ScanPopup(nullptr, cfg, articleNetMgr, audioPlayerFactory.player(),
     dictionaries, groupInstances, history );
 
   scanPopup->setStyleSheet(styleSheet());
@@ -795,7 +795,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   connect( scanPopup, &ScanPopup::isWordPresentedInFavorites, this, &MainWindow::isWordPresentedInFavorites );
 
 #ifdef Q_OS_MAC
-  macClipboard = new gd_clipboard();
+  macClipboard = new gd_clipboard(this);
   connect(macClipboard, &gd_clipboard::changed, this, &MainWindow::clipboardChange );
 #endif
 


### PR DESCRIPTION
see https://github.com/xiaoyifang/goldendict/pull/375#issuecomment-1459087832

fix https://github.com/xiaoyifang/goldendict/issues/376

We don't need to worry about scanpopup having no parent.

The Mainwindow has a nullptr parent too, and there is no need to explictly delete it. https://doc.qt.io/qt-6/qmainwindow.html#QMainWindow


See end of `main.cc`:
<img width="500" alt="end" src="https://user-images.githubusercontent.com/20123683/223911932-62dd9b16-63e5-4f7e-b5ff-973134b0e40a.png">
