### PR TITLE
cleanup: remove unnecessary variables in ArticleMaker

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -52,6 +52,7 @@ IndentAccessModifiers: false
 IndentPPDirectives: BeforeHash
 MaxEmptyLinesToKeep: 2
 NamespaceIndentation: Inner
+PackConstructorInitializers: Never
 PointerAlignment: Middle
 ReflowComments: false
 SortIncludes: false

--- a/article_maker.cc
+++ b/article_maker.cc
@@ -24,24 +24,13 @@ using std::list;
 
 ArticleMaker::ArticleMaker( vector< sptr< Dictionary::Class > > const & dictionaries_,
                             vector< Instances::Group > const & groups_,
-                            const Config::Preferences & cfg_,
-                            QString const & displayStyle_,
-                            QString const & addonStyle_):
+                            const Config::Preferences & cfg_ ):
   dictionaries( dictionaries_ ),
   groups( groups_ ),
-  cfg(cfg_),
-  displayStyle( displayStyle_ ),
-  addonStyle( addonStyle_ ),
-  collapseBigArticles( true )
-, articleLimitSize( 500 )
+  cfg( cfg_ )
 {
 }
 
-void ArticleMaker::setDisplayStyle( QString const & st, QString const & adst )
-{
-  displayStyle = st;
-  addonStyle = adst;
-}
 
 std::string ArticleMaker::makeHtmlHeader( QString const & word,
                                           QString const & icon,
@@ -87,19 +76,19 @@ std::string ArticleMaker::makeHtmlHeader( QString const & word,
   {
     result += R"(<link href="qrc:///article-style.css"  media="all" rel="stylesheet" type="text/css">)";
 
-    if ( displayStyle.size() )
+    if ( cfg.displayStyle.size() )
     {
       // Load an additional stylesheet
-      QString displayStyleCssFile = QString("qrc:///article-style-st-%1.css").arg(displayStyle);
+      QString displayStyleCssFile = QString("qrc:///article-style-st-%1.css").arg(cfg.displayStyle);
       result += "<link href=\"" + displayStyleCssFile.toStdString() +
                 R"("  media="all" rel="stylesheet" type="text/css">)";
     }
 
     result += readCssFile(Config::getUserCssFileName() ,"all");
 
-    if( !addonStyle.isEmpty() )
+    if( !cfg.addonStyle.isEmpty() )
     {
-      QString name = Config::getStylesDir() + addonStyle
+      QString name = Config::getStylesDir() + cfg.addonStyle
                      + QDir::separator() + "article-style.css";
 
       result += readCssFile(name ,"all");
@@ -122,9 +111,9 @@ std::string ArticleMaker::makeHtmlHeader( QString const & word,
 
     result += readCssFile(Config::getUserCssPrintFileName() ,"print");
 
-    if( !addonStyle.isEmpty() )
+    if( !cfg.addonStyle.isEmpty() )
     {
-      QString name = Config::getStylesDir() + addonStyle
+      QString name = Config::getStylesDir() + cfg.addonStyle
                      + QDir::separator() + "article-style-print.css";
       result += readCssFile(name ,"print");
     }
@@ -369,13 +358,13 @@ sptr< Dictionary::DataRequest > ArticleMaker::makeDefinitionFor(
 
     return  std::make_shared<ArticleRequest>( phrase, activeGroup ? activeGroup->name : "",
                                contexts, unmutedDicts, header,
-                               collapseBigArticles ? articleLimitSize : -1,
+                               cfg.collapseBigArticles ? cfg.articleSizeLimit : -1,
                                cfg.alwaysExpandOptionalParts, ignoreDiacritics );
   }
   else
     return std::make_shared<ArticleRequest>( phrase, activeGroup ? activeGroup->name : "",
                                contexts, activeDicts, header,
-                               collapseBigArticles ? articleLimitSize : -1,
+                               cfg.collapseBigArticles ? cfg.articleSizeLimit : -1,
                                cfg.alwaysExpandOptionalParts, ignoreDiacritics );
 }
 
@@ -421,12 +410,6 @@ sptr< Dictionary::DataRequest > ArticleMaker::makePicturePage( string const & ur
   memcpy( &( r->getData().front() ), result.data(), result.size() );
 
   return r;
-}
-
-void ArticleMaker::setCollapseParameters( bool autoCollapse, int articleSize )
-{
-  collapseBigArticles = autoCollapse;
-  articleLimitSize = articleSize;
 }
 
 

--- a/article_maker.hh
+++ b/article_maker.hh
@@ -22,26 +22,15 @@ class ArticleMaker: public QObject
   std::vector< Instances::Group > const & groups;
   const Config::Preferences & cfg;
 
-  QString displayStyle, addonStyle;
-
-  bool collapseBigArticles;
-  int articleLimitSize;
-
 public:
 
   /// On construction, a reference to all dictionaries and a reference all
   /// groups' instances are to be passed. Those references are kept stored as
   /// references, and as such, any changes to them would reflect on the results
   /// of the inquiries, although those changes are perfectly legal.
-  ArticleMaker( std::vector< sptr< Dictionary::Class > > const & dictionaries,
-                std::vector< Instances::Group > const & groups,
-                const Config::Preferences & cfg,
-                QString const & displayStyle,
-                QString const & addonStyle);
-
-  /// Sets the display style to use for any new requests. This affects the
-  /// choice of the stylesheet file.
-  void setDisplayStyle( QString const &, QString const & addonStyle );
+ ArticleMaker( std::vector< sptr< Dictionary::Class > > const & dictionaries,
+               std::vector< Instances::Group > const & groups,
+               const Config::Preferences & cfg );
 
   /// Looks up the given phrase within the given group, and creates a full html
   /// page text containing its definition.
@@ -73,9 +62,6 @@ public:
   /// Add base path to file path if it's relative and file not found
   /// Return true if path successfully adjusted
   static bool adjustFilePath( QString & fileName );
-
-  /// Set collapse articles parameters
-  void setCollapseParameters( bool autoCollapse, int articleSize );
 
 private:
   std::string readCssFile(QString const& fileName, std::string type) const;


### PR DESCRIPTION
Replace https://github.com/xiaoyifang/goldendict/pull/403

Now the code make sense. If any of the 6 parameters changed, reload().

