### PR TITLE
Add "make anki note" buttons to displayed articles.

### DIFF
--- a/ankiconnector.cpp
+++ b/ankiconnector.cpp
@@ -17,9 +17,12 @@ AnkiConnector::AnkiConnector( QObject * parent, Config::Class const & _cfg ) : Q
   connect( mgr, &QNetworkAccessManager::finished, this, &AnkiConnector::finishedSlot );
 }
 
-void AnkiConnector::sendToAnki( QString const & word, QString const & text, QString const & sentence )
+void AnkiConnector::sendToAnki( QString const & word, QString text, QString const & sentence )
 {
-  QString postTemplate = R"anki({
+  // Anki doesn't understand the newline character, so it should be escaped.
+  text = text.replace( "\n", "<br>" );
+
+  QString const postTemplate = R"anki({
       "action": "addNote",
       "version": 6,
       "params": {
@@ -48,7 +51,7 @@ void AnkiConnector::sendToAnki( QString const & word, QString const & text, QStr
                                        Utils::json2String( fields ) );
 
 //  qDebug().noquote() << postData;
-    postToAnki( postData );
+  postToAnki( postData );
 }
 
 void AnkiConnector::ankiSearch( QString const & word )
@@ -91,26 +94,25 @@ void AnkiConnector::postToAnki( QString const & postData )
 
 void AnkiConnector::finishedSlot( QNetworkReply * reply )
 {
-  if( reply->error() == QNetworkReply::NoError )
-  {
-    QByteArray bytes   = reply->readAll();
-    QJsonDocument json = QJsonDocument::fromJson( bytes );
-    auto obj           = json.object();
-    if( obj.size() != 2 || !obj.contains( "error" ) || !obj.contains( "result" ) ||
-        obj[ "result" ].toString().isEmpty() )
-    {
-      emit errorText( QObject::tr( "anki: post to anki failed" ) );
-    }
-    QString result = obj[ "result" ].toString();
+  if ( reply->error() == QNetworkReply::NoError ) {
+      QByteArray const bytes   = reply->readAll();
+      QJsonDocument const json = QJsonDocument::fromJson( bytes );
+      auto const obj           = json.object();
 
-    qDebug() << "anki result:" << result;
+      // Normally AnkiConnect always returns result and error,
+      // unless Anki is not running.
+      if ( obj.size() == 2 && obj.contains( "result" ) && obj.contains( "error" ) && obj[ "error" ].isNull() ) {
+        emit errorText( tr( "anki: post to anki success" ) );
+      }
+      else {
+        emit errorText( tr( "anki: post to anki failed" ) );
+      }
 
-    emit errorText( tr( "anki: post to anki success" ) );
+      qDebug().noquote() << "anki response:" << Utils::json2String( obj );
   }
-  else
-  {
-    qDebug() << "anki connect error" << reply->errorString();
-    emit errorText( "anki:" + reply->errorString() );
+  else {
+      qDebug() << "anki connect error" << reply->errorString();
+      emit errorText( "anki:" + reply->errorString() );
   }
 
   reply->deleteLater();

--- a/ankiconnector.cpp
+++ b/ankiconnector.cpp
@@ -19,6 +19,11 @@ AnkiConnector::AnkiConnector( QObject * parent, Config::Class const & _cfg ) : Q
 
 void AnkiConnector::sendToAnki( QString const & word, QString text, QString const & sentence )
 {
+  if ( word.isEmpty() ) {
+    emit this->errorText( tr( "anki: can't create a card without a word" ) );
+    return;
+  }
+
   // Anki doesn't understand the newline character, so it should be escaped.
   text = text.replace( "\n", "<br>" );
 

--- a/ankiconnector.h
+++ b/ankiconnector.h
@@ -13,7 +13,7 @@ class AnkiConnector : public QObject
 public:
   explicit AnkiConnector( QObject * parent, Config::Class const & cfg );
 
-  void sendToAnki( QString const & word, QString const & text, QString const & sentence );
+  void sendToAnki( QString const & word, QString text, QString const & sentence );
   void ankiSearch( QString const & word);
 
 private:

--- a/article-style.css
+++ b/article-style.css
@@ -45,17 +45,13 @@ pre
   padding-left: 0.5em;
   background: #def;
   user-select: none;
-
-  display: flex;
-  flex-flow: row nowrap;
-  align-items: center;
 }
 
 /* The anki plus button, which is shown if enabled. */
 .ankibutton {
+  float: right;
   display: grid;
   place-items: center;
-  margin-inline-start: auto;
   cursor: pointer;
   border-radius: 4px;
   padding: 3px;

--- a/article-style.css
+++ b/article-style.css
@@ -45,6 +45,24 @@ pre
   padding-left: 0.5em;
   background: #def;
   user-select: none;
+
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+}
+
+/* The anki plus button, which is shown if enabled. */
+.ankibutton {
+  display: grid;
+  place-items: center;
+  margin-inline-start: auto;
+  cursor: pointer;
+  border-radius: 4px;
+  padding: 3px;
+  transition: background-color 0.2s;
+}
+.ankibutton:active {
+  background-color: hsl(0deg 0% 70%);
 }
 
 .gddicttitle

--- a/article_maker.cc
+++ b/article_maker.cc
@@ -565,42 +565,25 @@ QString ArticleRequest::constructDictHeading( std::string const & dict_id_html,
   // Start .gddictname
   // Resort to QString here to be able to use its arg() method.
   QString gd_dict_name = QString( R"EOF(<div class="gddictname" id="gddictname-%1">)EOF" ).arg( dict_id_html.c_str() );
+  QString html_temp{};
 
   // Icon
-  gd_dict_name += [ &dict_name, &dict_id_html ]() {
-    auto html = QString( R"EOF(
-          <span class="gddicticon"><img src="gico://%1/dicticon.png"></span>
-          <span class="gdfromprefix">%2</span>
-          <span class="gddicttitle">%3</span>
-          )EOF" );
-    return html.arg( dict_id_html.c_str(), tr( "From " ), dict_name.c_str() );
-  }();
+  html_temp = R"EOF(
+  <span class="gddicticon"><img src="gico://%1/dicticon.png"></span>
+  <span class="gdfromprefix">%2</span>
+  <span class="gddicttitle">%3</span>
+  )EOF";
+  gd_dict_name += html_temp.arg( dict_id_html.c_str(), tr( "From " ), dict_name.c_str() );
 
   // Collapse/expand button (blue arrow)
-  gd_dict_name += [ collapse, &dict_id_html ]() {
-    auto html = QString( R"EOF(
-          <span class="collapse_expand_area" onclick="gdExpandArticle('%1');" >
-          <img src="qrc:///icons/blank.png" class="%2" id="expandicon-%3" title="%4">
-          </span>)EOF" );
-    return html.arg( dict_id_html.c_str(),
-                     collapse ? "gdexpandicon" : "gdcollapseicon",
-                     dict_id_html.c_str(),
-                     collapse ? tr( "Expand article" ) : tr( "Collapse article" ) );
-  }();
-
-  // If the user has enabled Anki integration in settings,
-  // Show a (+) button that lets the user add a new Anki card.
-  gd_dict_name += [ &dict_id_html ]() {
-    if ( ankiConnectEnabled() ) {
-      auto link = QString( R"EOF(
-            <a href="ankicard:%1" class="ankibutton" title="%2" >
-            <img src="qrc:///icons/add-anki-icon.svg">
-            </a>
-            )EOF" );
-      return link.arg( dict_id_html.c_str(), tr( "Make a new Anki note" ) );
-    }
-    return QString{};
-  }();
+  html_temp = R"EOF(
+  <span class="collapse_expand_area" onclick="gdExpandArticle('%1');" >
+  <img src="qrc:///icons/blank.png" class="%2" id="expandicon-%3" title="%4">
+  </span>)EOF";
+  gd_dict_name += html_temp.arg( dict_id_html.c_str(),
+                                 collapse ? "gdexpandicon" : "gdcollapseicon",
+                                 dict_id_html.c_str(),
+                                 collapse ? tr( "Expand article" ) : tr( "Collapse article" ) );
 
   // Close .gddictname
   gd_dict_name += "</div>";
@@ -700,6 +683,17 @@ void ArticleRequest::bodyFinished()
         head += constructDictHeading( Html::escape( dictId ), activeDict->getName(), collapse ).toStdString();
 
         head += "<div class=\"gddictnamebodyseparator\"></div>";
+
+        // If the user has enabled Anki integration in settings,
+        // Show a (+) button that lets the user add a new Anki card.
+        if ( ankiConnectEnabled() ) {
+          QString link{ R"EOF(
+          <a href="ankicard:%1" class="ankibutton" title="%2" >
+          <img src="qrc:///icons/add-anki-icon.svg">
+          </a>
+          )EOF" };
+          head += link.arg( Html::escape( dictId ).c_str(), tr( "Make a new Anki note" ) ).toStdString();
+        }
 
         head += "<div class=\"gdarticlebody gdlangfrom-";
         head += LangCoder::intToCode2( activeDict->getLangFrom() ).toLatin1().data();

--- a/article_maker.hh
+++ b/article_maker.hh
@@ -87,11 +87,12 @@ class ArticleRequest: public Dictionary::DataRequest
   
   std::set< gd::wstring > alts; // Accumulated main forms
   std::list< sptr< Dictionary::WordSearchRequest > > altSearches;
-  bool altsDone, bodyDone;
   std::list< sptr< Dictionary::DataRequest > > bodyRequests;
-  bool foundAnyDefinitions;
-  bool closePrevSpan; // Indicates whether the last opened article span is to
-                      // be closed after the article ends.
+  bool altsDone{ false };
+  bool bodyDone{ false };
+  bool foundAnyDefinitions{ false };
+  bool closePrevSpan{ false };          // Indicates whether the last opened article span is to
+                                        // be closed after the article ends.
   sptr< WordFinder > stemmedWordFinder; // Used when there're no results
 
   /// A sequence of words and spacings between them, including the initial
@@ -151,6 +152,10 @@ private:
 
   /// Find end of corresponding </div> tag
   int findEndOfCloseDiv( QString const &, int pos );
+
+  // A method used for constructing a dictionary heading,
+  // e.g. <div class="gddictname" >...</div>
+  QString constructDictHeading( std::string const & dict_id_html, std::string const & dict_name, bool const collapse );
 };
 
 

--- a/article_maker.hh
+++ b/article_maker.hh
@@ -152,10 +152,6 @@ private:
 
   /// Find end of corresponding </div> tag
   int findEndOfCloseDiv( QString const &, int pos );
-
-  // A method used for constructing a dictionary heading,
-  // e.g. <div class="gddictname" >...</div>
-  QString constructDictHeading( std::string const & dict_id_html, std::string const & dict_name, bool const collapse );
 };
 
 

--- a/config.cc
+++ b/config.cc
@@ -976,7 +976,7 @@ Class load()
     {
       c.preferences.ankiConnectServer.enabled = ( ankiConnectServer.toElement().attribute( "enabled" ) == "1" );
       c.preferences.ankiConnectServer.host = ankiConnectServer.namedItem( "host" ).toElement().text();
-      c.preferences.ankiConnectServer.port = ankiConnectServer.namedItem( "port" ).toElement().text().toULong();
+      c.preferences.ankiConnectServer.port    = ankiConnectServer.namedItem( "port" ).toElement().text().toInt();
       c.preferences.ankiConnectServer.deck = ankiConnectServer.namedItem( "deck" ).toElement().text();
       c.preferences.ankiConnectServer.model = ankiConnectServer.namedItem( "model" ).toElement().text();
 

--- a/config.hh
+++ b/config.hh
@@ -143,7 +143,8 @@ struct AnkiConnectServer
   bool enabled;
 
   QString host;
-  unsigned port;
+  int port; // Port will be passed to QUrl::setPort() which expects an int.
+
   QString deck;
   QString model;
 

--- a/icons/add-anki-icon.svg
+++ b/icons/add-anki-icon.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16" height="16" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs>
+  <linearGradient id="linearGradient4582" x1="-1.7198" x2="-1.7198" y1="3.5719" y2=".79375" gradientTransform="matrix(3.7795 0 0 3.7795 14.5 -6.308e-7)" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#6fb558" offset="0"/>
+   <stop stop-color="#a5db9b" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient4758-7" x1="7.5406" x2="5.1594" y1="3.3073" y2=".92604" gradientTransform="matrix(3.7795 0 0 3.7795 -16 -6e-7)" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#34812c" offset="0"/>
+   <stop stop-color="#87b870" offset="1"/>
+  </linearGradient>
+  <radialGradient id="radialGradient4683-3" cx="2.1167" cy="2.1167" r=".66146" gradientTransform="matrix(4.5354 8.0301e-7 -8.0301e-7 4.5354 -1.6 -1.6)" gradientUnits="userSpaceOnUse">
+   <stop stop-opacity=".28986" offset="0"/>
+   <stop stop-opacity="0" offset="1"/>
+  </radialGradient>
+ </defs>
+ <g>
+  <circle cx="8" cy="8" r="6.5" fill="url(#linearGradient4582)"/>
+  <circle cx="8" cy="8" r="5.75" fill="none" stroke="#fff" stroke-opacity=".50196" stroke-width="1.5"/>
+  <circle cx="8" cy="8" r="6.5" fill="none" stroke="url(#linearGradient4758-7)"/>
+  <circle cx="8" cy="8" r="3" fill="url(#radialGradient4683-3)"/>
+  <path d="m5 7h2v-2h2v2h2v2h-2v2h-2v-2h-2v-2" fill="#fff"/>
+ </g>
+</svg>

--- a/resources.qrc
+++ b/resources.qrc
@@ -1,5 +1,6 @@
 <RCC>
     <qresource prefix="/">
+        <file>icons/add-anki-icon.svg</file>
         <file>version.txt</file>
         <file>icons/arrow.png</file>
         <file>icons/prefix.png</file>

--- a/src/ui/articleview.cpp
+++ b/src/ui/articleview.cpp
@@ -539,8 +539,9 @@ void ArticleView::showDefinition( QString const & word, QStringList const & dict
   webview->setCursor( Qt::WaitCursor );
 }
 
-void ArticleView::sendToAnki(QString const & word, QString const & text, QString const & sentence ){
-  ankiConnector->sendToAnki(word,text,sentence);
+void ArticleView::sendToAnki( QString const & word, QString const & dict_definition, QString const & sentence )
+{
+  ankiConnector->sendToAnki( word, dict_definition, sentence );
 }
 
 void ArticleView::showAnticipation()

--- a/src/ui/articleview.cpp
+++ b/src/ui/articleview.cpp
@@ -1164,9 +1164,8 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref, QString const & 
   else if ( url.scheme().compare( "ankicard" ) == 0 ) {
     // If article id is set in path and selection is empty, use text from the current article.
     // Otherwise, grab currently selected text and use it as the definition.
-    if ( auto const selected_text = webview->selectedText(), article_id = url.path();
-         !article_id.isEmpty() && selected_text.isEmpty() ) {
-      makeAnkiCardFromArticle( article_id );
+    if ( !url.path().isEmpty() && webview->selectedText().isEmpty() ) {
+      makeAnkiCardFromArticle( url.path() );
     }
     else {
       sendToAnki( webview->title(), webview->selectedText(), translateLine->text() );

--- a/src/ui/articleview.cpp
+++ b/src/ui/articleview.cpp
@@ -1159,6 +1159,7 @@ void ArticleView::openLink( QUrl const & url, QUrl const & ref, QString const & 
     load( url );
   else if( url.scheme().compare( "ankisearch" ) == 0 ) {
     ankiConnector->ankiSearch( url.path() );
+    return;
   }
   else if ( url.scheme().compare( "ankicard" ) == 0 ) {
     // If article id is set in path and selection is empty, use text from the current article.

--- a/src/ui/articleview.cpp
+++ b/src/ui/articleview.cpp
@@ -1795,7 +1795,7 @@ void ArticleView::contextMenuRequested( QPoint const & pos )
       menu.addAction( saveSoundAction );
   }
 
-  QString selectedText = webview->selectedText();
+  QString const selectedText = webview->selectedText();
   QString text         = Utils::trimNonChar( selectedText );
 
   if ( text.size() && text.size() < 60 )

--- a/src/ui/articleview.cpp
+++ b/src/ui/articleview.cpp
@@ -1889,6 +1889,8 @@ void ArticleView::contextMenuRequested( QPoint const & pos )
   // If there is no selected text, it will extract text from the current article.
   if ( cfg.preferences.ankiConnectServer.enabled ) {
     menu.addAction( &sendToAnkiAction );
+    sendToAnkiAction.setText( webview->selectedText().isEmpty() ? tr( "&Send Current Article to Anki" ) :
+                                                                  tr( "&Send selected text to Anki" ) );
   }
 
   if( text.isEmpty() && !cfg.preferences.storeHistory)

--- a/src/ui/articleview.h
+++ b/src/ui/articleview.h
@@ -148,6 +148,10 @@ public:
   /// which will be restored when some article loads eventually.
   void showAnticipation();
 
+  /// Create a new Anki card from a currently displayed article with the provided id.
+  /// This function will call QWebEnginePage::runJavaScript() to fetch the corresponding HTML.
+  void makeAnkiCardFromArticle( QString const & article_id );
+
   /// Opens the given link. Supposed to be used in response to
   /// openLinkInNewTab() signal. The link scheme is therefore supposed to be
   /// one of the internal ones.

--- a/src/ui/articleview.h
+++ b/src/ui/articleview.h
@@ -55,6 +55,9 @@ class ArticleView: public QWidget
   bool expandOptionalParts;
   QString rangeVarName;
 
+  /// An action used to create Anki notes.
+  QAction sendToAnkiAction{ tr( "&Create Anki note" ), this };
+
   /// Any resource we've decided to download off the dictionary gets stored here.
   /// Full vector capacity is used for search requests, where we have to make
   /// a multitude of requests.
@@ -190,6 +193,9 @@ public:
 
   /// Takes the focus to the view
   void focus() { webview->setFocus( Qt::ShortcutFocusReason ); }
+
+  /// Sends *word* to Anki.
+  void handleAnkiAction();
 
 public:
 


### PR DESCRIPTION
This PR adds a "make a new anki note" button to each article if the user has configured Anki integration in Preferences. Pressing the button results in a new Anki note being added to one's Anki deck, with the corresponding article's text as the definition. If there is selected text, it will be sent instead, similarly to the context menu action that was added before.

![screenshot-2023-04-03-20-09-16](https://user-images.githubusercontent.com/69171671/229616188-7a84894c-afa3-43ac-a040-2151bbbef08a.png)

Having a button allows to mimic more closely the process of creating Anki cards with Yomichan. Yomichan also places a `+` button next to each search result on the right side.

![screenshot-2023-04-03-20-10-32](https://user-images.githubusercontent.com/69171671/229616495-33cdb6d6-8459-4558-8e4a-26616e3b5855.png)

Screencast:

https://user-images.githubusercontent.com/69171671/229608231-9cca36f0-8656-42b2-aaaa-ac61ad2c2f4a.mp4