### PR TITLE
Stardict: display `img:` in resource file list ('r'); support stardict's demo dict

### DIFF
--- a/stardict.cc
+++ b/stardict.cc
@@ -445,6 +445,8 @@ private:
 string StardictDictionary::handleResource( char type, char const * resource, size_t size )
 {
   QString text;
+
+  // See "Type identifiers" at http://www.huzheng.org/stardict/StarDictFileFormat
   switch( type )
   {
     case 'x': // Xdxf content
@@ -590,8 +592,24 @@ string StardictDictionary::handleResource( char type, char const * resource, siz
     case 'n': // WordNet data. We don't know anything about it.
       return "<div class=\"sdct_n\">" + Html::escape( string( resource, size ) ) + "</div>";
 
-    case 'r': // Resource file list. For now, resources aren't handled.
-      return "<div class=\"sdct_r\">" + Html::escape( string( resource, size ) ) + "</div>";
+    case 'r': // Resource file list. For now, only img: is handled.
+    {
+      string result = R"(<div class="sdct_r">)";
+
+      // Handle img:example.jpg
+      QString imgTemplate( R"(<img src="bres://)" + QString::fromStdString( getId() ) + R"(/%1">)" );
+
+      for ( const auto & file : QString::fromUtf8( resource, size ).simplified().split( " " ) ) {
+        if ( file.startsWith( "img:" ) ) {
+          result += imgTemplate.arg( file.right( file.size() - file.indexOf( ":" ) - 1 ) ).toStdString();
+        }
+        else {
+          result += Html::escape( file.toStdString() );
+        }
+      }
+
+      return result + "</div>";
+    }
 
     case 'W': // An embedded Wav file. Unhandled yet.
       return "<div class=\"sdct_W\">(an embedded .wav file)</div>";


### PR DESCRIPTION
Background: https://github.com/nikita-moor/latin-dictionary/issues/2#issuecomment-496029572

It is not implemented since 2009.

Fix this dict

https://github.com/xiaoyifang/goldendict/blob/54a4a052a5a09dbb6994b4eb58ef2196545be450/config.cc#L479

Which can be obtained from stardict's source tree

https://github.com/huzheng001/stardict-3/tree/master/dict/src/dic/stardict-dict

Or install the `stardict` package on Linux.

When encounters `r` inside the `*.dict` file ⇾ convert `img:wenjing.png\nimg:wenjing2.png` into `<img src="bres://{dict_id}/wenjing.png">`

![image](https://user-images.githubusercontent.com/20123683/232203128-b97f3655-09ac-4df8-a600-568bfda07496.png)

Then you can see the that stardict's author shipped that girl's image to every linux distro :)

![image](https://user-images.githubusercontent.com/20123683/232203394-5fd9def8-11b7-4d69-880c-5c4b5517debd.png)



