### PR TITLE
fix: white flash when using dark reader mode

### DIFF
--- a/article-style-st-babylon.css
+++ b/article-style-st-babylon.css
@@ -1,18 +1,3 @@
-html
-{
-  background-color: white;
-}
-
-body
-{
-	background: white;
-}
-
-.gdarticle
-{
-  background: white;
-}
-
 h3 {
 	font-size: 1em;
 }

--- a/article-style-st-lingvo.css
+++ b/article-style-st-lingvo.css
@@ -1,13 +1,3 @@
-html
-{
-  background-color: white;
-}
-
-body
-{
-  background: white;
-}
-
 a
 {
   text-decoration: none;

--- a/article-style-st-modern.css
+++ b/article-style-st-modern.css
@@ -1,15 +1,9 @@
-html
-{
-  background-color: white;
-}
-
 body
 {
   margin-top: 1px;
   margin-right: 3px;
   margin-left:  2px;
   margin-bottom: 3px;
-  background: white;
 }
 
 a

--- a/article_maker.cc
+++ b/article_maker.cc
@@ -51,6 +51,10 @@ std::string ArticleMaker::makeHtmlHeader( QString const & word,
       "<html><head>"
       "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">";
 
+  // background is #242525 because Darkreader will invert pure white to this value
+  if( GlobalBroadcaster::instance()->getPreference()->darkReaderMode ){
+    result += R"(<style> html { background-color: #242525;} body { background-color: #242525;} </style>)"; }
+
   // add jquery
   {
     result += "<script type=\"text/javascript\"  "
@@ -151,13 +155,12 @@ std::string ArticleMaker::makeHtmlHeader( QString const & word,
 
   if( GlobalBroadcaster::instance()->getPreference()->darkReaderMode )
   {
-    // #242525 because Darkreader will invert pure white to this value
+    // Why .gdarticle background reset?
+    // some custom theme may change it to other colors and they looks horrible in darkreader mode
+
     result += R"(
 <script src="qrc:///scripts/darkreader.js"></script>
-<style>
-body { background: #242525; }
-.gdarticle { background: initial;}
-</style>
+<style> .gdarticle { background: initial;} </style>
 <script>
   // This function returns a promise, but it is synchroneous because it does not use await
   function fetchShim(src) {

--- a/articleview.cc
+++ b/articleview.cc
@@ -364,6 +364,16 @@ ArticleView::ArticleView( QWidget * parent, ArticleNetworkAccessManager & nm, Au
            &AnkiConnector::errorText,
            this,
            [ this ]( QString const & errorText ) { emit statusBarMessage( errorText ); } );
+
+  connect( ui.definition, &ArticleWebView::loadFinished, this, [ this ]( bool ) {
+    ui.definition->show();
+
+    // search lightui+darkmode to jump to another section of this hack
+    // reset the background back to normal
+    if( cfg.preferences.darkReaderMode ) {
+      setStyleSheet( "ArticleView {background-color: palette(window);}" );
+    }
+  } );
 }
 
 // explicitly report the minimum size, to avoid
@@ -394,6 +404,16 @@ void ArticleView::showDefinition( Config::InputPhrase const & phrase, unsigned g
   currentWord = phrase.phrase.trimmed();
   if( currentWord.isEmpty() )
     return;
+
+  // search lightui+darkmode to jump to another section of this hack
+  // set the underlying Frame's background to Dark so that when
+  // the page is loading there is no flash when user has light ui + dark reader mode
+  // TODO: this is not efficient. rewrite ArticleView.ui so that the background of the search widget and the page is decoupled.
+  if( cfg.preferences.darkReaderMode ) {
+    setStyleSheet( "ArticleView {background-color: #242525;}" );
+  }
+  ui.definition->hide();
+
   historyMode = false;
   currentActiveDictIds.clear();
   // first, let's stop the player
@@ -480,6 +500,16 @@ void ArticleView::showDefinition( QString const & word, QStringList const & dict
   currentWord = word.trimmed();
   if( currentWord.isEmpty() )
     return;
+
+  // search lightui+darkmode to jump to another section of this hack
+  // set the underlying Frame's background to Dark so that when
+  // the page is loading there is no flash when user has light ui + dark reader mode
+  // TODO: this is not efficient. rewrite ArticleView.ui so that the background of the search widget and the page is decoupled.
+  if( cfg.preferences.darkReaderMode ) {
+    setStyleSheet( "ArticleView {background-color: #242525;}" );
+  }
+  ui.definition->hide();
+
   historyMode = false;
   // first, let's stop the player
   audioPlayer->stop();

--- a/articlewebpage.cpp
+++ b/articlewebpage.cpp
@@ -1,9 +1,15 @@
 #include "articlewebpage.h"
 #include "utils.hh"
+#include "globalbroadcaster.h"
+#include <QColor>
 
 ArticleWebPage::ArticleWebPage(QObject *parent)
   : QWebEnginePage{parent}
 {
+  // when opening a new tab in dark reader mode, there will be a white flash without this
+  if( GlobalBroadcaster::instance()->getPreference()->darkReaderMode ) {
+    setBackgroundColor( QColor(39,40,40) );
+  }
 }
 bool ArticleWebPage::acceptNavigationRequest( const QUrl & resUrl, NavigationType type, bool isMainFrame )
 {


### PR DESCRIPTION
Implement the design: <https://github.com/xiaoyifang/goldendict/issues/357#issuecomment-1472867555>
More background: <https://github.com/xiaoyifang/goldendict/issues/357#issuecomment-1471479304>
fix most cases of white flash https://github.com/xiaoyifang/goldendict/issues/357

Hide the page when a search begins and show it up again when the loading is finished.

Why we are doing this?

Well, we cannot change the source code of chromium, and there is no obvious API exposed by QtWebengine to change the background color during page loading. Maybe the QWebEnginePage.setBackground was designed for this purpose, but it doesn't work.
