### PR TITLE
Abstract `FsEncoding::dirname(getDictionaryFilenames()[0])` into `Dictionary::Class::getContainingDir`

### DIFF
--- a/dictionary.cc
+++ b/dictionary.cc
@@ -171,6 +171,11 @@ vector< wstring > Class::getAlternateWritings( wstring const & )
   return vector< wstring >();
 }
 
+QString Class::getContainingFolder()
+{
+  return QFileInfo( QString::fromStdString( dictionaryFiles[ 0 ] ) ).absolutePath();
+}
+
 sptr< DataRequest > Class::getResource( string const & /*name*/ )
 
 {

--- a/dictionary.hh
+++ b/dictionary.hh
@@ -312,6 +312,9 @@ public:
   vector< string > const & getDictionaryFilenames() noexcept
   { return dictionaryFiles; }
 
+  /// Get the main folder that contains the dictionary, without the ending separator .
+  QString getContainingFolder();
+
   /// Returns the dictionary's full name, utf8.
   virtual string getName() noexcept=0;
 

--- a/dsl.cc
+++ b/dsl.cc
@@ -849,7 +849,7 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
       // Otherwise, make a global 'search' one.
 
       bool search = !File::exists( n ) && !File::exists( resourceDir2 + filename )
-        && !File::exists( FsEncoding::dirname( getDictionaryFilenames()[ 0 ] ) + FsEncoding::separator() + filename )
+        && !File::exists( getContainingFolder().toStdString() + FsEncoding::separator() + filename )
         && ( !resourceZip.isOpen() || !resourceZip.hasFile( Utf8::decode( filename ) ) );
 
       QUrl url;
@@ -891,7 +891,7 @@ string DslDictionary::nodeToHtml( ArticleDom::Node const & node )
         {
           try
           {
-            n = FsEncoding::dirname( getDictionaryFilenames()[ 0 ] ) + FsEncoding::separator() + filename;
+            n = getContainingFolder().toStdString() + FsEncoding::separator() + filename;
             File::loadFromFile( n, imgdata );
           }
           catch( File::exCantOpen & )
@@ -1780,7 +1780,7 @@ void DslResourceRequest::run()
     return;
   }
 
-  string n = FsEncoding::dirname( dict.getDictionaryFilenames()[ 0 ] ) + FsEncoding::separator() + resourceName;
+  string n = dict.getContainingFolder().toStdString() + FsEncoding::separator() + resourceName;
 
   GD_DPRINTF( "n is %s\n", n.c_str() );
 

--- a/fsencoding.cc
+++ b/fsencoding.cc
@@ -13,16 +13,6 @@ char separator()
   return QDir::separator().toLatin1();
 }
 
-string dirname( string const & str )
-{
-  size_t x = str.rfind( separator() );
-
-  if ( x == string::npos )
-    return string( "." );
-
-  return string( str, 0, x );
-}
-
 string basename( string const & str )
 {
   size_t x = str.rfind( separator() );

--- a/fsencoding.hh
+++ b/fsencoding.hh
@@ -17,9 +17,6 @@ using std::string;
 /// Returns the filesystem separator (/ on Unix and clones, \ on Windows).
 char separator();
 
-/// Returns the directory part of the given filename.
-string dirname( string const & );
-
 /// Returns the name part of the given filename.
 string basename( string const & );
 

--- a/gls.cc
+++ b/gls.cc
@@ -1235,7 +1235,7 @@ void GlsResourceRequest::run()
 
   try
   {
-    string n = FsEncoding::dirname( dict.getDictionaryFilenames()[ 0 ] ) + FsEncoding::separator() + resourceName;
+    string n = dict.getContainingFolder().toStdString() + FsEncoding::separator() + resourceName;
 
     GD_DPRINTF( "n is %s\n", n.c_str() );
 

--- a/mainwindow.cc
+++ b/mainwindow.cc
@@ -4277,13 +4277,8 @@ void MainWindow::openDictionaryFolder( const QString & id )
   {
     if( dictionaries[ x ]->getId() == id.toUtf8().data() )
     {
-      if( dictionaries[ x ]->getDictionaryFilenames().size() > 0 )
-      {
-        QString fileName = dictionaries[ x ]->getDictionaryFilenames()[ 0 ].c_str();
-
-        QString folder = QFileInfo( fileName ).absoluteDir().absolutePath();
-        if( !folder.isEmpty() )
-          QDesktopServices::openUrl( QUrl::fromLocalFile( folder ) );
+      if ( !dictionaries[ x ]->getDictionaryFilenames().empty() ) {
+        QDesktopServices::openUrl( QUrl::fromLocalFile( dictionaries[ x ]->getContainingFolder() ) );
       }
       break;
     }

--- a/mdx.cc
+++ b/mdx.cc
@@ -1227,8 +1227,8 @@ void MdxDictionary::loadResourceFile( const wstring & resourceName, vector< char
     newResourceName.insert( 0, 1, '\\' );
   }
   // local file takes precedence
-  if( string fn = FsEncoding::dirname( getDictionaryFilenames()[ 0 ] ) + FsEncoding::separator() + u8ResourceName;
-      File::exists( fn ) ) {
+  if ( string fn = getContainingFolder().toStdString() + FsEncoding::separator() + u8ResourceName;
+       File::exists( fn ) ) {
     File::loadFromFile( fn, data );
     return;
   }

--- a/stardict.cc
+++ b/stardict.cc
@@ -1693,8 +1693,7 @@ void StardictResourceRequest::run()
     if( resourceName.at( resourceName.length() - 1 ) == '\x1F' )
       resourceName.erase( resourceName.length() - 1, 1 );
 
-    string n = FsEncoding::dirname( dict.getDictionaryFilenames()[ 0 ] ) + FsEncoding::separator() + "res"
-      + FsEncoding::separator() + resourceName;
+    string n = dict.getContainingFolder().toStdString() + FsEncoding::separator() + "res" + FsEncoding::separator() + resourceName;
 
     GD_DPRINTF( "n is %s\n", n.c_str() );
 
@@ -2005,7 +2004,8 @@ vector< sptr< Dictionary::Class > > makeDictionaries(
       // See if there's a zip file with resources present. If so, include it.
 
       string zipFileName;
-      string baseName = FsEncoding::dirname( idxFileName ) + FsEncoding::separator();
+      string baseName =
+        QDir( QString::fromStdString( idxFileName ) ).absolutePath().toStdString() + FsEncoding::separator();
 
       if ( File::tryPossibleZipName( baseName + "res.zip", zipFileName ) ||
            File::tryPossibleZipName( baseName + "RES.ZIP", zipFileName ) ||

--- a/xdxf.cc
+++ b/xdxf.cc
@@ -1053,7 +1053,7 @@ void XdxfResourceRequest::run()
     return;
   }
 
-  string n = FsEncoding::dirname( dict.getDictionaryFilenames()[ 0 ] ) + FsEncoding::separator() + resourceName;
+  string n = dict.getContainingFolder().toStdString() + FsEncoding::separator() + resourceName;
 
   GD_DPRINTF( "n is %s\n", n.c_str() );
 

--- a/xdxf2html.cc
+++ b/xdxf2html.cc
@@ -649,8 +649,7 @@ string convert( string const & in, DICT_TYPE type, map < string, string > const 
             bool search = false;
             if( type == STARDICT )
             {
-              string n = FsEncoding::dirname( dictPtr->getDictionaryFilenames()[ 0 ] ) + FsEncoding::separator()
-                + string( "res" ) + FsEncoding::separator() + filename;
+              string n = dictPtr->getContainingFolder().toStdString() + FsEncoding::separator() + string( "res" ) + FsEncoding::separator() + filename;
               search = !File::exists( n ) &&
                        ( !resourceZip ||
                          !resourceZip->isOpen() ||
@@ -660,8 +659,7 @@ string convert( string const & in, DICT_TYPE type, map < string, string > const 
             {
               string n = dictPtr->getDictionaryFilenames()[ 0 ] + ".files" + FsEncoding::separator() + filename;
               search   = !File::exists( n )
-                && !File::exists( FsEncoding::dirname( dictPtr->getDictionaryFilenames()[ 0 ] )
-                                  + FsEncoding::separator() + filename )
+                && !File::exists( dictPtr->getContainingFolder().toStdString() + FsEncoding::separator() + filename )
                 && ( !resourceZip || !resourceZip->isOpen() || !resourceZip->hasFile( Utf8::decode( filename ) ) );
             }
 


### PR DESCRIPTION
`FsEncoding::dirname` is removed :smile: 

`FsEncoding::dirname` is always used with `getDictionaryFilenames()[ 0 ]` to obtain the `containingDir` of a dictionary, with one exception at `stardict.cc`

Due to previously usage of std::string for path storage, this has to include a `toStdString()` for now.

The most beautiful change in this PR:
![image](https://user-images.githubusercontent.com/20123683/231934530-b9595a1c-d32b-4539-82a5-113e0681258c.png)

https://github.com/xiaoyifang/goldendict/issues/468
