### PR TITLE
feat: expose linux's selection clipboard delay timer to user

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -245,6 +245,7 @@ Preferences::Preferences():
   trackClipboardScan ( true ),
   trackSelectionScan ( true ),
   showScanFlag( false ),
+  selectionChangeDelayTimer( 500 ),
 #endif
   pronounceOnLoadMain( false ),
   pronounceOnLoadPopup( false ),
@@ -931,6 +932,8 @@ Class load()
     c.preferences.trackClipboardScan= ( preferences.namedItem( "trackClipboardScan" ).toElement().text() == "1" );
     c.preferences.trackSelectionScan= ( preferences.namedItem( "trackSelectionScan" ).toElement().text() == "1" );
     c.preferences.showScanFlag= ( preferences.namedItem( "showScanFlag" ).toElement().text() == "1" );
+    c.preferences.selectionChangeDelayTimer =
+      preferences.namedItem( "selectionChangeDelayTimer" ).toElement().text().toInt();
 #endif
 
     c.preferences.pronounceOnLoadMain = ( preferences.namedItem( "pronounceOnLoadMain" ).toElement().text() == "1" );
@@ -1842,6 +1845,11 @@ void save( Class const & c )
     opt = dd.createElement( "showScanFlag" );
     opt.appendChild( dd.createTextNode( c.preferences.showScanFlag? "1":"0" ) );
     preferences.appendChild( opt );
+
+    opt = dd.createElement( "selectionChangeDelayTimer" );
+    opt.appendChild( dd.createTextNode( QString::number( c.preferences.selectionChangeDelayTimer ) ) );
+    preferences.appendChild( opt );
+
 #endif
 
     opt = dd.createElement( "pronounceOnLoadMain" );

--- a/src/config.hh
+++ b/src/config.hh
@@ -296,6 +296,7 @@ struct Preferences
   bool trackClipboardScan;
   bool trackSelectionScan;
   bool showScanFlag;
+  int selectionChangeDelayTimer;
 #endif
 
   // Whether the word should be pronounced on page load, in main window/popup

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -228,11 +228,13 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   ui.enableX11SelectionTrack->setChecked(p.trackSelectionScan);
   ui.enableClipboardTrack ->setChecked(p.trackClipboardScan);
   ui.showScanFlag->setChecked(p.showScanFlag);
+  ui.delayTimer->setValue( p.selectionChangeDelayTimer );
 #else
   ui.enableX11SelectionTrack->hide();
   ui.enableClipboardTrack->hide();
   ui.showScanFlag->hide();
   ui.ignoreOwnClipboardChanges->hide();
+  ui.delayTimer->hide();
 #endif
 
   // Sound
@@ -409,6 +411,7 @@ Config::Preferences Preferences::getPreferences()
   p.trackSelectionScan = ui.enableX11SelectionTrack ->isChecked();
   p.trackClipboardScan = ui.enableClipboardTrack ->isChecked();
   p.showScanFlag= ui.showScanFlag->isChecked();
+  p.selectionChangeDelayTimer = ui.delayTimer->value();
 #endif
 
   p.storeHistory = ui.storeHistory->isChecked();

--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>787</width>
-    <height>629</height>
+    <height>730</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -618,6 +618,35 @@ in the pressed state when the word selection changes.</string>
             <property name="text">
              <string>Ignore GoldenDict's own selection and clipboard changes</string>
             </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QWidget" name="widget" native="true">
+            <layout class="QHBoxLayout" name="horizontalLayout_6">
+             <item>
+              <widget class="QLabel" name="delayTimerLabel">
+               <property name="text">
+                <string>Delay time</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="delayTimer">
+               <property name="suffix">
+                <string> ms</string>
+               </property>
+               <property name="minimum">
+                <number>0</number>
+               </property>
+               <property name="maximum">
+                <number>10000</number>
+               </property>
+               <property name="singleStep">
+                <number>50</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
          </layout>

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -285,9 +285,10 @@ ScanPopup::ScanPopup( QWidget * parent,
     translateWordFromSelection();
   });
 
-  // Use delay show to prevent multiple popups while selection in progress
+  // Use delay show to prevent popup from showing up while selection is still in progress
+  // Only certain software has this problem (e.g. Chrome)
   selectionDelayTimer.setSingleShot( true );
-  selectionDelayTimer.setInterval( 800 );
+  selectionDelayTimer.setInterval( cfg.preferences.selectionChangeDelayTimer );
 
   connect( &selectionDelayTimer, &QTimer::timeout, this, &ScanPopup::translateWordFromSelection );
 #endif
@@ -319,6 +320,9 @@ void ScanPopup::refresh() {
 
   connect( ui.groupList, &GroupComboBox::currentIndexChanged,
     this, &ScanPopup::currentGroupChanged );
+#ifdef HAVE_X11
+  selectionDelayTimer.setInterval( cfg.preferences.selectionChangeDelayTimer );
+#endif
 }
 
 


### PR DESCRIPTION
In some programs like Chrome, the selection clipboard will update even if the user has not released the mouse button.

We have received completely opposite complaints -> this value is too high / too low :sweat_smile: 

I don't know what else we can do.

fix https://github.com/xiaoyifang/goldendict-ng/issues/816
