### PR TITLE
Avoid copying a QVector

### DIFF
--- a/groups_widgets.cc
+++ b/groups_widgets.cc
@@ -731,16 +731,12 @@ void DictGroupsWidget::addAutoGroups()
       if( fileName.endsWith( ".aff", Qt::CaseInsensitive ) )
       {
         QString code = fileName.left( 2 ).toLower();
-        QVector<sptr<Dictionary::Class> > vd = morphoMap[ code ];
-        vd.append( dict );
-        morphoMap[ code ] = vd;
+        morphoMap[ code ].push_back( dict );
         continue;
       }
     }
 
-    QVector<sptr<Dictionary::Class> > vd = dictMap[ name ];
-    vd.append( dict );
-    dictMap[ name ] = vd;
+    dictMap[ name ].push_back( dict );
   }
 
   QStringList groupList = dictMap.keys();


### PR DESCRIPTION
Calling append() on a copy of a QVector detaches and makes a deep copy of the container. Modify the QVector in-place to prevent copying and thus improve performance.