### PR TITLE
action: drop support of AppImage

### DIFF
--- a/.github/workflows/macos-homebrew-breakpad.yml
+++ b/.github/workflows/macos-homebrew-breakpad.yml
@@ -203,7 +203,7 @@ jobs:
             Windows users can use either `****-installer.exe` (for installer) or `****.zip` (unzip and run).
             The `goldendict.exe` can be dropped into previous installation's folder (if dependencies aren't changed).
 
-            Linux users can use AppImages or Flatpak.
+            Linux users can use Flatpak or build from source.
             https://flathub.org/zh-Hans/apps/io.github.xiaoyifang.goldendict_ng
 
             macOS users can use `.dmg` installer.

--- a/.github/workflows/macos-homebrew-breakpad.yml
+++ b/.github/workflows/macos-homebrew-breakpad.yml
@@ -204,7 +204,7 @@ jobs:
             The `goldendict.exe` can be dropped into previous installation's folder (if dependencies aren't changed).
 
             Linux users can use Flatpak or build from source.
-            https://flathub.org/zh-Hans/apps/io.github.xiaoyifang.goldendict_ng
+            https://flathub.org/apps/io.github.xiaoyifang.goldendict_ng
 
             macOS users can use `.dmg` installer.
 

--- a/.github/workflows/macos-homebrew.yml
+++ b/.github/workflows/macos-homebrew.yml
@@ -206,7 +206,7 @@ jobs:
             Windows users can use either `****-installer.exe` (for installer) or `****.zip` (unzip and run).
             The `goldendict.exe` can be dropped into previous installation's folder (if dependencies aren't changed).
 
-            Linux users can use AppImages or Flatpak.
+            Linux users can use Flatpak or build from source.
             https://flathub.org/zh-Hans/apps/io.github.xiaoyifang.goldendict_ng
 
             macOS users can use `.dmg` installer.

--- a/.github/workflows/macos-homebrew.yml
+++ b/.github/workflows/macos-homebrew.yml
@@ -207,7 +207,7 @@ jobs:
             The `goldendict.exe` can be dropped into previous installation's folder (if dependencies aren't changed).
 
             Linux users can use Flatpak or build from source.
-            https://flathub.org/zh-Hans/apps/io.github.xiaoyifang.goldendict_ng
+            https://flathub.org/apps/io.github.xiaoyifang.goldendict_ng
 
             macOS users can use `.dmg` installer.
 

--- a/.github/workflows/ubuntu-6.2.yml
+++ b/.github/workflows/ubuntu-6.2.yml
@@ -185,7 +185,7 @@ jobs:
             Windows users can use either `****-installer.exe` (for installer) or `****.zip` (unzip and run).
             The `goldendict.exe` can be dropped into previous installation's folder (if dependencies aren't changed).
 
-            Linux users can use AppImages or Flatpak.
+            Linux users can use Flatpak or build from source.
             https://flathub.org/zh-Hans/apps/io.github.xiaoyifang.goldendict_ng
 
             macOS users can use `.dmg` installer.

--- a/.github/workflows/ubuntu-6.2.yml
+++ b/.github/workflows/ubuntu-6.2.yml
@@ -3,21 +3,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 on: 
-  # workflow_run:
-  #   workflows: [AutoTag]
-  #   types: [completed]
   workflow_dispatch:
-  push:
-    branches:
-      - dev
-      - master
-      # - staged
-    paths-ignore:
-      - 'docs/**'
-      # - ".github/**"
-      - "howto/**"
-      - "*.md"
-      - ".clang-format"
+  # push:
+  #   branches:
+  #     - dev
+  #     - master
+  #   paths-ignore:
+  #     - 'docs/**'
+  #     - "howto/**"
+  #     - "*.md"
+  #     - ".clang-format"
 
 jobs:
   build:

--- a/.github/workflows/ubuntu-6.2.yml
+++ b/.github/workflows/ubuntu-6.2.yml
@@ -186,7 +186,7 @@ jobs:
             The `goldendict.exe` can be dropped into previous installation's folder (if dependencies aren't changed).
 
             Linux users can use Flatpak or build from source.
-            https://flathub.org/zh-Hans/apps/io.github.xiaoyifang.goldendict_ng
+            https://flathub.org/apps/io.github.xiaoyifang.goldendict_ng
 
             macOS users can use `.dmg` installer.
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -172,7 +172,7 @@ jobs:
             Windows users can use either `****-installer.exe` (for installer) or `****.zip` (unzip and run).
             The `goldendict.exe` can be dropped into previous installation's folder (if dependencies aren't changed).
 
-            Linux users can use AppImages or Flatpak.
+            Linux users can use Flatpak or build from source.
             https://flathub.org/zh-Hans/apps/io.github.xiaoyifang.goldendict_ng
 
             macOS users can use `.dmg` installer.

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -173,7 +173,7 @@ jobs:
             The `goldendict.exe` can be dropped into previous installation's folder (if dependencies aren't changed).
 
             Linux users can use Flatpak or build from source.
-            https://flathub.org/zh-Hans/apps/io.github.xiaoyifang.goldendict_ng
+            https://flathub.org/apps/io.github.xiaoyifang.goldendict_ng
 
             macOS users can use `.dmg` installer.
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -4,21 +4,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 on: 
-  # workflow_run:
-  #   workflows: [AutoTag]
-  #   types: [completed]
   workflow_dispatch:
-  push:
-    branches:
-      - dev
-      - master
-      # - staged
-    paths-ignore:
-      - 'docs/**'
-      # - ".github/**"
-      - "howto/**"
-      - "*.md"
-      - ".clang-format"
+  # push:
+  #   branches:
+  #     - dev
+  #     - master
+  #   paths-ignore:
+  #     - 'docs/**'
+  #     - "howto/**"
+  #     - "*.md"
+  #     - ".clang-format"
 
 jobs:
   build:

--- a/.github/workflows/windows-6.x.yml
+++ b/.github/workflows/windows-6.x.yml
@@ -251,7 +251,7 @@ jobs:
             The `goldendict.exe` can be dropped into previous installation's folder (if dependencies aren't changed).
 
             Linux users can use Flatpak or build from source.
-            https://flathub.org/zh-Hans/apps/io.github.xiaoyifang.goldendict_ng
+            https://flathub.org/apps/io.github.xiaoyifang.goldendict_ng
 
             macOS users can use `.dmg` installer.
 

--- a/.github/workflows/windows-6.x.yml
+++ b/.github/workflows/windows-6.x.yml
@@ -250,7 +250,7 @@ jobs:
             Windows users can use either `****-installer.exe` (for installer) or `****.zip` (unzip and run).
             The `goldendict.exe` can be dropped into previous installation's folder (if dependencies aren't changed).
 
-            Linux users can use AppImages or Flatpak.
+            Linux users can use Flatpak or build from source.
             https://flathub.org/zh-Hans/apps/io.github.xiaoyifang.goldendict_ng
 
             macOS users can use `.dmg` installer.

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -220,7 +220,7 @@ jobs:
             Windows users can use either `****-installer.exe` (for installer) or `****.zip` (unzip and run).
             The `goldendict.exe` can be dropped into previous installation's folder (if dependencies aren't changed).
 
-            Linux users can use AppImages or Flatpak.
+            Linux users can use Flatpak or build from source.
             https://flathub.org/zh-Hans/apps/io.github.xiaoyifang.goldendict_ng
 
             macOS users can use `.dmg` installer.

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -221,7 +221,8 @@ jobs:
             The `goldendict.exe` can be dropped into previous installation's folder (if dependencies aren't changed).
 
             Linux users can use Flatpak or build from source.
-            https://flathub.org/zh-Hans/apps/io.github.xiaoyifang.goldendict_ng
+            https://flathub.org/apps/io.github.xiaoyifang.goldendict_ng
+
 
             macOS users can use `.dmg` installer.
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -223,7 +223,6 @@ jobs:
             Linux users can use Flatpak or build from source.
             https://flathub.org/apps/io.github.xiaoyifang.goldendict_ng
 
-
             macOS users can use `.dmg` installer.
 
             `6.5.1-GoldenDict.exe_windows-2019_20230701.zip` means built with Qt6.5.1, windows/msvc-2019 at 20230701 as a zip archive.

--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -21,8 +21,9 @@ If Qt's version is not changed, you can also download a single `goldendict.exe` 
 
 ## Linux
 
-* `.Appimage` can be used in any recent linux distros.
-* See the right side for available packages in various linux distros.
+<a href='https://flathub.org/apps/io.github.xiaoyifang.goldendict_ng'><img width='240' alt='Download on Flathub' src='https://dl.flathub.org/assets/badges/flathub-badge-en.svg'/></a>
+
+* See the right side for available packages in various Linux distros.
 * In Debian 12 and Ubuntu 23.04, `goldendict-webengine` is available (For later versions it is `goldendict-ng`).
 * Pre-built binary is also available from [archlinuxcn's repo](https://github.com/archlinuxcn/repo/tree/master/archlinuxcn/goldendict-ng-git).
 * [Gentoo package from PG_Overlay](https://gitlab.com/Perfect_Gentleman/PG_Overlay/-/blob/master/app-text/goldendict/goldendict-9999-r6.ebuild)


### PR DESCRIPTION
AppImage itself is still under development .

Usually it will work in some time and then failed in some other time,  it can not always guarrante the user a stable release with Qt.



Recommend users to build from source or from linux distribution's repository package.  or use flatpak package.