### PR TITLE
simplify MRU ctrl release handling

### DIFF
--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -411,7 +411,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   // Tab management
   tabListMenu = new MRUQMenu(tr("Opened tabs"), ui.tabWidget);
 
-  connect( tabListMenu, &MRUQMenu::ctrlReleased, this, &MainWindow::ctrlReleased );
+  connect( tabListMenu, &MRUQMenu::requestTabChange, ui.tabWidget, &MainTabWidget::setCurrentIndex );
 
   connect( &addTabAction, &QAction::triggered, this, &MainWindow::addNewTab );
 
@@ -1813,19 +1813,6 @@ void MainWindow::switchToPrevTab()
     ui.tabWidget->setCurrentIndex( ui.tabWidget->count() - 1 );
   else
     ui.tabWidget->setCurrentIndex( ui.tabWidget->currentIndex() - 1 );
-}
-
-//emitted by tabListMenu when user releases Ctrl
-void MainWindow::ctrlReleased()
-{
-    if (tabListMenu->actions().size() > 1)
-    {
-        QAction *act = tabListMenu->activeAction();
-        if( act == 0 )
-          act = tabListMenu->actions().at( 1 );
-        ui.tabWidget->setCurrentIndex( act->data().toInt() );
-    }
-    tabListMenu->hide();
 }
 
 void MainWindow::backClicked()

--- a/mainwindow.hh
+++ b/mainwindow.hh
@@ -320,7 +320,6 @@ private slots:
   void closeRestTabs();
   void switchToNextTab();
   void switchToPrevTab();
-  void ctrlReleased();
 
   // Handling of active tab list
   void createTabList();

--- a/mruqmenu.cc
+++ b/mruqmenu.cc
@@ -2,20 +2,19 @@
 #include <QKeyEvent>
 
 MRUQMenu::MRUQMenu(const QString title, QWidget *parent):
-        QMenu(title,parent)
-{
-    installEventFilter(this);
-}
+  QMenu(title,parent)
+{}
 
-bool MRUQMenu::eventFilter(QObject *obj, QEvent *event)
-{
-    (void) obj;
-    if (event->type() == QEvent::KeyRelease){
-        QKeyEvent *keyevent = static_cast<QKeyEvent*>(event);
-        if (keyevent->key() == Qt::Key_Control){
-	    emit ctrlReleased();
-            return true;
-        }
+void MRUQMenu::keyReleaseEvent (QKeyEvent * kev){
+  if (kev->key() == Qt::Key_Control && actions().size() > 1){
+    QAction *act = activeAction();
+    if( act == nullptr ){
+      act = actions().at( 1 );
     }
-    return false;
-}
+    emit requestTabChange( act->data().toInt() );
+    hide();
+  }
+  else {
+    kev->ignore();
+  }
+};

--- a/mruqmenu.hh
+++ b/mruqmenu.hh
@@ -4,20 +4,20 @@
 #include <QMenu>
 #include <QEvent>
 
-//The only difference between this class and QMenu is that this class emits
-//a signal when Ctrl button is released
+// Detail: http://goldendict.org/forum/viewtopic.php?f=4&t=1176
+// When ctrl during ctrl+tab released, a request to change current tab will be emitted.
 class MRUQMenu: public QMenu
 {
-    Q_OBJECT
+  Q_OBJECT
 
 public:
-    MRUQMenu(const QString title, QWidget *parent = 0);
+  explicit MRUQMenu(const QString title, QWidget *parent = 0);
 
 private:
-    bool eventFilter (QObject*, QEvent*);
+  void keyReleaseEvent (QKeyEvent * kev) override;
 
-    signals:
-    void ctrlReleased();
+signals:
+  void requestTabChange(int index);
 };
 
 

--- a/preferences.ui
+++ b/preferences.ui
@@ -359,6 +359,9 @@ be the last ones.</string>
           </item>
           <item row="1" column="1">
            <widget class="QCheckBox" name="mruTabOrder">
+            <property name="toolTip">
+             <string>MRU order: Most recently used order.</string>
+            </property>
             <property name="text">
              <string>Ctrl-Tab navigates tabs in MRU order</string>
             </property>


### PR DESCRIPTION
Merge
* `MainWindow::ctrlReleased`
* `MRUQMenu::eventFilter` 

Into

* `MRUQMenu::keyReleaseEvent`

# what is it?

http://goldendict.org/forum/viewtopic.php?f=4&t=1176

# Test

* enable "Preferences" -> "Interface" -> "Ctrl-Tab in MRU order"
* Ctrl+tab -> the tab menu will show, when finished, the selected one will become topmost. 