### PR TITLE
give external programs access to translateLine via %GDSEARCH%

### DIFF
--- a/globalbroadcaster.h
+++ b/globalbroadcaster.h
@@ -26,6 +26,7 @@ public:
   bool existedInWhitelist(QString host);
   static GlobalBroadcaster * instance();
   unsigned currentGroupId;
+  QString translateLineText{};
 
 signals:
   void dictionaryChanges( ActiveDictIds ad );

--- a/locale/ru_RU.ts
+++ b/locale/ru_RU.ts
@@ -4738,8 +4738,8 @@ of the appropriate groups to use them.</source>
     </message>
     <message>
         <location filename="../sources.ui" line="409"/>
-        <source>Any external programs. A string %GDWORD% will be replaced with the query word. If such string is not presented, the word will be fed into standard input. A string %GDSEARCH% will be replaced with the text in the searchbar.</source>
-        <translation>Любые внешние программы. Строка %GDWORD% будет заменена на запрашиваемое слово. Если такой строки нет, слово будет отправлено в стандартный входной поток. Строка %GDSEARCH% будет заменена на текст в поисковой строке.</translation>
+        <source>Any external programs. A string %GDWORD% will be replaced with the query word. A string %GDSEARCH% will be replaced with the text in the search bar. If both of the parameters are not provided, the headword will be fed into standard input.</source>
+        <translation>Любые внешние программы. Строка %GDWORD% будет заменена на запрашиваемое слово. Строка %GDSEARCH% будет заменена на текст в поисковой строке. Если обоих строк нет задано, запрашиваемое слово будет отправлено в стандартный входной поток внешней программы.</translation>
     </message>
     <message>
         <location filename="../sources.ui" line="462"/>

--- a/locale/ru_RU.ts
+++ b/locale/ru_RU.ts
@@ -4738,8 +4738,8 @@ of the appropriate groups to use them.</source>
     </message>
     <message>
         <location filename="../sources.ui" line="409"/>
-        <source>Any external programs. A string %GDWORD% will be replaced with the query word. If such string is not presented, the word will be fed into standard input.</source>
-        <translation>Любые внешние программы. Строка %GDWORD% будет заменена на запрашиваемое слово. Если такой строки нет, слово будет отправлено в стандартный входной поток.</translation>
+        <source>Any external programs. A string %GDWORD% will be replaced with the query word. If such string is not presented, the word will be fed into standard input. A string %GDSEARCH% will be replaced with the text in the searchbar.</source>
+        <translation>Любые внешние программы. Строка %GDWORD% будет заменена на запрашиваемое слово. Если такой строки нет, слово будет отправлено в стандартный входной поток. Строка %GDSEARCH% будет заменена на текст в поисковой строке.</translation>
     </message>
     <message>
         <location filename="../sources.ui" line="462"/>

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -2342,6 +2342,8 @@ void MainWindow::translateInputChanged( QString const & newValue )
 {
   updateSuggestionList( newValue );
   translateBoxSuffix = QString();
+  // Save translate line text. Later it can be passed to external applications.
+  GlobalBroadcaster::instance()->translateLineText = newValue;
 }
 
 void MainWindow::updateSuggestionList()

--- a/programs.cc
+++ b/programs.cc
@@ -158,13 +158,13 @@ bool RunInstance::start( Config::Program const & prg, QString const & word,
     auto const & search_string = GlobalBroadcaster::instance()->translateLineText;
 
     for( auto & arg : args ) {
-    if( arg.indexOf( "%GDWORD%" ) >= 0 ) {
-      writeToStdInput = false;
-      arg.replace( "%GDWORD%", word );
-    }
-    if( arg.indexOf( "%GDSEARCH%" ) >= 0 ) {
-      arg.replace( "%GDSEARCH%", search_string );
-    }
+      if( arg.indexOf( "%GDWORD%" ) >= 0 ) {
+        writeToStdInput = false;
+        arg.replace( "%GDWORD%", word );
+      }
+      if( arg.indexOf( "%GDSEARCH%" ) >= 0 ) {
+        arg.replace( "%GDSEARCH%", search_string );
+      }
     }
 
     process.start( programName, args );

--- a/programs.cc
+++ b/programs.cc
@@ -9,6 +9,7 @@
 #include "parsecmdline.hh"
 #include "iconv.hh"
 #include "utils.hh"
+#include "globalbroadcaster.h"
 
 #include <QDir>
 #include <QFileInfo>
@@ -154,13 +155,17 @@ bool RunInstance::start( Config::Program const & prg, QString const & word,
     args.pop_front();
 
     bool writeToStdInput = true;
+    auto const & search_string = GlobalBroadcaster::instance()->translateLineText;
 
-    for( int x = 0; x < args.size(); ++x )
-      if( args[ x ].indexOf( "%GDWORD%" ) >= 0 )
-      {
-        writeToStdInput = false;
-        args[ x ].replace( "%GDWORD%", word );
-      }
+    for( int x = 0; x < args.size(); ++x ) {
+    if( args[ x ].indexOf( "%GDWORD%" ) >= 0 ) {
+      writeToStdInput = false;
+      args[ x ].replace( "%GDWORD%", word );
+    }
+    if( args[ x ].indexOf( "%GDSEARCH%" ) >= 0 ) {
+      args[ x ].replace( "%GDSEARCH%", search_string );
+    }
+    }
 
     process.start( programName, args );
     if( writeToStdInput )

--- a/programs.cc
+++ b/programs.cc
@@ -157,13 +157,13 @@ bool RunInstance::start( Config::Program const & prg, QString const & word,
     bool writeToStdInput = true;
     auto const & search_string = GlobalBroadcaster::instance()->translateLineText;
 
-    for( int x = 0; x < args.size(); ++x ) {
-    if( args[ x ].indexOf( "%GDWORD%" ) >= 0 ) {
+    for( auto & arg : args ) {
+    if( arg.indexOf( "%GDWORD%" ) >= 0 ) {
       writeToStdInput = false;
-      args[ x ].replace( "%GDWORD%", word );
+      arg.replace( "%GDWORD%", word );
     }
-    if( args[ x ].indexOf( "%GDSEARCH%" ) >= 0 ) {
-      args[ x ].replace( "%GDSEARCH%", search_string );
+    if( arg.indexOf( "%GDSEARCH%" ) >= 0 ) {
+      arg.replace( "%GDSEARCH%", search_string );
     }
     }
 

--- a/programs.cc
+++ b/programs.cc
@@ -163,6 +163,7 @@ bool RunInstance::start( Config::Program const & prg, QString const & word,
         arg.replace( "%GDWORD%", word );
       }
       if( arg.indexOf( "%GDSEARCH%" ) >= 0 ) {
+        writeToStdInput = false;
         arg.replace( "%GDSEARCH%", search_string );
       }
     }

--- a/sources.ui
+++ b/sources.ui
@@ -409,7 +409,7 @@ of the appropriate groups to use them.</string>
        <item>
         <widget class="QLabel" name="label_16">
          <property name="text">
-          <string>Any external programs. A string %GDWORD% will be replaced with the query word. If such string is not presented, the word will be fed into standard input.</string>
+          <string>Any external programs. A string %GDWORD% will be replaced with the query word. If such string is not presented, the word will be fed into standard input. A string %GDSEARCH% will be replaced with the text in the searchbar.</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>

--- a/sources.ui
+++ b/sources.ui
@@ -409,7 +409,7 @@ of the appropriate groups to use them.</string>
        <item>
         <widget class="QLabel" name="label_16">
          <property name="text">
-          <string>Any external programs. A string %GDWORD% will be replaced with the query word. If such string is not presented, the word will be fed into standard input. A string %GDSEARCH% will be replaced with the text in the searchbar.</string>
+          <string>Any external programs. A string %GDWORD% will be replaced with the query word. A string %GDSEARCH% will be replaced with the text in the search bar. If both of the parameters are not provided, the headword will be fed into standard input.</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>


### PR DESCRIPTION
This PR allows the contents of the search bar to be passed to external programs, using the %GDSEARCH% keyword. 

![screenshot-2023-03-22-23-59-38](https://user-images.githubusercontent.com/69171671/227155161-3254f8cd-e5f0-48dc-aba8-f94cb750d1fd.png)

This could be useful for programs like Mecab that split sentences into individual words. You could look up a full sentence, then click on the individual words, but the sentence will not disappear since it is passed as a separate argument.
Without this PR it is hard to implement since %GDWORD% changes every time you click on a new word.

Example: 

https://user-images.githubusercontent.com/50422430/226139459-0c8bcf0e-e68f-491e-8171-bae3f50a7ae1.mp4