### PR TITLE
Simplify MainWindow::showDictionaryHeadwords

### DIFF
--- a/dictionarybar.cc
+++ b/dictionarybar.cc
@@ -177,10 +177,15 @@ void DictionaryBar::showContextMenu( QContextMenuEvent * event, bool extended )
     return;
   }
 
-  if( result && result == headwordsAction )
-  {
-    QString id = dictAction->data().toString();
-    emit showDictionaryHeadwords( id );
+  if ( result && result == headwordsAction ) {
+    std::string id = dictAction->data().toString().toStdString();
+    // TODO: use `Dictionary::class*` instead of `QString id` at action->setData to remove all similar `for` loops
+    for ( const auto & dict : allDictionaries ) {
+      if ( id == dict->getId() ) {
+        emit showDictionaryHeadwords( dict.get() );
+        break;
+      }
+    }
     return;
   }
 

--- a/dictionarybar.hh
+++ b/dictionarybar.hh
@@ -40,7 +40,7 @@ signals:
   void showDictionaryInfo( QString const & id );
 
   /// Signal for show dictionary headwords command from context menu
-  void showDictionaryHeadwords( QString const & id );
+  void showDictionaryHeadwords( Dictionary::Class * dict );
 
   /// Signal for open dictionary folder from context menu
   void openDictionaryFolder( QString const & id );

--- a/editdictionaries.hh
+++ b/editdictionaries.hh
@@ -62,7 +62,7 @@ signals:
 
   void showDictionaryInfo( QString const & dictId );
 
-  void showDictionaryHeadwords( QString const & dictId );
+  void showDictionaryHeadwords( Dictionary::Class * dict );
 
 private:
 

--- a/mainwindow.hh
+++ b/mainwindow.hh
@@ -252,8 +252,6 @@ private:
 
   void fillWordListFromHistory();
 
-  void showDictionaryHeadwords( QWidget * owner, Dictionary::Class * dict );
-
   QString unescapeTabHeader( QString const & header );
 
   void respondToTranslationRequest( Config::InputPhrase const & phrase,
@@ -294,7 +292,7 @@ private slots:
 
   void showDictionaryInfo( QString const & id );
 
-  void showDictionaryHeadwords( QString const & id );
+  void showDictionaryHeadwords( Dictionary::Class * dict );
 
   void openDictionaryFolder( QString const & id );
 

--- a/orderandprops.cc
+++ b/orderandprops.cc
@@ -279,7 +279,7 @@ void OrderAndProps::contextMenuRequested( const QPoint & pos )
 
   if( result && result == showHeadwordsAction )
   {
-    emit showDictionaryHeadwords( QString::fromUtf8( dict->getId().c_str() ) );
+    emit showDictionaryHeadwords( dict.get() );
   }
 }
 

--- a/orderandprops.hh
+++ b/orderandprops.hh
@@ -38,7 +38,7 @@ private:
   void describeDictionary( DictListWidget *, QModelIndex const & );
 
 signals:
-  void showDictionaryHeadwords( QString const & dictId );
+  void showDictionaryHeadwords( Dictionary::Class * dict );
 };
 
 #endif


### PR DESCRIPTION
# Problem with the old code

`connect` related to `showDictionaryHeadwords` cannot be converted to the new syntax
https://github.com/xiaoyifang/goldendict/blob/e32a7a2c94fd97f25f3f66d52d38106b09317138/mainwindow.cc#L547-L550

because there are two versions

1. `showDictionaryHeadwords( const QString & id )`
2. `showDictionaryHeadwords( QWidget * owner, Dictionary::Class * dict )`

-> (1) wraps around (2) with extra code that obtain owner and loop through `dictionaries` list to match the `id`.

The existence of (2) is useless because both `owner` and `dict` can be derived from `id`.

# Change

Instead of passing a string `id` and loop through the dictionary list to obtain `Dictionary::Class * dict`, just pass the `Dictionary::Class * dict` and show its head word.

The loop is removed :)

# To test

Cases where the dialog is NonModal -> click a word to query.
* Right click DictionaryBar -> Show Head words
* Right click DictionaryBar -> Show Info -> HeadWords
* Right click "Found in dicts" panel -> Show Head words

Case where the dialog is Modal -> interactions with other windows are blocked
* Edit -> Dictionaries -> Right Click a dict -> Show HeadWords