### PR TITLE
Display exception description when unhandled exception got thrown

### DIFF
--- a/termination.cc
+++ b/termination.cc
@@ -9,8 +9,26 @@
 
 static void termHandler()
 {
-  QString message( "GoldenDict has crashed with an unexpected exception\n\n" );
-  qDebug() << message;
+
+  // Trick: In c++17, there is no standardized way to know the exception name/type inside terminate_handler
+  // So, we just get the exception and throw it again, so that we can call the std::exception::what :)
+
+  // This trick can be removed/improved if something similar to
+  // boost::current_exception_diagnostic_information got standardized,
+
+  std::exception_ptr curException = std::current_exception();
+
+  try {
+    if ( curException != nullptr ) {
+      std::rethrow_exception( curException );
+    }
+    else {
+      qDebug() << "GoldenDict has crashed unexpectedly.\n\n";
+    }
+  }
+  catch ( const std::exception & e ) {
+    qDebug() << "GoldenDict has crashed with exception: " << e.what() ;
+  }
 
   if( logFilePtr && logFilePtr->isOpen() )
     logFilePtr->close();


### PR DESCRIPTION
GD's exceptions right now are mostly defined with this

https://github.com/xiaoyifang/goldendict/blob/21fa719c03b358531effc6de91dba3d572715395/ex.hh#L9-L18

https://github.com/xiaoyifang/goldendict/blob/37a08d45d3db1a4a45e68a33d9277227f091ec6e/slob.cc#L67

The code has a problem: they are all unhandled. If the code calls `throw exName()`, they will end up in the `termHandler` with a message "GoldenDict has crashed with an **unexpected exception**", the `exDescription` is not used in anywhere.

This PR added a trick to display the `exDescription` so that we can know exactly where are the "expected" crash happens.

The original code use a similar method, but the method is not portable.

https://github.com/goldendict/goldendict/blob/8834e4a2924d143751870f4b943c3ce608b10a7d/termination.cc#L38-L42

---

To test the change, you can use a smaller program, try toggling `throw exUserAbort();` or directly `std::terminate`.

The `throw exUserboard()` will display a message with `exDescription`.

```cpp
#include <iostream>

#define DEF_EX( exName, exDescription, exParent ) \
class exName: public exParent { \
public: \
virtual const char * what() const noexcept { return (exDescription); } \
virtual ~exName() noexcept {} };

DEF_EX( exUserAbort, "User abort", std::exception);

static void termHandler()
{
    std::exception_ptr curException = std::current_exception();

    try {
        if ( curException != nullptr ) {
            std::rethrow_exception(curException);
        }
        else {
            std::cout << "GoldenDict has crashed with an unexpected exception\n\n";
        }
    }
    catch (const std::exception &e) {
        std::cout << "Exception thrown: " << e.what() << std::endl;
    }

}

int main() {
    std::set_terminate(termHandler);
    throw exUserAbort();
    //std::terminate();
}

```