### PR TITLE
fix: wikimedia will cause cpu rise to 10%

### DIFF
--- a/article_netmgr.cc
+++ b/article_netmgr.cc
@@ -467,16 +467,16 @@ qint64 ArticleResourceReply::readData( char * out, qint64 maxSize )
   qint64 left = avail - alreadyRead;
   
   qint64 toRead = maxSize < left ? maxSize : left;
-  GD_DPRINTF( "====reading  %d of (%d) bytes . Finished: %d", (int)toRead, avail, finished );
 
   try
   {
-    req->getDataSlice( alreadyRead, toRead, out );
+    toRead = req->getDataSlice( alreadyRead, toRead, out );
   }
   catch( std::exception & e )
   {
     qWarning( "getDataSlice error: %s", e.what() );
   }
+  GD_DPRINTF( "====reading already readed: %d of %d bytes, toRead:%d.%d  Finished: %d", alreadyRead, avail, (int)toRead,maxSize, finished );
 
   alreadyRead += toRead;
 
@@ -546,7 +546,8 @@ void LocalSchemeHandler::requestStarted(QWebEngineUrlRequestJob *requestJob)
   }
 
   QNetworkReply * reply = this->mManager.getArticleReply( request );
+
   requestJob->reply( "text/html", reply );
-  //connect( reply, &QNetworkReply::finished, requestJob, [ = ]() {  } );
+
   connect( requestJob, &QObject::destroyed, reply, &QObject::deleteLater );
 }

--- a/dictionary.hh
+++ b/dictionary.hh
@@ -190,7 +190,7 @@ public:
 
   /// Writes "size" bytes starting from "offset" of the data read to the given
   /// buffer. "size + offset" must be <= than dataSize().
-  void getDataSlice( size_t offset, size_t size, void * buffer );
+  size_t getDataSlice( size_t offset, size_t size, void * buffer );
   void appendDataSlice( const void * buffer, size_t size );
 
   /// Returns all the data read. Since no further locking can or would be

--- a/mediawiki.cc
+++ b/mediawiki.cc
@@ -145,6 +145,7 @@ MediaWikiWordSearchRequest::MediaWikiWordSearchRequest( wstring const & str,
 
 MediaWikiWordSearchRequest::~MediaWikiWordSearchRequest()
 {
+  finish();
   GD_DPRINTF( "request end\n" );
 }
 
@@ -425,10 +426,10 @@ void MediaWikiArticleRequest::addQuery( QNetworkAccessManager & mgr,
   Utils::Url::addQueryItem( reqUrl, "page", gd::toQString( str ).replace( '+', "%2B" ) );
   QNetworkRequest req( reqUrl ) ;
   //millseconds.
-  req.setTransferTimeout(3000);
+  req.setTransferTimeout(2000);
   QNetworkReply * netReply = mgr.get(req);
   connect( netReply, &QNetworkReply::errorOccurred, this, [=](QNetworkReply::NetworkError e){
-            qDebug()<<  "error:"<<e;
+      qDebug()<<  "error:"<<e;
    } );
 #ifndef QT_NO_SSL
 


### PR DESCRIPTION
together with previous nonblock changes  ,replyjob continue to read data with available byte count=0 while wikimedia response is not return.

 getDataSlice return 0 immediately .
This will cause a loop which will make  rise a little