### PR TITLE
epwing: add Synonym search

### DIFF
--- a/article_maker.cc
+++ b/article_maker.cc
@@ -226,8 +226,7 @@ std::string ArticleMaker::makeNotFoundBody( QString const & word,
 
   if ( word.size() )
     result += tr( "No translation for <b>%1</b> was found in group <b>%2</b>." ).
-              arg( QString::fromUtf8( Html::escape( str.toUtf8().data() ).c_str() ) ).
-              arg( QString::fromUtf8( Html::escape( group.toUtf8().data() ).c_str() ) ).
+              arg( QString::fromUtf8( Html::escape( str.toUtf8().data() ).c_str() ), QString::fromUtf8( Html::escape( group.toUtf8().data() ).c_str() ) ).
                 toUtf8().data();
   else
     result += tr( "No translation was found in group <b>%1</b>." ).


### PR DESCRIPTION
for  reference links ,  add the text which  the reference link pointed to as a synonym .

In epwing dictionary, the reference link can be at any place , not only limited to the headword.
it can point to any position in the article text
