### PR TITLE
cleanup: simplify DSL's expand mode

### DIFF
--- a/article_maker.cc
+++ b/article_maker.cc
@@ -24,14 +24,15 @@ using std::list;
 
 ArticleMaker::ArticleMaker( vector< sptr< Dictionary::Class > > const & dictionaries_,
                             vector< Instances::Group > const & groups_,
+                            const Config::Preferences & cfg_,
                             QString const & displayStyle_,
                             QString const & addonStyle_):
   dictionaries( dictionaries_ ),
   groups( groups_ ),
+  cfg(cfg_),
   displayStyle( displayStyle_ ),
   addonStyle( addonStyle_ ),
-  needExpandOptionalParts( true )
-, collapseBigArticles( true )
+  collapseBigArticles( true )
 , articleLimitSize( 500 )
 {
 }
@@ -280,7 +281,7 @@ sptr< Dictionary::DataRequest > ArticleMaker::makeDefinitionFor(
   if ( groupId == Instances::Group::HelpGroupId )
   {
     // This is a special group containing internal welcome/help pages
-    string result = makeHtmlHeader( phrase.phrase, QString(), needExpandOptionalParts );
+    string result = makeHtmlHeader( phrase.phrase, QString(), cfg.alwaysExpandOptionalParts);
 
     if ( phrase.phrase == tr( "Welcome!" ) )
     {
@@ -353,7 +354,7 @@ sptr< Dictionary::DataRequest > ArticleMaker::makeDefinitionFor(
   string header = makeHtmlHeader( phrase.phrase,
                                   activeGroup && activeGroup->icon.size() ?
                                     activeGroup->icon : QString(),
-                                  needExpandOptionalParts );
+                                  cfg.alwaysExpandOptionalParts );
 
   if ( mutedDicts.size() )
   {
@@ -369,13 +370,13 @@ sptr< Dictionary::DataRequest > ArticleMaker::makeDefinitionFor(
     return  std::make_shared<ArticleRequest>( phrase, activeGroup ? activeGroup->name : "",
                                contexts, unmutedDicts, header,
                                collapseBigArticles ? articleLimitSize : -1,
-                               needExpandOptionalParts, ignoreDiacritics );
+                               cfg.alwaysExpandOptionalParts, ignoreDiacritics );
   }
   else
     return std::make_shared<ArticleRequest>( phrase, activeGroup ? activeGroup->name : "",
                                contexts, activeDicts, header,
                                collapseBigArticles ? articleLimitSize : -1,
-                               needExpandOptionalParts, ignoreDiacritics );
+                               cfg.alwaysExpandOptionalParts, ignoreDiacritics );
 }
 
 sptr< Dictionary::DataRequest > ArticleMaker::makeNotFoundTextFor(
@@ -420,11 +421,6 @@ sptr< Dictionary::DataRequest > ArticleMaker::makePicturePage( string const & ur
   memcpy( &( r->getData().front() ), result.data(), result.size() );
 
   return r;
-}
-
-void ArticleMaker::setExpandOptionalParts( bool expand )
-{
-  needExpandOptionalParts = expand;
 }
 
 void ArticleMaker::setCollapseParameters( bool autoCollapse, int articleSize )

--- a/article_maker.hh
+++ b/article_maker.hh
@@ -20,10 +20,10 @@ class ArticleMaker: public QObject
 
   std::vector< sptr< Dictionary::Class > > const & dictionaries;
   std::vector< Instances::Group > const & groups;
+  const Config::Preferences & cfg;
 
   QString displayStyle, addonStyle;
 
-  bool needExpandOptionalParts;
   bool collapseBigArticles;
   int articleLimitSize;
 
@@ -35,6 +35,7 @@ public:
   /// of the inquiries, although those changes are perfectly legal.
   ArticleMaker( std::vector< sptr< Dictionary::Class > > const & dictionaries,
                 std::vector< Instances::Group > const & groups,
+                const Config::Preferences & cfg,
                 QString const & displayStyle,
                 QString const & addonStyle);
 
@@ -68,9 +69,6 @@ public:
 
   /// Create page with one picture
   sptr< Dictionary::DataRequest > makePicturePage( std::string const & url ) const;
-
-  /// Set auto expanding optional parts of articles
-  void setExpandOptionalParts( bool expand );
 
   /// Add base path to file path if it's relative and file not found
   /// Return true if path successfully adjusted

--- a/mainwindow.hh
+++ b/mainwindow.hh
@@ -73,7 +73,6 @@ public slots:
   void phraseReceived( Config::InputPhrase const & );
   void wordReceived( QString const & );
   void headwordReceived( QString const &, QString const & );
-  void setExpandMode( bool expand );
   void headwordFromFavorites( QString const &, QString const & );
   void quitApp();
 
@@ -115,7 +114,7 @@ private:
           closeAllTabAction, closeRestTabAction,
           switchToNextTabAction, switchToPrevTabAction,
           showDictBarNamesAction, useSmallIconsInToolbarsAction, toggleMenuBarAction,
-          switchExpandModeAction, focusHeadwordsDlgAction, focusArticleViewAction,
+          focusHeadwordsDlgAction, focusArticleViewAction,
           addAllTabToFavoritesAction;
   QToolBar * navToolbar;
   MainStatusBar * mainStatusBar;
@@ -320,9 +319,6 @@ private slots:
   void switchToPrevTab();
   void ctrlReleased();
 
-  // Switch optional parts expand mode for current tab
-  void switchExpandOptionalPartsMode();
-
   // Handling of active tab list
   void createTabList();
   void fillWindowsMenu();
@@ -493,9 +489,6 @@ private slots:
   void inspectElement( QWebEnginePage * );
 
 signals:
-  /// Set optional parts expand mode for all tabs
-  void setExpandOptionalParts( bool expand );
-
   /// Retranslate Ctrl(Shift) + Click on dictionary pane to dictionary toolbar
   void clickOnDictPane( QString const & id );
 

--- a/scanpopup.cc
+++ b/scanpopup.cc
@@ -109,9 +109,6 @@ ScanPopup::ScanPopup( QWidget * parent,
                                 dictionaryBar.toggleViewAction()
                                 );
 
-  connect( this, &ScanPopup::switchExpandMode, definition, &ArticleView::switchExpandOptionalParts );
-  connect( this, &ScanPopup::setViewExpandMode, definition, &ArticleView::receiveExpandOptionalParts );
-  connect( definition, &ArticleView::setExpandMode, this, &ScanPopup::setExpandMode );
   connect( definition, &ArticleView::inspectSignal, this, &ScanPopup::inspectElementWhenPinned );
   connect( definition, &ArticleView::forceAddWordToHistory, this, &ScanPopup::forceAddWordToHistory );
   connect( this, &ScanPopup::closeMenu, definition, &ArticleView::closePopupMenu );

--- a/scanpopup.hh
+++ b/scanpopup.hh
@@ -67,10 +67,8 @@ signals:
   void sendPhraseToMainWindow( Config::InputPhrase const & phrase );
   /// Close opened menus when window hide
   void closeMenu();
-  /// Signals to set expand optional parts mode (retranslation from/to MainWindow and dictionary bar)
-  void setExpandMode( bool expand );
+
   void inspectSignal(QWebEnginePage * page);
-  void setViewExpandMode( bool expand );
   /// Signal to switch expand optional parts mode
   void switchExpandMode();
   /// Signal to add word to history even if history is disabled

--- a/src/ui/articleview.cpp
+++ b/src/ui/articleview.cpp
@@ -479,8 +479,6 @@ void ArticleView::showDefinition( Config::InputPhrase const & phrase, unsigned g
   // Any search opened is probably irrelevant now
   closeSearch();
 
-  emit setExpandMode( expandOptionalParts );
-
   load( req );
 
   //QApplication::setOverrideCursor( Qt::WaitCursor );
@@ -530,8 +528,6 @@ void ArticleView::showDefinition( QString const & word, QStringList const & dict
 
   // Clear highlight all button selection
   searchPanel->highlightAll->setChecked( false );
-
-  emit setExpandMode( expandOptionalParts );
 
   load( req );
 
@@ -2431,19 +2427,6 @@ void ArticleView::showEvent( QShowEvent * ev )
 
   if( !ftsSearchIsOpened )
     ftsSearchPanel->hide();
-}
-
-void ArticleView::receiveExpandOptionalParts( bool expand )
-{
-  if( expandOptionalParts != expand )
-    switchExpandOptionalParts();
-}
-
-void ArticleView::switchExpandOptionalParts()
-{
-  expandOptionalParts = !expandOptionalParts;
-  emit setExpandMode( expandOptionalParts );
-  reload();
 }
 
 void ArticleView::copyAsText()

--- a/src/ui/articleview.h
+++ b/src/ui/articleview.h
@@ -291,9 +291,6 @@ signals:
   /// Signal to close popup menu
   void closePopupMenu();
 
-  /// Signal to set optional parts expand mode
-  void setExpandMode ( bool  expand );
-
   void sendWordToInputLine( QString const & word );
 
   void storeResourceSavePath(QString const & );
@@ -317,10 +314,6 @@ public slots:
 
   /// Handles F3 and Shift+F3 for search navigation
   bool handleF3( QObject * obj, QEvent * ev );
-
-  /// Control optional parts expanding
-  void receiveExpandOptionalParts( bool expand );
-  void switchExpandOptionalParts();
 
   /// Selects an entire text of the current article
   void selectCurrentArticle();


### PR DESCRIPTION
The original code is extremely convoluted because the code was passing a "AlwaysExpand" from Mainwindow <> ArticleView <> ArticleMaker back and forth and back and forth via signals.

https://github.com/goldendict/goldendict/commit/305c9ed1b8acb36746d7d8a410417e945eaf67b1

Save this file as `test.dsl`
```
#NAME "test"
#INDEX_LANGUAGE "English"
#CONTENTS_LANGUAGE "English"

a
	[m1]ok[*]: what is this [/*][/m]
```

The "Expand mode" (Lingvo call it "Full translation mode") is a "+" toggle for text between the `[*][/*]`

![image](https://user-images.githubusercontent.com/20123683/226529949-e7d47e5b-b2cf-4e5d-8474-4dffaf3c05c4.png)

If the "AlwaysExpand" is turned on, the "+" toggle will be gone, and the text between`[*][/*]` will always be shown.

![image](https://user-images.githubusercontent.com/20123683/226530198-08645b3b-0a82-42d9-9c63-6476fb9f0624.png)

And that's all.

Why the original code has so much signals connected together?

They are used to toggling "AlwaysExpand" mode for a single ArticleView (Single Tab) via "Ctrl+8".

Considering DSL is the only format that has this feature and the usage is rare (I download multiple DSL dicts. Only 1 of them use `[*][/*]`), so I removed this shortcut and related code.

Users can still set this "AlwaysExpand" mode in preferences -> Advanced -> Expand Optional Parts, so the core feature is not lost.

Even without this mode, a user can just click the "+" toggle button to show the text between`[*][/*]`.

---

To test this PR:

add the `test.dsl` above -> search "a" -> toggle "Preferences -> Advanced -> Expand Optional Parts" 
