### PR TITLE
cleanup: remove all useless #include <QDebug>

### DIFF
--- a/bgl.cc
+++ b/bgl.cc
@@ -29,7 +29,6 @@
 #include <QSemaphore>
 #include <QThreadPool>
 #include <QAtomicInt>
-#include <QDebug>
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6,0,0))
 #include <QtCore5Compat/QRegExp>

--- a/bgl_babylon.cc
+++ b/bgl_babylon.cc
@@ -33,7 +33,6 @@
 #include "iconv.hh"
 #include "htmlescape.hh"
 #include <QString>
-#include <QDebug>
 #include "dictionary.hh"
 #include "wstring_qt.hh"
 

--- a/dictdfiles.cc
+++ b/dictdfiles.cc
@@ -20,7 +20,6 @@
 #include "ftshelpers.hh"
 #include <QUrl>
 
-#include <QDebug>
 
 #include <QRegularExpression>
 

--- a/dictionarybar.cc
+++ b/dictionarybar.cc
@@ -6,7 +6,6 @@
 #include <QProcess>
 #include "gddebug.hh"
 #include "fsencoding.hh"
-#include <QDebug>
 
 using std::vector;
 

--- a/favoritespanewidget.cc
+++ b/favoritespanewidget.cc
@@ -1,7 +1,6 @@
 /* This file is (c) 2017 Abs62
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
-#include <QDebug>
 #include <QApplication>
 #include <QDockWidget>
 #include <QKeyEvent>

--- a/ffmpegaudio.cc
+++ b/ffmpegaudio.cc
@@ -15,7 +15,6 @@ extern "C" {
 
 #include <QString>
 #include <QDataStream>
-#include <QDebug>
 
 #include <vector>
 #if( QT_VERSION >= QT_VERSION_CHECK( 6, 2, 0 ) )

--- a/gdappstyle.cc
+++ b/gdappstyle.cc
@@ -7,7 +7,6 @@
 
 #include <QWidget>
 #include <QToolButton>
-#include <QDebug>
 
 GdAppStyle::GdAppStyle(QProxyStyle * parent) : QProxyStyle(parent) {}
 

--- a/history.cc
+++ b/history.cc
@@ -5,7 +5,6 @@
 #include "config.hh"
 #include "atomic_rename.hh"
 #include <QFile>
-#include <QDebug>
 
 History::History( unsigned size, unsigned maxItemLength_ ): maxSize( size ),
   maxItemLength( maxItemLength_ ), addingEnabled( true )

--- a/historypanewidget.cc
+++ b/historypanewidget.cc
@@ -1,7 +1,6 @@
 /* This file is (c) 2013 Tvangeste <i.4m.l33t@yandex.ru>
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
-#include <QDebug>
 #include <QApplication>
 #include <QDockWidget>
 #include <QKeyEvent>

--- a/iconv.cc
+++ b/iconv.cc
@@ -5,7 +5,6 @@
 #include <vector>
 #include <errno.h>
 #include <string.h>
-#include <QDebug>
 #include "wstring_qt.hh"
 
 char const * const Iconv::GdWchar = "UTF-32LE";

--- a/indexedzip.cc
+++ b/indexedzip.cc
@@ -13,7 +13,6 @@
 #else
 #include <QTextCodec>
 #endif
-#include <QDebug>
 
 using namespace BtreeIndexing;
 using std::vector;

--- a/lsa.cc
+++ b/lsa.cc
@@ -22,7 +22,6 @@
 #include <vorbis/vorbisfile.h>
 #include <QDir>
 #include <QUrl>
-#include <QDebug>
 #include <QFile>
 
 #include "utils.hh"

--- a/main.cc
+++ b/main.cc
@@ -28,7 +28,6 @@
 #include "atomic_rename.hh"
 #include <QtWebEngineCore/QWebEngineUrlScheme>
 #include <QMessageBox>
-#include <QDebug>
 #include <QFile>
 #include <QByteArray>
 #include <QString>

--- a/mainstatusbar.cc
+++ b/mainstatusbar.cc
@@ -6,7 +6,6 @@
 #include <Qt>
 #include <QFrame>
 #include <QVBoxLayout>
-#include <QDebug>
 #include <QEvent>
 #include <QApplication>
 

--- a/maintabwidget.cc
+++ b/maintabwidget.cc
@@ -2,7 +2,6 @@
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
 #include "maintabwidget.hh"
-#include <QDebug>
 #include <QEvent>
 #include <QMouseEvent>
 

--- a/sdict.cc
+++ b/sdict.cc
@@ -26,7 +26,6 @@
 #include <QSemaphore>
 #include <QThreadPool>
 #include <QAtomicInt>
-#include <QDebug>
 #include <QRegExp>
 #if (QT_VERSION >= QT_VERSION_CHECK(6,0,0))
 #include <QtCore5Compat>

--- a/sounddir.cc
+++ b/sounddir.cc
@@ -17,7 +17,6 @@
 #include <set>
 #include <QDir>
 #include <QFileInfo>
-#include <QDebug>
 
 namespace SoundDir {
 

--- a/stardict.cc
+++ b/stardict.cc
@@ -41,7 +41,6 @@
 #include <QSemaphore>
 #include <QThreadPool>
 #include <QAtomicInt>
-#include <QDebug>
 #if (QT_VERSION >= QT_VERSION_CHECK(6,0,0))
 #include <QtCore5Compat/QRegExp>
 #else

--- a/translatebox.cc
+++ b/translatebox.cc
@@ -8,7 +8,6 @@
 #include <QEvent>
 #include <QKeyEvent>
 #include <QApplication>
-#include <QDebug>
 #include <QModelIndex>
 #include <QScrollBar>
 #include <QStyle>

--- a/wordlist.cc
+++ b/wordlist.cc
@@ -1,7 +1,6 @@
 /* This file is (c) 2013 Tvangeste <i.4m.l33t@yandex.ru>
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
-#include <QDebug>
 
 #include "wordlist.hh"
 

--- a/xdxf.cc
+++ b/xdxf.cc
@@ -37,7 +37,6 @@
 #include <QFileInfo>
 #include <QDir>
 #include <QPainter>
-#include <QDebug>
 #include <QRegExp>
 #if (QT_VERSION >= QT_VERSION_CHECK(6,0,0))
 #include <QtCore5Compat>

--- a/xdxf2html.cc
+++ b/xdxf2html.cc
@@ -13,7 +13,6 @@
 #include "filetype.hh"
 #include "htmlescape.hh"
 #include "utils.hh"
-#include <QDebug>
 #include "xdxf.hh"
 
 #include <QRegularExpression>

--- a/zim.cc
+++ b/zim.cc
@@ -33,7 +33,6 @@
 #include <QAtomicInt>
 #include <QImage>
 #include <QDir>
-#include <QDebug>
 
 #include <QRegularExpression>
 

--- a/zipsounds.cc
+++ b/zipsounds.cc
@@ -18,7 +18,6 @@
 #include <string>
 #include <QFile>
 #include <QDir>
-#include <QDebug>
 
 #ifdef _MSC_VER
 #include <stub_msvc.h>


### PR DESCRIPTION
Their existence has no purpose.

qDebug is part of `<QtGlobal>` which is included by almost all other headers.

https://doc.qt.io/qt-6/qtglobal.html#details