### PR TITLE
fix: findEndOfCloseDiv does not work as always

### DIFF
--- a/article_maker.cc
+++ b/article_maker.cc
@@ -15,6 +15,7 @@
 #include "gddebug.hh"
 #include "utils.hh"
 #include "globalbroadcaster.h"
+#include "base/globalregex.hh"
 
 using std::vector;
 using std::string;
@@ -549,11 +550,12 @@ int ArticleRequest::findEndOfCloseDiv( const QString &str, int pos )
 {
   for( ; ; )
   {
-    int n1 = str.indexOf( "</div>", pos );
+    const int n1 = str.indexOf( "</div>", pos );
     if( n1 <= 0 )
       return n1;
 
-    int n2 = str.indexOf( "<div ", pos );
+    // will there be some custom tags starts with <div but not <div> ,such as <divider>
+    const int n2 = str.indexOf( RX::Html::startDivTag, pos );
     if( n2 <= 0 || n2 > n1 )
       return n1 + 6;
 

--- a/base/globalregex.hh
+++ b/base/globalregex.hh
@@ -55,6 +55,10 @@ class Epwing{
   static QRegularExpression refWord;
 };
 
+namespace Html {
+const static QRegularExpression startDivTag( R"(<div[\s>])" );
+}
+
 } // namespace RX
 
 #endif // GLOBALREGEX_HH


### PR DESCRIPTION
if the start div is `<div>` ,the actual result will has an extra html closed tags .

fix  https://github.com/goldendict/goldendict/issues/1617