### PR TITLE
Remove FsEncoding::encode/decode

### DIFF
--- a/aard.cc
+++ b/aard.cc
@@ -7,7 +7,6 @@
 #include "utf8.hh"
 #include "chunkedstorage.hh"
 #include "langcoder.hh"
-#include "fsencoding.hh"
 #include "decompress.hh"
 #include "gddebug.hh"
 #include "ftshelpers.hh"
@@ -343,8 +342,7 @@ void AardDictionary::loadIcon() noexcept
   if ( dictionaryIconLoaded )
     return;
 
-  QString fileName =
-    QDir::fromNativeSeparators( FsEncoding::decode( getDictionaryFilenames()[ 0 ].c_str() ) );
+  QString fileName = QDir::fromNativeSeparators( QString::fromStdString( getDictionaryFilenames()[ 0 ] ) );
 
   // Remove the extension
   fileName.chop( 3 );
@@ -614,7 +612,7 @@ void AardDictionary::makeFTSIndex( QAtomicInt & isCancelled, bool firstIteration
   catch( std::exception &ex )
   {
     gdWarning( "Aard: Failed building full-text search index for \"%s\", reason: %s\n", getName().c_str(), ex.what() );
-    QFile::remove( FsEncoding::decode( ftsIdxName.c_str() ) );
+    QFile::remove( QString::fromStdString( ftsIdxName ) );
   }
 }
 
@@ -869,7 +867,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries(
           gdDebug( "Aard: Building the index for dictionary: %s\n", i->c_str() );
 
           {
-            QFileInfo info( FsEncoding::decode( i->c_str() ) );
+            QFileInfo info( QString::fromUtf8( i->c_str() ) );
             if( static_cast< quint64 >( info.size() ) > ULONG_MAX )
             {
               gdWarning( "File %s is too large\n", i->c_str() );

--- a/bgl.cc
+++ b/bgl.cc
@@ -306,8 +306,7 @@ namespace
     if ( dictionaryIconLoaded )
       return;
 
-    QString fileName =
-      QDir::fromNativeSeparators( FsEncoding::decode( getDictionaryFilenames()[ 0 ].c_str() ) );
+    QString fileName = QDir::fromNativeSeparators( QString::fromStdString(getDictionaryFilenames()[ 0 ] ) );
 
     // Remove the extension
     fileName.chop( 3 );
@@ -483,7 +482,7 @@ namespace
     catch( std::exception &ex )
     {
       gdWarning( "Bgl: Failed building full-text search index for \"%s\", reason: %s\n", getName().c_str(), ex.what() );
-      QFile::remove( FsEncoding::decode( ftsIdxName.c_str() ) );
+      QFile::remove( QString::fromStdString( ftsIdxName ) );
     }
   }
 

--- a/dictdfiles.cc
+++ b/dictdfiles.cc
@@ -211,7 +211,7 @@ string nameFromFileName( string const & indexFileName )
   if ( !dot )
     dot = indexFileName.c_str() + indexFileName.size();
 
-  return Utf8::encode( FsEncoding::decode( string( sep + 1, dot - sep - 1 ) ) );
+  return  string( sep + 1, dot - sep - 1 );
 }
 
 void DictdDictionary::loadIcon() noexcept
@@ -219,8 +219,7 @@ void DictdDictionary::loadIcon() noexcept
   if ( dictionaryIconLoaded )
     return;
 
-  QString fileName =
-    QDir::fromNativeSeparators( FsEncoding::decode( getDictionaryFilenames()[ 0 ].c_str() ) );
+  QString fileName = QDir::fromNativeSeparators( QString::fromStdString( getDictionaryFilenames()[ 0 ] ) );
 
   // Remove the extension
   fileName.chop( 5 );
@@ -486,7 +485,7 @@ void DictdDictionary::makeFTSIndex( QAtomicInt & isCancelled, bool firstIteratio
   catch( std::exception &ex )
   {
     gdWarning( "DictD: Failed building full-text search index for \"%s\", reason: %s\n", getName().c_str(), ex.what() );
-    QFile::remove( FsEncoding::decode( ftsIdxName.c_str() ) );
+    QFile::remove( QString::fromStdString( ftsIdxName ) );
   }
 }
 

--- a/dictinfo.cc
+++ b/dictinfo.cc
@@ -40,7 +40,7 @@ void DictInfo::showInfo( sptr<Dictionary::Class> dict )
 
   for( unsigned x = 0; x < filenames.size(); x++ )
   {
-    filenamesText += FsEncoding::decode( filenames[ x ].c_str() );
+    filenamesText += QString::fromStdString( filenames[ x ] );
     filenamesText += '\n';
   }
 

--- a/dictionary.cc
+++ b/dictionary.cc
@@ -514,10 +514,10 @@ string makeDictionaryId( vector< string > const & dictionaryFiles ) noexcept
     {
       string const & full( dictionaryFiles[ x ] );
 
-      QFileInfo fileInfo( FsEncoding::decode( full.c_str() ) );
+      QFileInfo fileInfo( QString::fromStdString( full ) );
 
       if ( fileInfo.isAbsolute() )
-        sortedList.push_back( FsEncoding::encode( dictionariesDir.relativeFilePath( fileInfo.filePath() ) ) );
+        sortedList.push_back( dictionariesDir.relativeFilePath( fileInfo.filePath() ).toStdString() );
       else
       {
         // Well, it's relative. We don't technically support those, but
@@ -552,7 +552,7 @@ bool needToRebuildIndex( vector< string > const & dictionaryFiles,
   for( std::vector< string >::const_iterator i = dictionaryFiles.begin();
        i != dictionaryFiles.end(); ++i )
   {
-    QString name = FsEncoding::decode( i->c_str() );
+    QString name = QString::fromUtf8( i->c_str() );
     QFileInfo fileInfo( name );
     unsigned long ts;
 
@@ -577,12 +577,12 @@ bool needToRebuildIndex( vector< string > const & dictionaryFiles,
       lastModified = ts;
   }
 #ifndef USE_XAPIAN
-  QDir d(FsEncoding::decode( indexFile.c_str() ));
+  QDir d( indexFile.c_str() );
   if(d.exists()){
     d.removeRecursively();
   }
 #endif
-  QFileInfo fileInfo( FsEncoding::decode( indexFile.c_str() ) );
+  QFileInfo fileInfo( indexFile.c_str() );
 
   if ( !fileInfo.exists() )
     return true;

--- a/epwing.cc
+++ b/epwing.cc
@@ -272,9 +272,8 @@ void EpwingDictionary::loadIcon() noexcept
   if ( dictionaryIconLoaded )
     return;
 
-  QString fileName = FsEncoding::decode( getDictionaryFilenames()[ 0 ].c_str() )
-                     + QDir::separator()
-                     + eBook.getCurrentSubBookDirectory() + ".";
+  QString fileName = QString::fromStdString( getDictionaryFilenames()[ 0 ] ) + QDir::separator()
+    + eBook.getCurrentSubBookDirectory() + ".";
 
   if( !fileName.isEmpty() )
     loadIconFromFile( fileName );
@@ -486,7 +485,7 @@ void EpwingDictionary::makeFTSIndex( QAtomicInt & isCancelled, bool firstIterati
   catch( std::exception &ex )
   {
     gdWarning( "Epwing: Failed building full-text search index for \"%s\", reason: %s\n", getName().c_str(), ex.what() );
-    QFile::remove( FsEncoding::decode( ftsIdxName.c_str() ) );
+    QFile::remove( QString::fromStdString( ftsIdxName ) );
   }
 }
 
@@ -923,8 +922,7 @@ void EpwingResourceRequest::run()
       return;
     }
 
-    QString fullName = cacheDir + QDir::separator()
-                       + FsEncoding::decode( resourceName.c_str() );
+    QString fullName = cacheDir + QDir::separator() + QString::fromStdString( resourceName );
 
     QFile f( fullName );
     if( f.open( QFile::ReadOnly ) )
@@ -1278,18 +1276,15 @@ vector< sptr< Dictionary::Class > > makeDictionaries(
 
           dict.setSubBook( sb );
 
-          dir = FsEncoding::decode( mainDirectory.c_str() )
-                + FsEncoding::separator()
-                + dict.getCurrentSubBookDirectory();
+          dir = QString::fromStdString( mainDirectory ) + FsEncoding::separator() + dict.getCurrentSubBookDirectory();
 
           Epwing::Book::EpwingBook::collectFilenames( dir, dictFiles );
 
-          QString fontSubName = FsEncoding::decode( mainDirectory.c_str() )
-                                + QDir::separator()
-                                + "afonts_" + QString::number( sb );
+          QString fontSubName =
+            QString::fromStdString( mainDirectory ) + QDir::separator() + "afonts_" + QString::number( sb );
           QFileInfo info( fontSubName );
           if( info.exists() && info.isFile() )
-            dictFiles.push_back( FsEncoding::encode( fontSubName ) );
+          dictFiles.push_back( fontSubName.toStdString() );
 
           // Check if we need to rebuid the index
 

--- a/epwing_book.cc
+++ b/epwing_book.cc
@@ -449,7 +449,7 @@ void EpwingBook::collectFilenames( QString const & directory, vector< string > &
     if( i->isDir() )
       collectFilenames( fullName, files );
     else
-      files.push_back( FsEncoding::encode( fullName ) );
+      files.push_back( fullName.toStdString() );
   }
 }
 
@@ -499,7 +499,7 @@ int EpwingBook::setBook( string const & directory )
       || ( book.character_code == EB_CHARCODE_JISX0208_GB2312 && !codec_GB ) )
     throw exEpwing( "No required codec to decode dictionary" );
 
-  rootDir = FsEncoding::decode( directory.c_str() );
+  rootDir = QString::fromStdString( directory );
 
   return subBookCount;
 }

--- a/file.cc
+++ b/file.cc
@@ -43,8 +43,7 @@ bool tryPossibleName( std::string const & name, std::string & copyTo )
 
 bool tryPossibleZipName( std::string const & name, std::string & copyTo )
 {
-  if ( ZipFile::SplitZipFile( FsEncoding::decode( name.c_str() ) ).exists() )
-  {
+  if ( ZipFile::SplitZipFile( name.c_str() ).exists() ) {
     copyTo = name;
     return true;
   }
@@ -112,7 +111,7 @@ void Class::open( char const * filename, char const * mode )
     ++pch;
   }
 
-  f.setFileName( FsEncoding::decode( filename ) );
+  f.setFileName( filename );
 
   if ( !f.open( openMode ) )
     throw exCantOpen( std::string( filename ) + ": " + f.errorString().toUtf8().data() );

--- a/fsencoding.cc
+++ b/fsencoding.cc
@@ -5,54 +5,8 @@
 #include "wstring_qt.hh"
 #include <QString>
 #include <QDir>
-#include <vector>
 
 namespace FsEncoding {
-
-string encode( wstring const & str )
-{
-#ifdef __WIN32
-  return string( gd::toQString( str ).toUtf8().data() );
-#else
-  return string( gd::toQString( str ).toLocal8Bit().data() );
-#endif
-}
-
-string encode( string const & str )
-{
-#ifdef __WIN32
-  return string( str );
-#else
-  return string( QString::fromUtf8( str.c_str() ).toLocal8Bit().data() );
-#endif
-}
-
-string encode( QString const & str )
-{
-#ifdef __WIN32
-  return string( str.toUtf8().data() );
-#else
-  return string( str.toLocal8Bit().data() );
-#endif
-}
-
-wstring decode( string const & str )
-{
-#ifdef __WIN32
-  return gd::toWString( QString::fromUtf8( str.c_str() ) );
-#else
-  return gd::toWString( QString::fromLocal8Bit( str.c_str() ) );
-#endif
-}
-
-QString decode( const char *str )
-{
-#ifdef __WIN32
-  return QString::fromUtf8( str );
-#else
-  return QString::fromLocal8Bit( str );
-#endif
-}
 
 char separator()
 {

--- a/fsencoding.hh
+++ b/fsencoding.hh
@@ -13,22 +13,6 @@
 namespace FsEncoding {
 
 using std::string;
-using gd::wstring;
-
-/// Encodes the given wide string to the utf8 encoding.
-string encode( wstring const & );
-
-/// Encodes the given string in utf8 to the system 8bit encoding.
-string encode( string const & );
-
-/// Encodes the QString to the utf8/local 8-bit encoding.
-string encode( QString const & );
-
-/// Decodes the given utf8-encoded string to a wide string.
-wstring decode( string const & str );
-
-/// Decodes the given utf8/local 8-bit string to a QString.
-QString decode( const char *str );
 
 /// Returns the filesystem separator (/ on Unix and clones, \ on Windows).
 char separator();

--- a/gls.cc
+++ b/gls.cc
@@ -493,8 +493,7 @@ GlsDictionary::GlsDictionary( string const & id,
                                       idxHeader.zipIndexRootOffset ),
                            idx, idxMutex );
 
-    QString zipName = QDir::fromNativeSeparators(
-        FsEncoding::decode( getDictionaryFilenames().back().c_str() ) );
+    QString zipName = QDir::fromNativeSeparators( getDictionaryFilenames().back().c_str() );
 
     if ( zipName.endsWith( ".zip", Qt::CaseInsensitive ) ) // Sanity check
       resourceZip.openZipFile( zipName );
@@ -522,8 +521,7 @@ void GlsDictionary::loadIcon() noexcept
   if ( dictionaryIconLoaded )
     return;
 
-  QString fileName =
-    QDir::fromNativeSeparators( FsEncoding::decode( getDictionaryFilenames()[ 0 ].c_str() ) );
+  QString fileName = QDir::fromNativeSeparators( getDictionaryFilenames()[ 0 ].c_str() );
 
   // Remove the extension
   if ( fileName.endsWith( ".gls.dz", Qt::CaseInsensitive ) )
@@ -574,10 +572,7 @@ QString const& GlsDictionary::getDescription()
   return dictionaryDescription;
 }
 
-QString GlsDictionary::getMainFilename()
-{
-  return FsEncoding::decode( getDictionaryFilenames()[ 0 ].c_str() );
-}
+QString GlsDictionary::getMainFilename() { return getDictionaryFilenames()[ 0 ].c_str(); }
 
 void GlsDictionary::makeFTSIndex( QAtomicInt & isCancelled, bool firstIteration )
 {
@@ -605,7 +600,7 @@ void GlsDictionary::makeFTSIndex( QAtomicInt & isCancelled, bool firstIteration 
   catch( std::exception &ex )
   {
     gdWarning( "Gls: Failed building full-text search index for \"%s\", reason: %s\n", getName().c_str(), ex.what() );
-    QFile::remove( FsEncoding::decode( ftsIdxName.c_str() ) );
+    QFile::remove( ftsIdxName.c_str() );
   }
 }
 
@@ -1240,10 +1235,7 @@ void GlsResourceRequest::run()
 
   try
   {
-    string n =
-      FsEncoding::dirname( dict.getDictionaryFilenames()[ 0 ] ) +
-      FsEncoding::separator() +
-      FsEncoding::encode( resourceName );
+    string n = FsEncoding::dirname( dict.getDictionaryFilenames()[ 0 ] ) + FsEncoding::separator() + resourceName;
 
     GD_DPRINTF( "n is %s\n", n.c_str() );
 
@@ -1255,9 +1247,7 @@ void GlsResourceRequest::run()
     }
     catch( File::exCantOpen & )
     {
-      n = dict.getDictionaryFilenames()[ 0 ] + ".files" +
-          FsEncoding::separator() +
-          FsEncoding::encode( resourceName );
+      n = dict.getDictionaryFilenames()[ 0 ] + ".files" + FsEncoding::separator() + resourceName;
 
       try
       {
@@ -1532,9 +1522,8 @@ vector< sptr< Dictionary::Class > > makeDictionaries(
 
             IndexedWords zipFileNames;
             IndexedZip zipFile;
-            if( zipFile.openZipFile( QDir::fromNativeSeparators(
-                                     FsEncoding::decode( zipFileName.c_str() ) ) ) )
-                zipFile.indexFile( zipFileNames );
+            if ( zipFile.openZipFile( QDir::fromNativeSeparators( zipFileName.c_str() ) ) )
+              zipFile.indexFile( zipFileNames );
 
             if( !zipFileNames.empty() )
             {

--- a/groups_widgets.cc
+++ b/groups_widgets.cc
@@ -247,7 +247,7 @@ QVariant DictListModel::data( QModelIndex const & index, int role ) const
       if ( dirs.size() )
       {
         tt += "<hr>";
-        tt += FsEncoding::decode( dirs.at( 0 ).c_str() );
+        tt += dirs.at( 0 ).c_str();
       }
 
       tt.replace( " ", "&nbsp;" );
@@ -727,7 +727,7 @@ void DictGroupsWidget::addAutoGroups()
     {
       // Handle special case - morphology dictionaries
 
-      QString fileName = QFileInfo( FsEncoding::decode( dict->getDictionaryFilenames()[ 0 ].c_str() ) ).fileName();
+      QString fileName = QFileInfo( dict->getDictionaryFilenames()[ 0 ].c_str() ).fileName();
       if( fileName.endsWith( ".aff", Qt::CaseInsensitive ) )
       {
         QString code = fileName.left( 2 ).toLower();

--- a/hunspell.cc
+++ b/hunspell.cc
@@ -151,8 +151,7 @@ void HunspellDictionary::loadIcon() noexcept
   if ( dictionaryIconLoaded )
     return;
 
-  QString fileName =
-    QDir::fromNativeSeparators( FsEncoding::decode( getDictionaryFilenames()[ 0 ].c_str() ) );
+  QString fileName = QDir::fromNativeSeparators( getDictionaryFilenames()[ 0 ].c_str() );
 
   // Remove the extension
   fileName.chop( 3 );
@@ -743,7 +742,7 @@ string encodeToHunspell( Hunspell & hunspell, wstring const & str )
   size_t outLeft = result.size();
 
   QString convStr= conv.convert( in, inLeft);
-  return FsEncoding::encode(convStr);
+  return convStr.toStdString();
 }
 
 wstring decodeFromHunspell( Hunspell & hunspell, char const * str )
@@ -781,10 +780,8 @@ vector< sptr< Dictionary::Class > > makeDictionaries( Config::Hunspell const & c
 
         vector< string > dictFiles;
 
-        dictFiles.push_back(
-          FsEncoding::encode( QDir::toNativeSeparators( dataFiles[ d ].affFileName ) ) );
-        dictFiles.push_back(
-          FsEncoding::encode( QDir::toNativeSeparators( dataFiles[ d ].dicFileName ) ) );
+        dictFiles.push_back( QDir::toNativeSeparators( dataFiles[ d ].affFileName ).toStdString() );
+        dictFiles.push_back( QDir::toNativeSeparators( dataFiles[ d ].dicFileName ).toStdString() );
 
         result.push_back(
             std::make_shared<HunspellDictionary>( Dictionary::makeDictionaryId( dictFiles ),

--- a/loaddictionaries.cc
+++ b/loaddictionaries.cc
@@ -21,7 +21,6 @@
 #include "programs.hh"
 #include "voiceengines.hh"
 #include "gddebug.hh"
-#include "fsencoding.hh"
 #include "xdxf.hh"
 #include "sdict.hh"
 #include "aard.hh"
@@ -84,7 +83,7 @@ void LoadDictionaries::run()
     // Make soundDirs
     {
       vector< sptr< Dictionary::Class > > soundDirDictionaries =
-        SoundDir::makeDictionaries( soundDirs, FsEncoding::encode( Config::getIndexDir() ), *this );
+        SoundDir::makeDictionaries( soundDirs, Config::getIndexDir().toStdString(), *this );
 
       dictionaries.insert( dictionaries.end(), soundDirDictionaries.begin(),
                            soundDirDictionaries.end() );
@@ -133,27 +132,28 @@ void LoadDictionaries::handlePath( Config::Path const & path )
     }
 
     if ( !i->isDir() )
-      allFiles.push_back( FsEncoding::encode( QDir::toNativeSeparators( fullName ) ) );
+      allFiles.push_back( QDir::toNativeSeparators( fullName ).toStdString() );
   }
 
-  addDicts(Bgl::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this ) );
-  addDicts(Stardict::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this, maxHeadwordToExpand ) );
-  addDicts(Lsa::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this ) );
-  addDicts(Dsl::makeDictionaries( allFiles,FsEncoding::encode( Config::getIndexDir() ),*this,maxPictureWidth,maxHeadwordSize ) );
-  addDicts(DictdFiles::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this ) );
-  addDicts(Xdxf::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this ) );
-  addDicts(Sdict::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this ) );
-  addDicts(Aard::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this, maxHeadwordToExpand ) );
-  addDicts(ZipSounds::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this ) );
-  addDicts(Mdx::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this ) );
-  addDicts(Gls::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this ) );
+  addDicts( Bgl::makeDictionaries( allFiles, Config::getIndexDir().toStdString(), *this ) );
+  addDicts( Stardict::makeDictionaries( allFiles, Config::getIndexDir().toStdString(), *this, maxHeadwordToExpand ) );
+  addDicts( Lsa::makeDictionaries( allFiles, Config::getIndexDir().toStdString(), *this ) );
+  addDicts(
+    Dsl::makeDictionaries( allFiles, Config::getIndexDir().toStdString(), *this, maxPictureWidth, maxHeadwordSize ) );
+  addDicts( DictdFiles::makeDictionaries( allFiles, Config::getIndexDir().toStdString(), *this ) );
+  addDicts( Xdxf::makeDictionaries( allFiles, Config::getIndexDir().toStdString(), *this ) );
+  addDicts( Sdict::makeDictionaries( allFiles, Config::getIndexDir().toStdString(), *this ) );
+  addDicts( Aard::makeDictionaries( allFiles, Config::getIndexDir().toStdString(), *this, maxHeadwordToExpand ) );
+  addDicts( ZipSounds::makeDictionaries( allFiles, Config::getIndexDir().toStdString(), *this ) );
+  addDicts( Mdx::makeDictionaries( allFiles, Config::getIndexDir().toStdString(), *this ) );
+  addDicts( Gls::makeDictionaries( allFiles, Config::getIndexDir().toStdString(), *this ) );
 
 #ifdef MAKE_ZIM_SUPPORT
-  addDicts(Zim::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this, maxHeadwordToExpand ) );
-  addDicts(Slob::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this, maxHeadwordToExpand ) );
+  addDicts( Zim::makeDictionaries( allFiles, Config::getIndexDir().toStdString(), *this, maxHeadwordToExpand ) );
+  addDicts( Slob::makeDictionaries( allFiles, Config::getIndexDir().toStdString(), *this, maxHeadwordToExpand ) );
 #endif
 #ifndef NO_EPWING_SUPPORT
-  addDicts( Epwing::makeDictionaries( allFiles, FsEncoding::encode( Config::getIndexDir() ), *this ) );
+  addDicts( Epwing::makeDictionaries( allFiles, Config::getIndexDir().toStdString(), *this ) );
 #endif
 }
 
@@ -266,18 +266,17 @@ void loadDictionaries( QWidget * parent, bool showInitially,
 
   QStringList allIdxFiles = indexDir.entryList( QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot | QDir::NoSymLinks );
 
-  for( QStringList::const_iterator i = allIdxFiles.constBegin(); i != allIdxFiles.constEnd(); ++i )
+  for( const auto & file : allIdxFiles)
   {
-    if( i->size() >= 32 && ids.find( FsEncoding::encode( i->left( 32 ) ) ) == ids.end() )
-    {
-      if( QFile::exists( *i ) )
+    if ( file.size() >= 32 && ids.find( file.left( 32 ).toStdString() ) == ids.end() ) {
+      if( QFile::exists( file ) )
       {
-        indexDir.remove( *i );
+        indexDir.remove( file );
       }
       else
       {
         // must be folder .
-        auto dirPath = Utils::Path::combine( Config::getIndexDir(), *i );
+        auto dirPath = Utils::Path::combine( Config::getIndexDir(), file );
         QDir t( dirPath );
         t.removeRecursively();
       }

--- a/lsa.cc
+++ b/lsa.cc
@@ -502,8 +502,7 @@ void LsaDictionary::loadIcon() noexcept
   if ( dictionaryIconLoaded )
     return;
 
-  QString fileName =
-    QDir::fromNativeSeparators( FsEncoding::decode( getDictionaryFilenames()[ 0 ].c_str() ) );
+  QString fileName = QDir::fromNativeSeparators( getDictionaryFilenames()[ 0 ].c_str() );
 
   // Remove the extension
   fileName.chop( 3 );

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -4279,7 +4279,7 @@ void MainWindow::openDictionaryFolder( const QString & id )
     {
       if( dictionaries[ x ]->getDictionaryFilenames().size() > 0 )
       {
-        QString fileName = FsEncoding::decode( dictionaries[ x ]->getDictionaryFilenames()[ 0 ].c_str() );
+        QString fileName = dictionaries[ x ]->getDictionaryFilenames()[ 0 ].c_str();
 
         QString folder = QFileInfo( fileName ).absoluteDir().absolutePath();
         if( !folder.isEmpty() )

--- a/mdx.cc
+++ b/mdx.cc
@@ -499,7 +499,7 @@ void MdxDictionary::makeFTSIndex( QAtomicInt & isCancelled, bool firstIteration 
   catch( std::exception &ex )
   {
     gdWarning( "MDict: Failed building full-text search index for \"%s\", reason: %s", getName().c_str(), ex.what() );
-    QFile::remove( FsEncoding::decode( ftsIdxName.c_str() ) );
+    QFile::remove( ftsIdxName.c_str() );
   }
 }
 
@@ -871,8 +871,7 @@ void MdxDictionary::loadIcon() noexcept
   if ( dictionaryIconLoaded )
     return;
 
-  QString fileName =
-    QDir::fromNativeSeparators( FsEncoding::decode( getDictionaryFilenames()[ 0 ].c_str() ) );
+  QString fileName = QDir::fromNativeSeparators( getDictionaryFilenames()[ 0 ].c_str() );
 
   // Remove the extension
   fileName.chop( 3 );
@@ -1173,7 +1172,7 @@ QString MdxDictionary::getCachedFileName( QString filename )
     gdWarning( R"(Mdx: file "%s" creating error: "%s")", fullName.toUtf8().data(), f.errorString().toUtf8().data() );
     return QString();
   }
-  gd::wstring resourceName = FsEncoding::decode( filename.toStdString() );
+  gd::wstring resourceName = filename.toStdU32String();
   vector< char > data;
 
   // In order to prevent recursive internal redirection...

--- a/orderandprops.cc
+++ b/orderandprops.cc
@@ -219,7 +219,7 @@ void OrderAndProps::describeDictionary( DictListWidget * lst, QModelIndex const 
 
     for( unsigned x = 0; x < filenames.size(); x++ )
     {
-      filenamesText += FsEncoding::decode( filenames[ x ].c_str() );
+      filenamesText += filenames[ x ].c_str();
       filenamesText += '\n';
     }
 

--- a/sdict.cc
+++ b/sdict.cc
@@ -244,8 +244,7 @@ void SdictDictionary::loadIcon() noexcept
   if ( dictionaryIconLoaded )
     return;
 
-  QString fileName =
-    QDir::fromNativeSeparators( FsEncoding::decode( getDictionaryFilenames()[ 0 ].c_str() ) );
+  QString fileName = QDir::fromNativeSeparators( getDictionaryFilenames()[ 0 ].c_str() );
 
   // Remove the extension
   fileName.chop( 3 );
@@ -439,7 +438,7 @@ void SdictDictionary::makeFTSIndex( QAtomicInt & isCancelled, bool firstIteratio
   catch( std::exception &ex )
   {
     gdWarning( "SDict: Failed building full-text search index for \"%s\", reason: %s\n", getName().c_str(), ex.what() );
-    QFile::remove( FsEncoding::decode( ftsIdxName.c_str() ) );
+    QFile::remove( ftsIdxName.c_str() );
   }
 }
 

--- a/slob.cc
+++ b/slob.cc
@@ -674,7 +674,7 @@ SlobDictionary::SlobDictionary( string const & id,
 
     try
     {
-      sf.open( FsEncoding::decode( dictionaryFiles[ 0 ].c_str() ) );
+      sf.open( dictionaryFiles[ 0 ].c_str() );
     }
     catch( std::exception & e )
     {
@@ -697,7 +697,7 @@ SlobDictionary::SlobDictionary( string const & id,
     dictionaryName = sf.getDictionaryName().toStdString();
     if( dictionaryName.empty() )
     {
-      QString name = QDir::fromNativeSeparators( FsEncoding::decode( dictionaryFiles[ 0 ].c_str() ) );
+      QString name   = QDir::fromNativeSeparators( dictionaryFiles[ 0 ].c_str() );
       int n = name.lastIndexOf( '/' );
       dictionaryName = name.mid( n + 1 ).toStdString();
     }
@@ -751,8 +751,7 @@ void SlobDictionary::loadIcon() noexcept
   if ( dictionaryIconLoaded )
     return;
 
-  QString fileName =
-    QDir::fromNativeSeparators( FsEncoding::decode( getDictionaryFilenames()[ 0 ].c_str() ) );
+  QString fileName = QDir::fromNativeSeparators( getDictionaryFilenames()[ 0 ].c_str() );
 
   // Remove the extension
   fileName.chop( 4 );
@@ -1260,7 +1259,7 @@ void SlobDictionary::makeFTSIndex( QAtomicInt & isCancelled, bool firstIteration
   catch( std::exception &ex )
   {
     gdWarning( "Slob: Failed building full-text search index for \"%s\", reason: %s\n", getName().c_str(), ex.what() );
-    QFile::remove( FsEncoding::decode( ftsIdxName.c_str() ) );
+    QFile::remove( ftsIdxName.c_str() );
   }
 }
 
@@ -1638,7 +1637,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries(
       // Skip files with the extensions different to .slob to speed up the
       // scanning
 
-      QString firstName = QDir::fromNativeSeparators( FsEncoding::decode( i->c_str() ) );
+      QString firstName = QDir::fromNativeSeparators( i->c_str() );
       if( !firstName.endsWith( ".slob") )
         continue;
 

--- a/sounddir.cc
+++ b/sounddir.cc
@@ -338,7 +338,7 @@ sptr< Dictionary::DataRequest > SoundDirDictionary::getResource( string const & 
 
   chunk.back() = 0; // It must end with 0 anyway, but just in case
 
-  QDir dir( QDir::fromNativeSeparators( FsEncoding::decode( getDictionaryFilenames()[ 0 ].c_str() ) ) );
+  QDir dir( QDir::fromNativeSeparators( getDictionaryFilenames()[ 0 ].c_str() ) );
 
   QString fileName = QDir::toNativeSeparators( dir.filePath( QString::fromUtf8( articleData ) ) );
 
@@ -346,7 +346,7 @@ sptr< Dictionary::DataRequest > SoundDirDictionary::getResource( string const & 
 
   try
   {
-    File::Class f( FsEncoding::encode( fileName ), "rb" );
+    File::Class f( fileName.toStdString(), "rb" );
 
     sptr< Dictionary::DataRequestInstant > dr =
             std::make_shared<Dictionary::DataRequestInstant>( true );
@@ -419,8 +419,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( Config::SoundDirs const & 
     if ( !dir.exists() )
       continue; // No such dir, no dictionary then
 
-    vector< string > dictFiles( 1,
-      FsEncoding::encode( QDir::toNativeSeparators( dir.canonicalPath() ) ) );
+    vector< string > dictFiles( 1, QDir::toNativeSeparators( dir.canonicalPath() ).toStdString() );
 
     dictFiles.push_back( "SoundDir" ); // A mixin
 

--- a/splitfile.cc
+++ b/splitfile.cc
@@ -43,7 +43,7 @@ void SplitFile::close()
 void SplitFile::getFilenames( vector< string > &names ) const
 {
   for( QVector< QFile * >::const_iterator i = files.begin(); i != files.end(); ++i )
-    names.push_back( FsEncoding::encode( (*i)->fileName() ) );
+    names.push_back( ( *i )->fileName().toStdString() );
 }
 
 bool SplitFile::open( QFile::OpenMode mode )

--- a/stardict.cc
+++ b/stardict.cc
@@ -270,8 +270,7 @@ StardictDictionary::StardictDictionary( string const & id,
                                       idxHeader.zipIndexRootOffset ),
                            idx, idxMutex );
 
-    QString zipName = QDir::fromNativeSeparators(
-        FsEncoding::decode( getDictionaryFilenames().back().c_str() ) );
+    QString zipName = QDir::fromNativeSeparators( getDictionaryFilenames().back().c_str() );
 
     if ( zipName.endsWith( ".zip", Qt::CaseInsensitive ) ) // Sanity check
       resourceZip.openZipFile( zipName );
@@ -299,8 +298,7 @@ void StardictDictionary::loadIcon() noexcept
   if ( dictionaryIconLoaded )
     return;
 
-  QString fileName =
-    QDir::fromNativeSeparators( FsEncoding::decode( getDictionaryFilenames()[ 0 ].c_str() ) );
+  QString fileName = QDir::fromNativeSeparators( getDictionaryFilenames()[ 0 ].c_str() );
 
   // Remove the extension
   fileName.chop( 3 );
@@ -1140,10 +1138,7 @@ QString const& StardictDictionary::getDescription()
     return dictionaryDescription;
 }
 
-QString StardictDictionary::getMainFilename()
-{
-  return FsEncoding::decode( getDictionaryFilenames()[ 0 ].c_str() );
-}
+QString StardictDictionary::getMainFilename() { return getDictionaryFilenames()[ 0 ].c_str(); }
 
 void StardictDictionary::makeFTSIndex( QAtomicInt & isCancelled, bool firstIteration )
 {
@@ -1171,7 +1166,7 @@ void StardictDictionary::makeFTSIndex( QAtomicInt & isCancelled, bool firstItera
   catch( std::exception &ex )
   {
     gdWarning( "Stardict: Failed building full-text search index for \"%s\", reason: %s\n", getName().c_str(), ex.what() );
-    QFile::remove( FsEncoding::decode( ftsIdxName.c_str() ) );
+    QFile::remove( ftsIdxName.c_str() );
   }
 }
 
@@ -1698,12 +1693,8 @@ void StardictResourceRequest::run()
     if( resourceName.at( resourceName.length() - 1 ) == '\x1F' )
       resourceName.erase( resourceName.length() - 1, 1 );
 
-    string n =
-      FsEncoding::dirname( dict.getDictionaryFilenames()[ 0 ] ) +
-      FsEncoding::separator() +
-      "res" +
-      FsEncoding::separator() +
-      FsEncoding::encode( resourceName );
+    string n = FsEncoding::dirname( dict.getDictionaryFilenames()[ 0 ] ) + FsEncoding::separator() + "res"
+      + FsEncoding::separator() + resourceName;
 
     GD_DPRINTF( "n is %s\n", n.c_str() );
 
@@ -2146,9 +2137,8 @@ vector< sptr< Dictionary::Class > > makeDictionaries(
 
           IndexedWords zipFileNames;
           IndexedZip zipFile;
-          if( zipFile.openZipFile( QDir::fromNativeSeparators(
-                                   FsEncoding::decode( zipFileName.c_str() ) ) ) )
-              zipFile.indexFile( zipFileNames );
+          if ( zipFile.openZipFile( QDir::fromNativeSeparators( zipFileName.c_str() ) ) )
+            zipFile.indexFile( zipFileNames );
 
           if( !zipFileNames.empty() )
           {

--- a/xdxf.cc
+++ b/xdxf.cc
@@ -296,8 +296,7 @@ XdxfDictionary::XdxfDictionary( string const & id,
                                         idxHeader.zipIndexRootOffset ),
                              idx, idxMutex );
 
-      QString zipName = QDir::fromNativeSeparators(
-          FsEncoding::decode( getDictionaryFilenames().back().c_str() ) );
+      QString zipName = QDir::fromNativeSeparators( getDictionaryFilenames().back().c_str() );
 
       if ( zipName.endsWith( ".zip", Qt::CaseInsensitive ) ) // Sanity check
         resourceZip.openZipFile( zipName );
@@ -332,8 +331,7 @@ void XdxfDictionary::loadIcon() noexcept
   if ( dictionaryIconLoaded )
     return;
 
-  QString fileName =
-    QDir::fromNativeSeparators( FsEncoding::decode( getDictionaryFilenames()[ 0 ].c_str() ) );
+  QString fileName = QDir::fromNativeSeparators( getDictionaryFilenames()[ 0 ].c_str() );
 
   QFileInfo baseInfo( fileName );
 
@@ -386,10 +384,7 @@ QString const& XdxfDictionary::getDescription()
     return dictionaryDescription;
 }
 
-QString XdxfDictionary::getMainFilename()
-{
-  return FsEncoding::decode( getDictionaryFilenames()[ 0 ].c_str() );
-}
+QString XdxfDictionary::getMainFilename() { return getDictionaryFilenames()[ 0 ].c_str(); }
 
 void XdxfDictionary::makeFTSIndex( QAtomicInt & isCancelled, bool firstIteration )
 {
@@ -417,7 +412,7 @@ void XdxfDictionary::makeFTSIndex( QAtomicInt & isCancelled, bool firstIteration
   catch( std::exception &ex )
   {
     gdWarning( "Xdxf: Failed building full-text search index for \"%s\", reason: %s\n", getName().c_str(), ex.what() );
-    QFile::remove( FsEncoding::decode( ftsIdxName.c_str() ) );
+    QFile::remove( ftsIdxName.c_str() );
   }
 }
 
@@ -1058,10 +1053,7 @@ void XdxfResourceRequest::run()
     return;
   }
 
-  string n =
-    FsEncoding::dirname( dict.getDictionaryFilenames()[ 0 ] ) +
-    FsEncoding::separator() +
-    FsEncoding::encode( resourceName );
+  string n = FsEncoding::dirname( dict.getDictionaryFilenames()[ 0 ] ) + FsEncoding::separator() + resourceName;
 
   GD_DPRINTF( "n is %s\n", n.c_str() );
 
@@ -1075,9 +1067,7 @@ void XdxfResourceRequest::run()
     }
     catch( File::exCantOpen & )
     {
-      n = dict.getDictionaryFilenames()[ 0 ] + ".files" +
-          FsEncoding::separator() +
-          FsEncoding::encode( resourceName );
+      n = dict.getDictionaryFilenames()[ 0 ] + ".files" + FsEncoding::separator() + resourceName;
 
       try
       {
@@ -1446,9 +1436,8 @@ vector< sptr< Dictionary::Class > > makeDictionaries(
 
                 IndexedWords zipFileNames;
                 IndexedZip zipFile;
-                if( zipFile.openZipFile( QDir::fromNativeSeparators(
-                                         FsEncoding::decode( zipFileName.c_str() ) ) ) )
-                    zipFile.indexFile( zipFileNames );
+                if ( zipFile.openZipFile( QDir::fromNativeSeparators( zipFileName.c_str() ) ) )
+                  zipFile.indexFile( zipFileNames );
 
                 if( !zipFileNames.empty() )
                 {

--- a/xdxf2html.cc
+++ b/xdxf2html.cc
@@ -649,9 +649,8 @@ string convert( string const & in, DICT_TYPE type, map < string, string > const 
             bool search = false;
             if( type == STARDICT )
             {
-              string n = FsEncoding::dirname( dictPtr->getDictionaryFilenames()[ 0 ] ) +
-                         FsEncoding::separator() + string( "res" ) + FsEncoding::separator() +
-                         FsEncoding::encode( filename );
+              string n = FsEncoding::dirname( dictPtr->getDictionaryFilenames()[ 0 ] ) + FsEncoding::separator()
+                + string( "res" ) + FsEncoding::separator() + filename;
               search = !File::exists( n ) &&
                        ( !resourceZip ||
                          !resourceZip->isOpen() ||
@@ -659,15 +658,11 @@ string convert( string const & in, DICT_TYPE type, map < string, string > const 
             }
             else
             {
-              string n = dictPtr->getDictionaryFilenames()[ 0 ] + ".files" +
-                         FsEncoding::separator() +
-                         FsEncoding::encode( filename );
-              search = !File::exists( n ) && !File::exists( FsEncoding::dirname( dictPtr->getDictionaryFilenames()[ 0 ] ) +
-                                                            FsEncoding::separator() +
-                                                            FsEncoding::encode( filename ) ) &&
-                       ( !resourceZip ||
-                         !resourceZip->isOpen() ||
-                         !resourceZip->hasFile( Utf8::decode( filename ) ) );
+              string n = dictPtr->getDictionaryFilenames()[ 0 ] + ".files" + FsEncoding::separator() + filename;
+              search   = !File::exists( n )
+                && !File::exists( FsEncoding::dirname( dictPtr->getDictionaryFilenames()[ 0 ] )
+                                  + FsEncoding::separator() + filename )
+                && ( !resourceZip || !resourceZip->isOpen() || !resourceZip->hasFile( Utf8::decode( filename ) ) );
             }
 
 

--- a/zim.cc
+++ b/zim.cc
@@ -745,14 +745,12 @@ private:
     friend class ZimResourceRequest;
 };
 
-ZimDictionary::ZimDictionary( string const & id,
-                              string const & indexFile,
-                              vector< string > const & dictionaryFiles ):
-    BtreeDictionary( id, dictionaryFiles ),
-    idx( indexFile, "rb" ),
-    idxHeader( idx.read< IdxHeader >() ),
-    df( FsEncoding::decode( dictionaryFiles[ 0 ].c_str() ) ),
-    linksType( UNKNOWN )
+ZimDictionary::ZimDictionary( string const & id, string const & indexFile, vector< string > const & dictionaryFiles ):
+  BtreeDictionary( id, dictionaryFiles ),
+  idx( indexFile, "rb" ),
+  idxHeader( idx.read< IdxHeader >() ),
+  df( dictionaryFiles[ 0 ].c_str() ),
+  linksType( UNKNOWN )
 {
     // Open data file
 
@@ -772,7 +770,7 @@ ZimDictionary::ZimDictionary( string const & id,
 
     if( idxHeader.namePtr == 0xFFFFFFFF )
     {
-      QString name = QDir::fromNativeSeparators( FsEncoding::decode( dictionaryFiles[ 0 ].c_str() ) );
+      QString name   = QDir::fromNativeSeparators( dictionaryFiles[ 0 ].c_str() );
       int n = name.lastIndexOf( '/' );
       dictionaryName = name.mid( n + 1 ).toStdString();
     }
@@ -802,8 +800,7 @@ void ZimDictionary::loadIcon() noexcept
   if ( dictionaryIconLoaded )
     return;
 
-  QString fileName =
-    QDir::fromNativeSeparators( FsEncoding::decode( getDictionaryFilenames()[ 0 ].c_str() ) );
+  QString fileName = QDir::fromNativeSeparators( getDictionaryFilenames()[ 0 ].c_str() );
 
   // Remove the extension
   fileName.chop( 3 );
@@ -1186,7 +1183,7 @@ void ZimDictionary::makeFTSIndex( QAtomicInt & isCancelled, bool firstIteration 
   catch( std::exception &ex )
   {
     gdWarning( "Zim: Failed building full-text search index for \"%s\", reason: %s\n", getName().c_str(), ex.what() );
-    QFile::remove( FsEncoding::decode( ftsIdxName.c_str() ) );
+    QFile::remove( ftsIdxName.c_str() );
   }
 }
 
@@ -1544,9 +1541,9 @@ vector< sptr< Dictionary::Class > > makeDictionaries(
       // Skip files with the extensions different to .zim to speed up the
       // scanning
 
-      QString firstName = QDir::fromNativeSeparators( FsEncoding::decode( i->c_str() ) );
-      if( !firstName.endsWith( ".zim") && !firstName.endsWith( ".zimaa" ) )
-        continue;
+    QString firstName = QDir::fromNativeSeparators( i->c_str() );
+    if ( !firstName.endsWith( ".zim" ) && !firstName.endsWith( ".zimaa" ) )
+      continue;
 
       // Got the file -- check if we need to rebuid the index
       ZimFile df( firstName );

--- a/zipsounds.cc
+++ b/zipsounds.cc
@@ -153,8 +153,7 @@ ZipSoundsDictionary::ZipSoundsDictionary( string const & id,
                         idxHeader.indexRootOffset ),
                         idx, idxMutex );
 
-  QString zipName = QDir::fromNativeSeparators(
-                    FsEncoding::decode( getDictionaryFilenames()[ 0 ].c_str() ) );
+  QString zipName = QDir::fromNativeSeparators( getDictionaryFilenames()[ 0 ].c_str() );
 
   zipsFile.openZipFile( zipName );
   zipsFile.openIndex( IndexInfo( idxHeader.indexBtreeMaxElements,
@@ -388,8 +387,7 @@ void ZipSoundsDictionary::loadIcon() noexcept
   if ( dictionaryIconLoaded )
     return;
 
-  QString fileName =
-    QDir::fromNativeSeparators( FsEncoding::decode( getDictionaryFilenames()[ 0 ].c_str() ) );
+  QString fileName = QDir::fromNativeSeparators( getDictionaryFilenames()[ 0 ].c_str() );
 
   // Remove the extension
   fileName.chop( 4 );
@@ -447,8 +445,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries(
         quint32 namesCount;
 
         IndexedZip zipFile;
-        if( zipFile.openZipFile( QDir::fromNativeSeparators(
-                                 FsEncoding::decode( i->c_str() ) ) ) )
+        if ( zipFile.openZipFile( QDir::fromNativeSeparators( i->c_str() ) ) )
           zipFile.indexFile( zipFileNames, &namesCount );
 
         if( !zipFileNames.empty() )
@@ -499,8 +496,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries(
         else
         {
           idx.close();
-          QFile::remove( QDir::fromNativeSeparators(
-                         FsEncoding::decode( indexFile.c_str() ) ) );
+          QFile::remove( QDir::fromNativeSeparators( indexFile.c_str() ) );
           throw exInvalidData();
         }
       }


### PR DESCRIPTION
Rename a dict path to `😎whatرحبًا你好¡Hola!💩` and GD still works :)

Tested on Linux & Windows11.

## FsEncoding::decode

`Qt_Method(FsEncoding::decode(a_std_string.c_str()))` is converted to `Qt_Method(a_std_string.c_str())`, becuase all related Qt_methods can take `char *`. A few places are converted to `Qt_Method(QString::fromStdString(a_std_string))`.

## FsEncoding::encode

`FsEncoding::encode(a_QString)` is converted to `a_QString.toStdString()` or `a_QString.toUtf8()` (They are equivalent).

---

https://github.com/xiaoyifang/goldendict/issues/468
