### PR TITLE
fix: remove the webplugin option

### DIFF
--- a/config.cc
+++ b/config.cc
@@ -265,7 +265,6 @@ Preferences::Preferences():
   internalPlayerBackend( InternalPlayerBackend::defaultBackend() ),
   checkForNewReleases( true ),
   disallowContentFromOtherSites( false ),
-  enableWebPlugins( false ),
   hideGoldenDictHeader( false ),
   maxNetworkCacheSize( 50 ),
   clearNetworkCacheOnExit( true ),
@@ -990,9 +989,6 @@ Class load()
 
     if ( !preferences.namedItem( "disallowContentFromOtherSites" ).isNull() )
       c.preferences.disallowContentFromOtherSites = ( preferences.namedItem( "disallowContentFromOtherSites" ).toElement().text() == "1" );
-
-    if ( !preferences.namedItem( "enableWebPlugins" ).isNull() )
-      c.preferences.enableWebPlugins = ( preferences.namedItem( "enableWebPlugins" ).toElement().text() == "1" );
 
     if ( !preferences.namedItem( "hideGoldenDictHeader" ).isNull() )
       c.preferences.hideGoldenDictHeader = ( preferences.namedItem( "hideGoldenDictHeader" ).toElement().text() == "1" );
@@ -1984,10 +1980,6 @@ void save( Class const & c )
 
     opt = dd.createElement( "disallowContentFromOtherSites" );
     opt.appendChild( dd.createTextNode( c.preferences.disallowContentFromOtherSites ? "1" : "0" ) );
-    preferences.appendChild( opt );
-
-    opt = dd.createElement( "enableWebPlugins" );
-    opt.appendChild( dd.createTextNode( c.preferences.enableWebPlugins ? "1" : "0" ) );
     preferences.appendChild( opt );
 
     opt = dd.createElement( "hideGoldenDictHeader" );

--- a/config.hh
+++ b/config.hh
@@ -355,7 +355,6 @@ struct Preferences
 
   bool checkForNewReleases;
   bool disallowContentFromOtherSites;
-  bool enableWebPlugins;
   bool hideGoldenDictHeader;
   int maxNetworkCacheSize;
   bool clearNetworkCacheOnExit;

--- a/preferences.cc
+++ b/preferences.cc
@@ -332,7 +332,6 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
 
   ui.checkForNewReleases->setChecked( p.checkForNewReleases );
   ui.disallowContentFromOtherSites->setChecked( p.disallowContentFromOtherSites );
-  ui.enableWebPlugins->setChecked( p.enableWebPlugins );
   ui.hideGoldenDictHeader->setChecked( p.hideGoldenDictHeader );
   ui.maxNetworkCacheSize->setValue( p.maxNetworkCacheSize );
   ui.clearNetworkCacheOnExit->setChecked( p.clearNetworkCacheOnExit );
@@ -481,7 +480,6 @@ Config::Preferences Preferences::getPreferences()
 
   p.checkForNewReleases = ui.checkForNewReleases->isChecked();
   p.disallowContentFromOtherSites = ui.disallowContentFromOtherSites->isChecked();
-  p.enableWebPlugins = ui.enableWebPlugins->isChecked();
   p.hideGoldenDictHeader = ui.hideGoldenDictHeader->isChecked();
   p.maxNetworkCacheSize = ui.maxNetworkCacheSize->value();
   p.clearNetworkCacheOnExit = ui.clearNetworkCacheOnExit->isChecked();

--- a/preferences.ui
+++ b/preferences.ui
@@ -1168,18 +1168,6 @@ you are browsing. If some site breaks because of this, try disabling this.</stri
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="enableWebPlugins">
-         <property name="toolTip">
-          <string>Enabling this would allow to listen to sound pronunciations from
-online dictionaries that rely on Flash or other web plugins.
-Plugin must be installed for this option to work.</string>
-         </property>
-         <property name="text">
-          <string>Enable web plugins</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <widget class="QCheckBox" name="hideGoldenDictHeader">
          <property name="toolTip">
           <string>Some sites detect GoldenDict via HTTP headers and block the requests.

--- a/src/ui/articleview.cpp
+++ b/src/ui/articleview.cpp
@@ -355,7 +355,7 @@ ArticleView::ArticleView( QWidget * parent, ArticleNetworkAccessManager & nm, Au
   settings->defaultSettings()->setAttribute( QWebEngineSettings::LocalContentCanAccessRemoteUrls, true );
   settings->defaultSettings()->setAttribute( QWebEngineSettings::LocalContentCanAccessFileUrls, true );
   settings->defaultSettings()->setAttribute( QWebEngineSettings::ErrorPageEnabled, false );
-  settings->defaultSettings()->setAttribute( QWebEngineSettings::PluginsEnabled, cfg.preferences.enableWebPlugins );
+  settings->defaultSettings()->setAttribute( QWebEngineSettings::PluginsEnabled, true );
   settings->defaultSettings()->setAttribute( QWebEngineSettings::PlaybackRequiresUserGesture, false );
   settings->defaultSettings()->setAttribute( QWebEngineSettings::JavascriptCanAccessClipboard, true );
   settings->defaultSettings()->setAttribute( QWebEngineSettings::PrintElementBackgrounds, false );
@@ -363,7 +363,7 @@ ArticleView::ArticleView( QWidget * parent, ArticleNetworkAccessManager & nm, Au
   settings->setAttribute( QWebEngineSettings::LocalContentCanAccessRemoteUrls, true );
   settings->setAttribute( QWebEngineSettings::LocalContentCanAccessFileUrls, true );
   settings->setAttribute( QWebEngineSettings::ErrorPageEnabled, false );
-  settings->setAttribute( QWebEngineSettings::PluginsEnabled, cfg.preferences.enableWebPlugins );
+  settings->setAttribute( QWebEngineSettings::PluginsEnabled, true );
   settings->setAttribute( QWebEngineSettings::PlaybackRequiresUserGesture, false );
   settings->setAttribute( QWebEngineSettings::JavascriptCanAccessClipboard, true );
   settings->setAttribute( QWebEngineSettings::PrintElementBackgrounds, false );


### PR DESCRIPTION
this plugin is used mainly for flash plugins, which has been disabled in modern browser. There is no need to configure this option.

![image](https://user-images.githubusercontent.com/105986/232177073-fb38a3f6-bb50-43a3-af34-abc2e63bb98d.png)

fix #481
