### PR TITLE
update .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,23 +1,35 @@
-# Format Style Options - Created with Clang Power Tools
 ---
-AccessModifierOffset: -1
+Language: Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
 AlignConsecutiveAssignments: Consecutive
+AlignConsecutiveBitFields: Consecutive
+AlignConsecutiveDeclarations: None
+AlignConsecutiveMacros: Consecutive
 AlignEscapedNewlines: Left
 AlignOperands: DontAlign
 AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: Empty
-AllowShortLambdasOnASingleLine: None
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
 AllowShortEnumsOnASingleLine: false
 AlwaysBreakBeforeMultilineStrings: true
-BasedOnStyle: LLVM
+AlwaysBreakTemplateDeclarations: MultiLine
 BinPackArguments: false
 BinPackParameters: false
-BraceWrapping: 
+BraceWrapping:
   AfterCaseLabel: false
   AfterClass: true
-  AfterControlStatement: false
+  AfterControlStatement: Never
   AfterEnum: false
   AfterFunction: true
   AfterNamespace: false
@@ -35,35 +47,99 @@ BraceWrapping:
   BeforeWhile: false
 BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
 BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: AfterColon
 BreakStringLiterals: false
 ColumnLimit: 120
+QualifierAlignment: Leave
+CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth : 2
 ContinuationIndentWidth: 2
+Cpp11BracedListStyle: true
 DeriveLineEnding: false
-EmptyLineBeforeAccessModifier: Leave
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Leave
+EmptyLineBeforeAccessModifier: Always
 ExperimentalAutoDetectBinPacking: true
-FixNamespaceComments: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: true
+ForEachMacros:
+  - Q_FOREACH
 IncludeBlocks: Regroup
 IndentCaseLabels: true
 IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
 IndentPPDirectives: BeforeHash
+IndentExternBlock: AfterExternBlock
+IndentRequiresClause: true
+IndentWidth: 2
+IndentWrappedFunctionNames: false
+InsertBraces: false
+InsertTrailingCommas: None
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd: ''
 MaxEmptyLinesToKeep: 2
-NamespaceIndentation: Inner
+NamespaceIndentation: None
 PackConstructorInitializers: Never
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyIndentedWhitespace: 0
 PointerAlignment: Middle
+PPIndentWidth:   -1
+ReferenceAlignment: Pointer
 ReflowComments: false
-SortIncludes: false
+SortIncludes: Never
+RequiresClausePosition: OwnLine
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
 SortUsingDeclarations: false
-SpaceAfterCStyleCast: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: false
 SpaceBeforeInheritanceColon: false
-SpaceBeforeParens: Never
+SpaceBeforeParens: ControlStatements
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
 SpacesInAngles: true
 SpacesInConditionalStatement: true
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: -1
 SpacesInParentheses: true
 SpacesInSquareBrackets: true
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard: Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+UseCRLF: false
 UseTab: Never
 ...

--- a/howto/how to use .clang-format to format the code.md
+++ b/howto/how to use .clang-format to format the code.md
@@ -6,8 +6,13 @@ the project has included a .clang-format as the code guideline.
 # How to use this file
 
 
-## QtCreator:
+## CommandLine
 
+Stash changes via `git add files` then `git-clang-format`
+
+<https://clang.llvm.org/docs/ClangFormat.html#git-integration>
+
+## QtCreator:
 
 Check the steps in the following webpage.
 https://doc.qt.io/qtcreator/creator-indenting-code.html#automatic-formatting-and-indentation


### PR DESCRIPTION
close https://github.com/xiaoyifang/goldendict/issues/424 via "Solution 1"

To test this change:

1. open `config.cc`, find the part below, remove all identifications

```
if ( !ves.isNull() )
{
QDomNodeList nl = ves.toElement().elementsByTagName( "voiceEngine" );

for ( int x = 0; x < nl.length(); ++x )
{
QDomElement ve = nl.item( x ).toElement();
VoiceEngine v;

v.enabled = ve.attribute( "enabled" ) == "1";
v.id = ve.attribute( "id" );
v.name = ve.attribute( "name" );
v.iconFilename = ve.attribute( "icon" );
v.volume = ve.attribute( "volume", "50" ).toInt();
if( v.volume < 0 || v.volume > 100 )
v.volume = 50;
v.rate = ve.attribute( "rate", "50" ).toInt();
if( v.rate < 0 || v.rate > 100 )
v.rate = 50;
c.voiceEngines.push_back( v );
}
}
```

2. `git add config.cc`
3. run`git-clang-format` (included in clang) to reformat within the `goldendict/`
4. The code is correctly formatted
5. Try reformat entire file → unnamed namespaces won't cause entire file reformat.

The problem is fixed in `NamespaceIndentation: Inner` which is changed to `NamespaceIndentation: None`.

The result of changes is added according to `mainwindow.cc` `mainwindow.hh` `ankiconnector.cc` and `config.cc`. The goal is to minimize how many lines will be changed for a whole file reformat.

The `public:` indent is fixed.

The `if else` is adjusted as below. This appears to be what past maintainers and you would write

```
if() // no space between `if` and `()` -> in existing code 50% has space another 50% don't
{
  asd
}
else
{
  asd
}
```

