### PR TITLE
Remove the WriteBuffer from File::Class

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -15,7 +15,7 @@ AllowAllArgumentsOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: Empty
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: All
+AllowShortFunctionsOnASingleLine: Empty
 AllowShortLambdasOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
@@ -23,7 +23,7 @@ AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AllowShortEnumsOnASingleLine: false
 AlwaysBreakBeforeMultilineStrings: true
-AlwaysBreakTemplateDeclarations: MultiLine
+AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: false
 BinPackParameters: false
 BraceWrapping:

--- a/file.hh
+++ b/file.hh
@@ -1,19 +1,22 @@
 /* This file is (c) 2008-2012 Konstantin Isakov <ikm@goldendict.org>
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
-#ifndef __FILE_HH_INCLUDED__
-#define __FILE_HH_INCLUDED__
+#ifndef GOLDENDICT_FILE_HH
+#define GOLDENDICT_FILE_HH
 
+#include "ex.hh"
+#include "mutex.hh"
+#include <QFile>
+#include <QFileInfo>
 #include <cstdio>
 #include <string>
 #include <vector>
-#include <QFile>
-#include "ex.hh"
-#include "mutex.hh"
 
-/// A simple wrapper over FILE * operations with added write-buffering,
-/// used for non-Qt parts of code.
-/// It is possible to ifdef implementation details for some platforms.
+/// A simple wrapper over QFile with some convenient GD specific functions
+/// Consider the wrapped QFile as private implementation in the `Pimpl Idiom`
+///
+/// Note: this is used *only* in code related to `Dictionary::CLass` to manage dict files.
+/// In other places, just use QFile directly.
 namespace File {
 
 DEF_EX( Ex, "File exception", std::exception )
@@ -23,111 +26,106 @@ DEF_EX( exWriteError, "Error writing to the file", Ex )
 DEF_EX( exSeekError, "File seek error", Ex )
 DEF_EX( exAllocation, "Memory allocation error", Ex )
 
-/// Checks if the file exists or not.
-
 bool tryPossibleName( std::string const & name, std::string & copyTo );
 
 bool tryPossibleZipName( std::string const & name, std::string & copyTo );
 
-void loadFromFile( std::string const & n, std::vector< char > & data );
+void loadFromFile( std::string const & filename, std::vector< char > & data );
 
-bool exists( char const * filename ) noexcept;
-
-inline bool exists( std::string const & filename ) noexcept
-{ return exists( filename.c_str() ); }
+// QFileInfo::exists but used for std::string and char*
+inline bool exists( std::string_view filename ) noexcept
+{
+  return QFileInfo::exists( QString::fromUtf8( filename.data(), filename.size() ) );
+};
 
 class Class
 {
   QFile f;
-  char * writeBuffer;
-  qint64 writeBufferLeft;
-
-  void open( char const * filename, char const * mode ) ;
 
 public:
   QMutex lock;
 
-  Class( char const * filename, char const * mode ) ;
+  // Create QFile Object and open() it.
+  Class( std::string_view filename, char const * mode );
 
-  Class( std::string const & filename, char const * mode ) ;
+  /// QFile::read  & QFile::write , but with exception throwing
+  void read( void * buf, qint64 size );
+  void write( void const * buf, qint64 size );
 
-  /// Reads the number of bytes to the buffer, throws an error if it
-  /// failed to fill the whole buffer (short read, i/o error etc).
-  void read( void * buf, qint64 size ) ;
+  // Read sizeof(T) bytes and convert the read data to T
+  template< typename T >
+  T read()
+  {
+    T value;
+    readType( value );
+    return value;
+  }
 
   template< typename T >
-  void read( T & value ) 
-  { read( &value, sizeof( value ) ); }
-
-  template< typename T >
-  T read() 
-  { T value; read( value ); return value; }
+  void write( T const & value )
+  {
+    write( &value, sizeof( value ) );
+  }
 
   /// Attempts reading at most 'count' records sized 'size'. Returns
   /// the number of records it managed to read, up to 'count'.
-  size_t readRecords( void * buf, qint64 size, size_t count ) ;
-
-  /// Writes the number of bytes from the buffer, throws an error if it
-  /// failed to write the whole buffer (short write, i/o error etc).
-  /// This function employs write buffering, and as such, writes may not
-  /// end up on disk immediately, or a short write may occur later
-  /// than it really did. If you don't want write buffering, use
-  /// writeRecords() function instead.
-  void write( void const * buf, qint64 size ) ;
-
-  template< typename T >
-  void write( T const & value ) 
-  { write( &value, sizeof( value ) ); }
+  size_t readRecords( void * buf, qint64 size, qint64 count );
 
   /// Attempts writing at most 'count' records sized 'size'. Returns
   /// the number of records it managed to write, up to 'count'.
   /// This function does not employ buffering, but flushes the buffer if it
   /// was used before.
-  size_t writeRecords( void const * buf, qint64 size, size_t count )
-    ;
+  size_t writeRecords( void const * buf, qint64 size, qint64 count );
 
-  /// Reads a string from the file. Unlike the normal fgets(), this one
-  /// can strip the trailing newline character, if this was requested.
+  /// Read a line with option to strip the trailing newline character
   /// Returns either s or 0 if no characters were read.
-  char * gets( char * s, int size, bool stripNl = false ) ;
+  char * gets( char * s, int size, bool stripNl = false );
 
-  /// Like the above, but uses its own local internal buffer (1024 bytes
-  /// currently), and strips newlines by default.
-  std::string gets( bool stripNl = true ) ;
+  /// Like the above, but uses its own local internal buffer and strips newlines by default.
+  std::string gets( bool stripNl = true );
 
-  /// Seeks in the file, relative to its beginning.
-  void seek( qint64 offset ) ;
-  uchar * map( qint64 offset, qint64 size );
-  /// Seeks in the file, relative to the current position.
-  void seekCur( qint64 offset ) ;
-  /// Seeks in the file, relative to the end of file.
-  void seekEnd( qint64 offset = 0 ) ;
+  /// export QFile::readall
+  QByteArray readall();
+
+  /// export QFile::seek
+  void seek( qint64 offset );
+
+  /// Seeks to the end of file.
+  void seekEnd();
 
   /// Seeks to the beginning of file
-  void rewind() ;
+  void rewind();
 
   /// Tells the current position within the file, relative to its beginning.
-  qint64 tell() ;
+  qint64 tell();
 
-  /// Returns true if end-of-file condition is set.
-  bool eof() ;
+  /// QFile::atEnd() const
+  bool eof() const;
 
-  /// Returns the underlying FILE * record, so other operations can be
-  /// performed on it.
-  QFile & file() ;
-
-  /// Closes the file. No further operations are valid.
-  void close() ;
-
-  ~Class() noexcept;
+  uchar * map( qint64 offset, qint64 size );
   bool unmap( uchar * address );
 
-private:
 
-  void flushWriteBuffer() ;
-  void releaseWriteBuffer() ;
+  /// Returns the underlying QFile* , so other operations can be
+  /// performed on it.
+  QFile & file();
+
+  /// Closes the file. No further operations are valid.
+  void close();
+
+  ~Class() noexcept;
+
+private:
+  // QFile::open but with fopen-like mode settings.
+  void open( char const * mode );
+
+  template< typename T >
+  void readType( T & value )
+  {
+    read( &value, sizeof( value ) );
+  }
 };
 
-}
+} // namespace File
 
 #endif


### PR DESCRIPTION
After `File::Class`'s migration from `FILE` to `QFile` https://github.com/xiaoyifang/goldendict/commit/becc74c730d350e06cc58cea3396a4e4ce82c3bf , the buffer is no longer useful because `QFile` already did that.

---

This PR is intended to avoid any change outside `file.cc/file.h`. The new implementation is a drop-in replacement. If unforeseeable bugs ever happen, we can revert without problem :)

---

To minimize changes, the `QFile` is hold as `f` as before, because of the name confliction between the template read(). If we change the template's name, all files will need a change. Also, we don't want all QFile's API to be exposed.

https://github.com/xiaoyifang/goldendict/issues/468