### PR TITLE
feat: session collapsable feature support

### DIFF
--- a/article_maker.cc
+++ b/article_maker.cc
@@ -573,13 +573,12 @@ bool ArticleRequest::isCollapsable( Dictionary::DataRequest & req ,QString const
       if( !needExpandOptionalParts )
       {
         // Strip DSL optional parts
-        int pos = 0;
         for( ; ; )
         {
-          pos = text.indexOf( "<div class=\"dsl_opt\"" );
+          const int pos = text.indexOf( "<div class=\"dsl_opt\"" );
           if( pos > 0 )
           {
-            int endPos = findEndOfCloseDiv( text, pos + 1 );
+            const int endPos = findEndOfCloseDiv( text, pos + 1 );
             if( endPos > pos)
               text.remove( pos, endPos - pos );
             else

--- a/article_maker.hh
+++ b/article_maker.hh
@@ -152,6 +152,7 @@ private:
 
   /// Find end of corresponding </div> tag
   int findEndOfCloseDiv( QString const &, int pos );
+  bool isCollapsable( Dictionary::DataRequest & req,QString const & dictId );
 };
 
 

--- a/article_netmgr.cc
+++ b/article_netmgr.cc
@@ -558,6 +558,5 @@ void LocalSchemeHandler::requestStarted(QWebEngineUrlRequestJob *requestJob)
 
   QNetworkReply * reply = this->mManager.getArticleReply( request );
   requestJob->reply( "text/html", reply );
-  //connect( reply, &QNetworkReply::finished, requestJob, [ = ]() {  } );
   connect( requestJob, &QObject::destroyed, reply, &QObject::deleteLater );
 }

--- a/article_netmgr.cc
+++ b/article_netmgr.cc
@@ -4,7 +4,6 @@
 #include <stdint.h>
 #include <QUrl>
 #include "article_netmgr.hh"
-#include "wstring_qt.hh"
 #include "gddebug.hh"
 #include "utils.hh"
 #include <QNetworkAccessManager>

--- a/articlewebview.cc
+++ b/articlewebview.cc
@@ -9,7 +9,7 @@
 #include <QTimer>
 #include <QDialog>
 #include <QMainWindow>
-
+#include "globalbroadcaster.h"
 #ifdef Q_OS_WIN32
 #include <qt_windows.h>
 #endif

--- a/articlewebview.hh
+++ b/articlewebview.hh
@@ -74,8 +74,8 @@ private:
 
 public slots:
 
-    //receive signal ,a link has been clicked.
-    void linkClickedInHtml(QUrl const& url);
+  //receive signal ,a link has been clicked.
+  void linkClickedInHtml( QUrl const & url );
 };
 
 #endif

--- a/config.cc
+++ b/config.cc
@@ -930,6 +930,11 @@ Class load()
     c.preferences.ignoreDiacritics = ( preferences.namedItem( "ignoreDiacritics" ).toElement().text() == "1" );
     if( !preferences.namedItem( "ignorePunctuation" ).isNull() )
       c.preferences.ignorePunctuation = ( preferences.namedItem( "ignorePunctuation" ).toElement().text() == "1" );
+
+    if ( !preferences.namedItem( "sessionCollapse" ).isNull() ) {
+      c.preferences.sessionCollapse = ( preferences.namedItem( "sessionCollapse" ).toElement().text() == "1" );
+    }
+
 #ifdef HAVE_X11
     c.preferences.trackClipboardScan= ( preferences.namedItem( "trackClipboardScan" ).toElement().text() == "1" );
     c.preferences.trackSelectionScan= ( preferences.namedItem( "trackSelectionScan" ).toElement().text() == "1" );
@@ -1843,6 +1848,10 @@ void save( Class const & c )
 
     opt = dd.createElement( "ignorePunctuation" );
     opt.appendChild( dd.createTextNode( c.preferences.ignorePunctuation ? "1":"0" ) );
+    preferences.appendChild( opt );
+
+    opt = dd.createElement( "sessionCollapse" );
+    opt.appendChild( dd.createTextNode( c.preferences.sessionCollapse ? "1" : "0" ) );
     preferences.appendChild( opt );
 
 #ifdef HAVE_X11

--- a/config.hh
+++ b/config.hh
@@ -338,6 +338,7 @@ struct Preferences
   bool scanToMainWindow;
   bool ignoreDiacritics;
   bool ignorePunctuation;
+  bool sessionCollapse = false;
 #ifdef HAVE_X11
   bool trackClipboardScan;
   bool trackSelectionScan;

--- a/globalbroadcaster.h
+++ b/globalbroadcaster.h
@@ -29,6 +29,9 @@ public:
   unsigned currentGroupId;
   QString translateLineText{};
   QWebEngineProfile * profile;
+  //hold the dictionary id;
+  QSet<QString> collapsedDicts;
+
 
 signals:
   void dictionaryChanges( ActiveDictIds ad );

--- a/locale/zh_CN.ts
+++ b/locale/zh_CN.ts
@@ -3985,7 +3985,12 @@ however, the article from the topmost dictionary is shown.</source>
         <translation type="unfinished">深色阅读模式</translation>
     </message>
     <message>
-        <location filename="../preferences.ui" line="457"/>
+        <location filename="../preferences.ui" line="363"/>
+        <source>MRU order: Most recently used order.</source>
+        <translation>排序：最近使用优先</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="440"/>
         <source>Track clipboard changes when Scanning is enabled. Notice! You should always enable this unless you are on Linux.</source>
         <translation>剪贴板取词。注意！非Linux系统，这个选项必须打开</translation>
     </message>
@@ -4140,7 +4145,17 @@ clears its network cache from disk during exit.</source>
         <translation>高级(&amp;v)</translation>
     </message>
     <message>
-        <location filename="../preferences.ui" line="1749"/>
+        <location filename="../preferences.ui" line="1769"/>
+        <source>During successive searches,if one dictionary is collapsed by manual, it will remain collapsed in the next search</source>
+        <translation>如果用户折叠了词典，下次搜索的时候，保持折叠状态。</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="1772"/>
+        <source>Session collapse</source>
+        <translation>搜索期间保持折叠</translation>
+    </message>
+    <message>
+        <location filename="../preferences.ui" line="1793"/>
         <source>When using clipboard,strip everything after newline</source>
         <translation>当使用剪贴板时，忽略剪贴板中换行之后的内容</translation>
     </message>

--- a/preferences.cc
+++ b/preferences.cc
@@ -218,6 +218,7 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   ui.ignoreDiacritics->setChecked( p.ignoreDiacritics );
 
   ui.ignorePunctuation->setChecked( p.ignorePunctuation );
+  ui.sessionCollapse->setChecked( p.sessionCollapse );
 
   ui.synonymSearchEnabled->setChecked( p.synonymSearchEnabled );
 
@@ -444,6 +445,7 @@ Config::Preferences Preferences::getPreferences()
   p.inputPhraseLengthLimit = ui.inputPhraseLengthLimit->value();
   p.ignoreDiacritics = ui.ignoreDiacritics->isChecked();
   p.ignorePunctuation = ui.ignorePunctuation->isChecked();
+  p.sessionCollapse        = ui.sessionCollapse->isChecked();
   p.stripClipboard = ui.stripClipboard->isChecked();
   p.raiseWindowOnSearch = ui.raiseWindowOnSearch->isChecked();
 

--- a/preferences.ui
+++ b/preferences.ui
@@ -1556,6 +1556,19 @@ download page.</string>
               </item>
              </layout>
             </item>
+            <item>
+             <spacer name="verticalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
            </layout>
           </widget>
          </item>
@@ -1627,76 +1640,10 @@ download page.</string>
           <string>Articles</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="limitInputPhraseLength">
-            <property name="toolTip">
-             <string>Turn this option on to ignore unreasonably long input text
-from mouse-over, selection, clipboard or command line</string>
-            </property>
+          <item row="2" column="4">
+           <widget class="QCheckBox" name="ignorePunctuation">
             <property name="text">
-             <string>Ignore input phrases longer than</string>
-            </property>
-            <property name="checked">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3">
-           <spacer name="horizontalSpacer_11">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="1" column="3">
-           <spacer name="horizontalSpacer_14">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="0" column="1">
-           <widget class="QSpinBox" name="articleSizeLimit">
-            <property name="toolTip">
-             <string>Articles longer than this size will be collapsed</string>
-            </property>
-            <property name="maximum">
-             <number>100000</number>
-            </property>
-            <property name="singleStep">
-             <number>50</number>
-            </property>
-            <property name="value">
-             <number>2000</number>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="4">
-           <widget class="QCheckBox" name="ignoreDiacritics">
-            <property name="toolTip">
-             <string>Turn this option on to ignore diacritics while searching articles</string>
-            </property>
-            <property name="text">
-             <string>Ignore diacritics while searching</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QLabel" name="label_13">
-            <property name="text">
-             <string>symbols</string>
+             <string>Ignore punctuation while searching</string>
             </property>
            </widget>
           </item>
@@ -1716,6 +1663,13 @@ from mouse-over, selection, clipboard or command line</string>
             </property>
            </widget>
           </item>
+          <item row="1" column="2">
+           <widget class="QLabel" name="label_19">
+            <property name="text">
+             <string>symbols</string>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="0">
            <widget class="QCheckBox" name="collapseBigArticles">
             <property name="toolTip">
@@ -1723,6 +1677,56 @@ from mouse-over, selection, clipboard or command line</string>
             </property>
             <property name="text">
              <string>Collapse articles more than</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="limitInputPhraseLength">
+            <property name="toolTip">
+             <string>Turn this option on to ignore unreasonably long input text
+from mouse-over, selection, clipboard or command line</string>
+            </property>
+            <property name="text">
+             <string>Ignore input phrases longer than</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <spacer name="horizontalSpacer_14">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="0" column="2">
+           <widget class="QLabel" name="label_13">
+            <property name="text">
+             <string>symbols</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="articleSizeLimit">
+            <property name="toolTip">
+             <string>Articles longer than this size will be collapsed</string>
+            </property>
+            <property name="maximum">
+             <number>100000</number>
+            </property>
+            <property name="singleStep">
+             <number>50</number>
+            </property>
+            <property name="value">
+             <number>2000</number>
             </property>
            </widget>
           </item>
@@ -1736,17 +1740,36 @@ from mouse-over, selection, clipboard or command line</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="2">
-           <widget class="QLabel" name="label_19">
+          <item row="1" column="4">
+           <widget class="QCheckBox" name="ignoreDiacritics">
+            <property name="toolTip">
+             <string>Turn this option on to ignore diacritics while searching articles</string>
+            </property>
             <property name="text">
-             <string>symbols</string>
+             <string>Ignore diacritics while searching</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="4">
-           <widget class="QCheckBox" name="ignorePunctuation">
+          <item row="0" column="3">
+           <spacer name="horizontalSpacer_11">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="3" column="4">
+           <widget class="QCheckBox" name="sessionCollapse">
+            <property name="toolTip">
+             <string>During successive searches,if one dictionary is collapsed by manual, it will remain collapsed in the next search</string>
+            </property>
             <property name="text">
-             <string>Ignore punctuation while searching</string>
+             <string>Session collapse</string>
             </property>
            </widget>
           </item>

--- a/scripts/gd-builtin.js
+++ b/scripts/gd-builtin.js
@@ -102,6 +102,7 @@ function gdExpandArticle(id) {
             ev.stopPropagation()
         ico.title = tr("Expand article")
         nm.title = ''
+        articleview.collapseInHtml(id,true);
     } else if (elem.style.display == 'none') {
         elem.style.display = 'inline'
         ico.className = 'gdcollapseicon'
@@ -110,6 +111,7 @@ function gdExpandArticle(id) {
         nm.style.cursor = 'default'
         nm.title = ''
         ico.title = tr("Collapse article")
+        articleview.collapseInHtml(id,false);
     }
 }
 

--- a/src/ui/articleview.cpp
+++ b/src/ui/articleview.cpp
@@ -2753,3 +2753,16 @@ void ArticleViewAgent::linkClickedInHtml( QUrl const & url )
 {
   articleView->linkClickedInHtml( url );
 }
+
+void ArticleViewAgent::collapseInHtml( QString const & dictId, bool on )
+{
+  if ( GlobalBroadcaster::instance()->getPreference()->sessionCollapse ) {
+    if ( on ) {
+      GlobalBroadcaster::instance()->collapsedDicts.insert( dictId );
+    }
+    else {
+      GlobalBroadcaster::instance()->collapsedDicts.remove( dictId );
+    }
+  }
+}
+

--- a/src/ui/articleview.cpp
+++ b/src/ui/articleview.cpp
@@ -2754,7 +2754,7 @@ void ArticleViewAgent::linkClickedInHtml( QUrl const & url )
   articleView->linkClickedInHtml( url );
 }
 
-void ArticleViewAgent::collapseInHtml( QString const & dictId, bool on )
+void ArticleViewAgent::collapseInHtml( QString const & dictId, bool on ) const
 {
   if ( GlobalBroadcaster::instance()->getPreference()->sessionCollapse ) {
     if ( on ) {

--- a/src/ui/articleview.h
+++ b/src/ui/articleview.h
@@ -467,7 +467,7 @@ public:
 public slots:
   Q_INVOKABLE void onJsActiveArticleChanged( QString const & id );
   Q_INVOKABLE void linkClickedInHtml( QUrl const & );
-  Q_INVOKABLE void collapseInHtml( QString const & dictId, bool on = true );
+  Q_INVOKABLE void collapseInHtml( QString const & dictId, bool on = true ) const;
 };
 
 #endif

--- a/src/ui/articleview.h
+++ b/src/ui/articleview.h
@@ -463,11 +463,11 @@ class ArticleViewAgent : public QObject
 public:
   ArticleViewAgent( ArticleView * articleView );
 
-signals:
 
 public slots:
   Q_INVOKABLE void onJsActiveArticleChanged( QString const & id );
   Q_INVOKABLE void linkClickedInHtml( QUrl const & );
+  Q_INVOKABLE void collapseInHtml( QString const & dictId, bool on = true );
 };
 
 #endif


### PR DESCRIPTION
when enabled , user's manual collapsed dictionary will remain collapsed in the successive search until user expand the dictionary again.

fix #115 