### PR TITLE
feature: epwing dictionary reference navigation improved.

### DIFF
--- a/base/globalregex.cc
+++ b/base/globalregex.cc
@@ -66,3 +66,6 @@ QRegularExpression Mdx::styleElment( R"((<style[^>]*>)([\w\W]*?)(<\/style>))",
 
 
 QRegularExpression Zim::linkSpecialChar("[\\.\\/]");
+
+
+QRegularExpression Epwing::refWord(R"([r|p](\d+)at(\d+))", QRegularExpression::CaseInsensitiveOption);

--- a/base/globalregex.hh
+++ b/base/globalregex.hh
@@ -50,6 +50,11 @@ class Zim{
   static QRegularExpression linkSpecialChar;
 };
 
+class Epwing{
+ public:
+  static QRegularExpression refWord;
+};
+
 } // namespace RX
 
 #endif // GLOBALREGEX_HH

--- a/epwing_book.hh
+++ b/epwing_book.hh
@@ -100,6 +100,9 @@ class EpwingBook
 
   // Retrieve article text from dictionary
   QString getText( int page, int offset, bool text_only);
+  void seekBookThrow( int page, int offset );
+  QString getTextWithLength( int page, int offset, int total, EB_Position & pos );
+  QString getPreviousTextWithLength( int page, int offset, int total, EB_Position & pos );
 
   unsigned int normalizeDecorationCode( unsigned int code );
 
@@ -196,7 +199,11 @@ public:
   // Retrieve article from dictionary
   void getArticle( QString & headword, QString & articleText,
                    int page, int offset, bool text_only );
+  void readHeadword( QString & headword, bool text_only);
 
+  EB_Position getArticleNextPage( QString & headword, QString & articleText,
+    int page, int offset, bool text_only );
+  EB_Position getArticlePreviousPage( QString & headword, QString & articleText, int page, int offset, bool text_only );
   const char * beginDecoration( unsigned int code );
   const char * endDecoration( unsigned int code );
 

--- a/locale/zh_CN.ts
+++ b/locale/zh_CN.ts
@@ -4564,6 +4564,16 @@ from Stardict, Babylon and GLS dictionaries</source>
         <source>anki: post to anki failed</source>
         <translation>anki:发布失败</translation>
     </message>
+    <message>
+        <location filename="../epwing.cc" line="337"/>
+        <source>Previous Page</source>
+        <translation>上一页</translation>
+    </message>
+    <message>
+        <location filename="../epwing.cc" line="373"/>
+        <source>Next Page</source>
+        <translation>下一页</translation>
+    </message>
 </context>
 <context>
     <name>QuickFilterLine</name>


### PR DESCRIPTION
Ｅｐｗｉｎｇ　is designed for ebook. used as dictionary is not quite supported.

epwing use ref links to navigate to **any place** in the ebook .  the place may not a a dictionary headword.

before this commit:
reference in some dictionaries has the following effect.
![image](https://user-images.githubusercontent.com/105986/224531870-0ae03d33-db38-46b8-b326-c091fa611022.png)

after:
![image](https://user-images.githubusercontent.com/105986/226083767-41031f3c-cab0-4bed-ae9f-e5248cd12419.png)

compared to ebwin
![image](https://user-images.githubusercontent.com/105986/224543904-7e773458-a669-4aa7-b9d0-dfa7233de1ce.png)
