### PR TITLE
Let the user disable main window stealing focus when searching.

### DIFF
--- a/config.cc
+++ b/config.cc
@@ -222,70 +222,70 @@ InputPhrase Preferences::sanitizeInputPhrase( QString const & inputPhrase ) cons
 }
 
 Preferences::Preferences():
-    newTabsOpenAfterCurrentOne( false ),
-    newTabsOpenInBackground( true ),
-    hideSingleTab( false ),
-    mruTabOrder( false ),
-    hideMenubar( false ),
-    enableTrayIcon( true ),
-    startToTray( false ),
-    closeToTray( true ),
-    autoStart( false ),
-    doubleClickTranslates( true ),
-    selectWordBySingleClick( false ),
-    autoScrollToTargetArticle( true ),
-    escKeyHidesMainWindow( false ),
-    darkMode( false ),
-    darkReaderMode( false ),
-    alwaysOnTop( false ),
-    searchInDock( false ),
+  newTabsOpenAfterCurrentOne( false ),
+  newTabsOpenInBackground( true ),
+  hideSingleTab( false ),
+  mruTabOrder ( false ),
+  hideMenubar( false ),
+  enableTrayIcon( true ),
+  startToTray( false ),
+  closeToTray( true ),
+  autoStart( false ),
+  doubleClickTranslates( true ),
+  selectWordBySingleClick( false ),
+  autoScrollToTargetArticle( true ),
+  escKeyHidesMainWindow( false ),
+  darkMode( false ),
+  darkReaderMode ( false ),
+  alwaysOnTop ( false ),
+  searchInDock ( false ),
 
-    enableMainWindowHotkey( true ),
-    mainWindowHotkey( QKeySequence( "Ctrl+F11,F11" ) ),
-    enableClipboardHotkey( true ),
-    clipboardHotkey( QKeySequence( "Ctrl+C,C" ) ),
+  enableMainWindowHotkey( true ),
+  mainWindowHotkey( QKeySequence( "Ctrl+F11,F11" ) ),
+  enableClipboardHotkey( true ),
+  clipboardHotkey( QKeySequence( "Ctrl+C,C" ) ),
 
-    startWithScanPopupOn( false ),
-    enableScanPopupModifiers( false ),
-    scanPopupModifiers( 0 ),
-    ignoreOwnClipboardChanges( false ),
-    scanToMainWindow( false ),
-    ignoreDiacritics( false ),
-    ignorePunctuation( false ),
+  startWithScanPopupOn( false ),
+  enableScanPopupModifiers( false ),
+  scanPopupModifiers( 0 ),
+  ignoreOwnClipboardChanges( false ),
+  scanToMainWindow( false ),
+  ignoreDiacritics( false ),
+  ignorePunctuation( false ),
 #ifdef HAVE_X11
-    // Enable both Clipboard and Selection by default so that X users can enjoy full
-    // power and disable optionally.
-    trackClipboardScan( true ),
-    trackSelectionScan( true ),
-    showScanFlag( false ),
+  // Enable both Clipboard and Selection by default so that X users can enjoy full
+  // power and disable optionally.
+  trackClipboardScan ( true ),
+  trackSelectionScan ( true ),
+  showScanFlag( false ),
 #endif
-    pronounceOnLoadMain( false ),
-    pronounceOnLoadPopup( false ),
-    useInternalPlayer( InternalPlayerBackend::anyAvailable() ),
-    internalPlayerBackend( InternalPlayerBackend::defaultBackend() ),
-    checkForNewReleases( true ),
-    disallowContentFromOtherSites( false ),
-    enableWebPlugins( false ),
-    hideGoldenDictHeader( false ),
-    maxNetworkCacheSize( 50 ),
-    clearNetworkCacheOnExit( true ),
-    zoomFactor( 1 ),
-    helpZoomFactor( 1 ),
-    wordsZoomLevel( 0 ),
-    maxStringsInHistory( 500 ),
-    storeHistory( 1 ),
-    alwaysExpandOptionalParts( false ),
-    historyStoreInterval( 0 ),
-    favoritesStoreInterval( 0 ),
-    confirmFavoritesDeletion( true ),
-    collapseBigArticles( false ),
-    articleSizeLimit( 2000 ),
-    limitInputPhraseLength( false ),
-    inputPhraseLengthLimit( 1000 ),
-    maxDictionaryRefsInContextMenu( 20 ),
-    synonymSearchEnabled( true ),
-    stripClipboard( false ),
-    raiseWindowOnSearch( true )
+  pronounceOnLoadMain( false ),
+  pronounceOnLoadPopup( false ),
+  useInternalPlayer( InternalPlayerBackend::anyAvailable() ),
+  internalPlayerBackend( InternalPlayerBackend::defaultBackend() ),
+  checkForNewReleases( true ),
+  disallowContentFromOtherSites( false ),
+  enableWebPlugins( false ),
+  hideGoldenDictHeader( false ),
+  maxNetworkCacheSize( 50 ),
+  clearNetworkCacheOnExit( true ),
+  zoomFactor( 1 ),
+  helpZoomFactor( 1 ),
+  wordsZoomLevel( 0 ),
+  maxStringsInHistory( 500 ),
+  storeHistory( 1 ),
+  alwaysExpandOptionalParts( false )
+, historyStoreInterval( 0 )
+, favoritesStoreInterval( 0 )
+, confirmFavoritesDeletion( true )
+, collapseBigArticles( false )
+, articleSizeLimit( 2000 )
+, limitInputPhraseLength( false )
+, inputPhraseLengthLimit( 1000 )
+, maxDictionaryRefsInContextMenu ( 20 )
+, synonymSearchEnabled( true ),
+  stripClipboard( false ),
+  raiseWindowOnSearch(true)
 {
 }
 

--- a/config.cc
+++ b/config.cc
@@ -283,8 +283,9 @@ Preferences::Preferences():
 , limitInputPhraseLength( false )
 , inputPhraseLengthLimit( 1000 )
 , maxDictionaryRefsInContextMenu ( 20 )
-, synonymSearchEnabled( true )
-    , stripClipboard( false )
+, synonymSearchEnabled( true ),
+  stripClipboard( false ),
+  raiseWindowOnSearch(true)
 {
 }
 
@@ -1040,6 +1041,9 @@ Class load()
 
     if ( !preferences.namedItem( "stripClipboard" ).isNull() )
       c.preferences.stripClipboard = ( preferences.namedItem( "stripClipboard" ).toElement().text() == "1" );
+
+    if ( !preferences.namedItem( "raiseWindowOnSearch" ).isNull() )
+      c.preferences.raiseWindowOnSearch = ( preferences.namedItem( "raiseWindowOnSearch" ).toElement().text() == "1" );
 
     QDomNode fts = preferences.namedItem( "fullTextSearch" );
 
@@ -2030,6 +2034,10 @@ void save( Class const & c )
 
     opt = dd.createElement( "stripClipboard" );
     opt.appendChild( dd.createTextNode( c.preferences.stripClipboard ? "1" : "0" ) );
+    preferences.appendChild( opt );
+
+    opt = dd.createElement( "raiseWindowOnSearch" );
+    opt.appendChild( dd.createTextNode( c.preferences.raiseWindowOnSearch ? "1" : "0" ) );
     preferences.appendChild( opt );
 
     {

--- a/config.cc
+++ b/config.cc
@@ -222,70 +222,70 @@ InputPhrase Preferences::sanitizeInputPhrase( QString const & inputPhrase ) cons
 }
 
 Preferences::Preferences():
-  newTabsOpenAfterCurrentOne( false ),
-  newTabsOpenInBackground( true ),
-  hideSingleTab( false ),
-  mruTabOrder ( false ),
-  hideMenubar( false ),
-  enableTrayIcon( true ),
-  startToTray( false ),
-  closeToTray( true ),
-  autoStart( false ),
-  doubleClickTranslates( true ),
-  selectWordBySingleClick( false ),
-  autoScrollToTargetArticle( true ),
-  escKeyHidesMainWindow( false ),
-  darkMode( false ),
-  darkReaderMode ( false ),
-  alwaysOnTop ( false ),
-  searchInDock ( false ),
+    newTabsOpenAfterCurrentOne( false ),
+    newTabsOpenInBackground( true ),
+    hideSingleTab( false ),
+    mruTabOrder( false ),
+    hideMenubar( false ),
+    enableTrayIcon( true ),
+    startToTray( false ),
+    closeToTray( true ),
+    autoStart( false ),
+    doubleClickTranslates( true ),
+    selectWordBySingleClick( false ),
+    autoScrollToTargetArticle( true ),
+    escKeyHidesMainWindow( false ),
+    darkMode( false ),
+    darkReaderMode( false ),
+    alwaysOnTop( false ),
+    searchInDock( false ),
 
-  enableMainWindowHotkey( true ),
-  mainWindowHotkey( QKeySequence( "Ctrl+F11,F11" ) ),
-  enableClipboardHotkey( true ),
-  clipboardHotkey( QKeySequence( "Ctrl+C,C" ) ),
+    enableMainWindowHotkey( true ),
+    mainWindowHotkey( QKeySequence( "Ctrl+F11,F11" ) ),
+    enableClipboardHotkey( true ),
+    clipboardHotkey( QKeySequence( "Ctrl+C,C" ) ),
 
-  startWithScanPopupOn( false ),
-  enableScanPopupModifiers( false ),
-  scanPopupModifiers( 0 ),
-  ignoreOwnClipboardChanges( false ),
-  scanToMainWindow( false ),
-  ignoreDiacritics( false ),
-  ignorePunctuation( false ),
+    startWithScanPopupOn( false ),
+    enableScanPopupModifiers( false ),
+    scanPopupModifiers( 0 ),
+    ignoreOwnClipboardChanges( false ),
+    scanToMainWindow( false ),
+    ignoreDiacritics( false ),
+    ignorePunctuation( false ),
 #ifdef HAVE_X11
-  // Enable both Clipboard and Selection by default so that X users can enjoy full
-  // power and disable optionally.
-  trackClipboardScan ( true ),
-  trackSelectionScan ( true ),
-  showScanFlag( false ),
+    // Enable both Clipboard and Selection by default so that X users can enjoy full
+    // power and disable optionally.
+    trackClipboardScan( true ),
+    trackSelectionScan( true ),
+    showScanFlag( false ),
 #endif
-  pronounceOnLoadMain( false ),
-  pronounceOnLoadPopup( false ),
-  useInternalPlayer( InternalPlayerBackend::anyAvailable() ),
-  internalPlayerBackend( InternalPlayerBackend::defaultBackend() ),
-  checkForNewReleases( true ),
-  disallowContentFromOtherSites( false ),
-  enableWebPlugins( false ),
-  hideGoldenDictHeader( false ),
-  maxNetworkCacheSize( 50 ),
-  clearNetworkCacheOnExit( true ),
-  zoomFactor( 1 ),
-  helpZoomFactor( 1 ),
-  wordsZoomLevel( 0 ),
-  maxStringsInHistory( 500 ),
-  storeHistory( 1 ),
-  alwaysExpandOptionalParts( false )
-, historyStoreInterval( 0 )
-, favoritesStoreInterval( 0 )
-, confirmFavoritesDeletion( true )
-, collapseBigArticles( false )
-, articleSizeLimit( 2000 )
-, limitInputPhraseLength( false )
-, inputPhraseLengthLimit( 1000 )
-, maxDictionaryRefsInContextMenu ( 20 )
-, synonymSearchEnabled( true ),
-  stripClipboard( false ),
-  raiseWindowOnSearch(true)
+    pronounceOnLoadMain( false ),
+    pronounceOnLoadPopup( false ),
+    useInternalPlayer( InternalPlayerBackend::anyAvailable() ),
+    internalPlayerBackend( InternalPlayerBackend::defaultBackend() ),
+    checkForNewReleases( true ),
+    disallowContentFromOtherSites( false ),
+    enableWebPlugins( false ),
+    hideGoldenDictHeader( false ),
+    maxNetworkCacheSize( 50 ),
+    clearNetworkCacheOnExit( true ),
+    zoomFactor( 1 ),
+    helpZoomFactor( 1 ),
+    wordsZoomLevel( 0 ),
+    maxStringsInHistory( 500 ),
+    storeHistory( 1 ),
+    alwaysExpandOptionalParts( false ),
+    historyStoreInterval( 0 ),
+    favoritesStoreInterval( 0 ),
+    confirmFavoritesDeletion( true ),
+    collapseBigArticles( false ),
+    articleSizeLimit( 2000 ),
+    limitInputPhraseLength( false ),
+    inputPhraseLengthLimit( 1000 ),
+    maxDictionaryRefsInContextMenu( 20 ),
+    synonymSearchEnabled( true ),
+    stripClipboard( false ),
+    raiseWindowOnSearch( true )
 {
 }
 
@@ -1042,7 +1042,7 @@ Class load()
     if ( !preferences.namedItem( "stripClipboard" ).isNull() )
       c.preferences.stripClipboard = ( preferences.namedItem( "stripClipboard" ).toElement().text() == "1" );
 
-    if ( !preferences.namedItem( "raiseWindowOnSearch" ).isNull() )
+    if( !preferences.namedItem( "raiseWindowOnSearch" ).isNull() )
       c.preferences.raiseWindowOnSearch = ( preferences.namedItem( "raiseWindowOnSearch" ).toElement().text() == "1" );
 
     QDomNode fts = preferences.namedItem( "fullTextSearch" );

--- a/config.hh
+++ b/config.hh
@@ -382,6 +382,7 @@ struct Preferences
 
   bool synonymSearchEnabled;
   bool stripClipboard;
+  bool raiseWindowOnSearch;
 
   QString addonStyle;
 

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -2934,11 +2934,9 @@ void MainWindow::toggleMainWindow( bool onlyShow )
     raise();
     shown = true;
   }
-  else
-  if ( !isActiveWindow() )
-  {
+  else if( !isActiveWindow() ) {
     qApp->setActiveWindow( this );
-    if (cfg.preferences.raiseWindowOnSearch) {
+    if( cfg.preferences.raiseWindowOnSearch ) {
       raise();
       activateWindow();
     }

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -2938,8 +2938,10 @@ void MainWindow::toggleMainWindow( bool onlyShow )
   if ( !isActiveWindow() )
   {
     qApp->setActiveWindow( this );
-    raise();
-    activateWindow();
+    if (cfg.preferences.raiseWindowOnSearch) {
+      raise();
+      activateWindow();
+    }
     shown = true;
   }
   else

--- a/preferences.cc
+++ b/preferences.cc
@@ -223,6 +223,8 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
 
   ui.stripClipboard->setChecked( p.stripClipboard );
 
+  ui.raiseWindowOnSearch->setChecked( p.raiseWindowOnSearch );
+
   ui.maxDictsInContextMenu->setValue( p.maxDictionaryRefsInContextMenu );
 
   // Different platforms have different keys available
@@ -443,6 +445,7 @@ Config::Preferences Preferences::getPreferences()
   p.ignoreDiacritics = ui.ignoreDiacritics->isChecked();
   p.ignorePunctuation = ui.ignorePunctuation->isChecked();
   p.stripClipboard = ui.stripClipboard->isChecked();
+  p.raiseWindowOnSearch = ui.raiseWindowOnSearch->isChecked();
 
   p.synonymSearchEnabled = ui.synonymSearchEnabled->isChecked();
 

--- a/preferences.ui
+++ b/preferences.ui
@@ -1769,6 +1769,13 @@ from Stardict, Babylon and GLS dictionaries</string>
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="raiseWindowOnSearch">
+         <property name="text">
+          <string>On a new search, focus the main or popup window even if it's visible</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_17">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -581,16 +581,18 @@ void ScanPopup::engagePopup( bool forcePopup, bool giveFocus )
     //QApplication::processEvents(); // Make window appear immediately no matter what
   }
   else
-  if ( ui.pinButton->isChecked() )
+  if ( ui.pinButton->isChecked())
   {
     // Pinned-down window isn't always on top, so we need to raise it
     show();
-    activateWindow();
-    raise();
+    if (cfg.preferences.raiseWindowOnSearch) {
+      activateWindow();
+      raise();
+    }
   }
 #if defined( HAVE_X11 )
   else
-  if ( ( windowFlags() & Qt::Tool ) == Qt::Tool )
+  if ( ( windowFlags() & Qt::Tool ) == Qt::Tool && cfg.preferences.raiseWindowOnSearch)
   {
     // Ensure that the window with Qt::Tool flag always has focus on X11.
     activateWindow();

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -580,20 +580,16 @@ void ScanPopup::engagePopup( bool forcePopup, bool giveFocus )
     // This produced some funky mouse grip-related bugs so we commented it out
     //QApplication::processEvents(); // Make window appear immediately no matter what
   }
-  else
-  if ( ui.pinButton->isChecked())
-  {
+  else if( ui.pinButton->isChecked() ) {
     // Pinned-down window isn't always on top, so we need to raise it
     show();
-    if (cfg.preferences.raiseWindowOnSearch) {
+    if( cfg.preferences.raiseWindowOnSearch ) {
       activateWindow();
       raise();
     }
   }
 #if defined( HAVE_X11 )
-  else
-  if ( ( windowFlags() & Qt::Tool ) == Qt::Tool && cfg.preferences.raiseWindowOnSearch)
-  {
+  else if( ( windowFlags() & Qt::Tool ) == Qt::Tool && cfg.preferences.raiseWindowOnSearch ) {
     // Ensure that the window with Qt::Tool flag always has focus on X11.
     activateWindow();
     raise();


### PR DESCRIPTION
When a search is triggered, the main window focuses itself even if it's already visible, which may be undesirable for some users. Let the user disable this behavior.

![screenshot](https://user-images.githubusercontent.com/69171671/224797658-81663ca4-7b21-48a9-ba99-8d765b0384bd.png)
