### PR TITLE
fix white flash in dark reader mode

### DIFF
--- a/article-style-st-babylon.css
+++ b/article-style-st-babylon.css
@@ -1,18 +1,3 @@
-html
-{
-  background-color: white;
-}
-
-body
-{
-	background: white;
-}
-
-.gdarticle
-{
-  background: white;
-}
-
 h3 {
 	font-size: 1em;
 }

--- a/article-style-st-lingvo.css
+++ b/article-style-st-lingvo.css
@@ -1,13 +1,3 @@
-html
-{
-  background-color: white;
-}
-
-body
-{
-  background: white;
-}
-
 a
 {
   text-decoration: none;
@@ -17,11 +7,6 @@ a
 a:hover
 {
   text-decoration: underline;
-}
-
-.gdarticle
-{
-  background: white;
 }
 
 /* The 'From ' string which preceeds dictionary name in the heading */

--- a/article-style-st-modern.css
+++ b/article-style-st-modern.css
@@ -1,15 +1,9 @@
-html
-{
-  background-color: white;
-}
-
 body
 {
   margin-top: 1px;
   margin-right: 3px;
   margin-left:  2px;
   margin-bottom: 3px;
-  background: white;
 }
 
 a
@@ -30,7 +24,6 @@ a:hover
   padding: 5px;
   border: 1px solid #d0dde2;
   border-radius: 8px;
-  background: white;
 }
 
 .gdactivearticle

--- a/article_maker.cc
+++ b/article_maker.cc
@@ -51,6 +51,11 @@ std::string ArticleMaker::makeHtmlHeader( QString const & word,
       "<html><head>"
       "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">";
 
+  // background is #242525 because Darkreader will invert pure white to this value
+  if( GlobalBroadcaster::instance()->getPreference()->darkReaderMode ){
+    result += R"(<style> html { background-color: #242525;} body { background-color: #242525;} </style>)";
+  }
+
   // add jquery
   {
     result += "<script type=\"text/javascript\"  "
@@ -151,13 +156,11 @@ std::string ArticleMaker::makeHtmlHeader( QString const & word,
 
   if( GlobalBroadcaster::instance()->getPreference()->darkReaderMode )
   {
-    // #242525 because Darkreader will invert pure white to this value
+    // Why .gdarticle background reset?
+    // some custom theme may change it to other colors and they looks horrible in darkreader mode
     result += R"(
 <script src="qrc:///scripts/darkreader.js"></script>
-<style>
-body { background: #242525; }
-.gdarticle { background: initial;}
-</style>
+<style> .gdarticle { background: initial;} </style>
 <script>
   // This function returns a promise, but it is synchroneous because it does not use await
   function fetchShim(src) {

--- a/articlewebview.cc
+++ b/articlewebview.cc
@@ -9,29 +9,32 @@
 #include <QTimer>
 #include <QDialog>
 #include <QMainWindow>
+#include <QColor>
 
 #ifdef Q_OS_WIN32
 #include <qt_windows.h>
 #endif
 
-ArticleWebView::ArticleWebView( QWidget *parent ):
+ArticleWebView::ArticleWebView( QWidget * parent, Config::Class * cfg ):
   QWebEngineView( parent ),
   midButtonPressed( false ),
-  selectionBySingleClick( false )
+  selectionBySingleClick( false ),
+  cfg(cfg)
 {
-  auto page = new ArticleWebPage( this );
+  auto *page = new ArticleWebPage( this );
+
+  if(cfg->preferences.darkReaderMode){
+    page->setBackgroundColor(QColor(36,37,37));
+  }
+
   connect( page, &ArticleWebPage::linkClicked, this, &ArticleWebView::linkClicked );
   this->setPage( page );
+  setZoomFactor(cfg->preferences.zoomFactor);
+
 }
 
 ArticleWebView::~ArticleWebView()
 {
-}
-
-void ArticleWebView::setUp( Config::Class * cfg )
-{
-  this->cfg = cfg;
-  setZoomFactor(cfg->preferences.zoomFactor);
 }
 
 QWebEngineView * ArticleWebView::createWindow( QWebEnginePage::WebWindowType type )

--- a/articlewebview.hh
+++ b/articlewebview.hh
@@ -22,9 +22,8 @@ class ArticleWebView: public QWebEngineView
 
 public:
 
-  ArticleWebView( QWidget * parent );
+  ArticleWebView( QWidget * parent, Config::Class * cfg);
   ~ArticleWebView();
-  void setUp( Config::Class * cfg );
 
   bool isMidButtonPressed() const
   { return midButtonPressed; }

--- a/src/ui/articleview.cpp
+++ b/src/ui/articleview.cpp
@@ -42,6 +42,7 @@
 #endif
 
 #include <QBuffer>
+#include <QStackedWidget>
 
 #if defined( Q_OS_WIN32 ) || defined( Q_OS_MAC )
 #include "speechclient.hh"
@@ -250,13 +251,45 @@ ArticleView::ArticleView( QWidget * parent, ArticleNetworkAccessManager & nm, Au
   ftsPosition( 0 )
 {
   // setup GUI
-  webview        = new ArticleWebView( this );
+
+  webview        = new ArticleWebView( this , const_cast< Config::Class * >( &cfg ) );
   ftsSearchPanel = new FtsSearchPanel( this );
   searchPanel    = new SearchPanel( this );
 
-  // Layout
   auto * mainLayout = new QVBoxLayout( this );
-  mainLayout->addWidget( webview );
+
+  // Special treatment of darkReaderMode
+  // As of Qt6.4, the Qt WebEngine/Chromium's white loading color cannot be changed.
+  // Here we cover the problem by swapping it out when the page is loading.
+
+  // if darkReaderMode not enabled, then just add webview normally.
+  if( !cfg.preferences.darkReaderMode ) {
+    mainLayout->addWidget( webview );
+  }
+  else {
+
+    auto * container  = new QStackedWidget( this );
+    auto * dummyBlack = new QWidget( this );
+    dummyBlack->setStyleSheet( "background-color:#242525;" );
+    container->setStyleSheet( "background-color:#242525;" );
+    container->addWidget( webview );
+    container->addWidget( dummyBlack );
+
+    connect( webview, &ArticleWebView::loadFinished, this, [ = ]() {
+      // delay showing the webview because page rendering will show a glimpse of white
+      QTimer::singleShot( 200, [ = ]() { container->setCurrentWidget( webview );});
+    });
+
+    connect( webview, &ArticleWebView::loadStarted, this, [ = ]() {
+      container->setCurrentWidget( dummyBlack );
+    } );
+
+    mainLayout->addWidget( container );
+
+    container->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
+  }
+
+  // Layout
   mainLayout->addWidget( ftsSearchPanel );
   mainLayout->addWidget( searchPanel );
 
@@ -279,8 +312,6 @@ ArticleView::ArticleView( QWidget * parent, ArticleNetworkAccessManager & nm, Au
   connect( ftsSearchPanel->previous, &QPushButton::clicked, this, &ArticleView::on_ftsSearchPrevious_clicked );
 
   //
-
-  webview->setUp( const_cast< Config::Class * >( &cfg ) );
 
   goBackAction.setShortcut( QKeySequence( "Alt+Left" ) );
   webview->addAction( &goBackAction );


### PR DESCRIPTION
https://github.com/xiaoyifang/goldendict/issues/357

This fix is bad, but it does reduce the white flash greatly.

* Swap out `webview` when a page Loading started
* Immediately set the page's background to black after the `<html>` tag
* Delayed swapping back (200ms) to cover a glimpse of white during page Rendering
* Set the initial background of QWebEnginePage to black (which only affect the background when creating a new tab)