### PR TITLE
delete WebSiteDictionary::getResource

### DIFF
--- a/src/dict/website.cc
+++ b/src/dict/website.cc
@@ -91,7 +91,6 @@ sptr< WordSearchRequest > WebSiteDictionary::prefixMatch( const std::u32string &
 }
 
 
-
 class WebSiteArticleRequest: public WebSiteDataRequestSlots
 {
   QNetworkReply * netReply;
@@ -328,7 +327,7 @@ sandbox="allow-same-origin allow-scripts allow-popups allow-forms"></iframe>)",
 }
 
 
-sptr< DataRequest > WebSiteDictionary::getResource( const string &  /*name*/ )
+sptr< DataRequest > WebSiteDictionary::getResource( const string & /*name*/ )
 {
   return std::make_shared< DataRequestInstant >( false );
 }


### PR DESCRIPTION
This is one of the 2 odd implementations of `Dictionay::getResource`.

Big question: what does this thing even do?

The original PR that adds it don't even use it. It used a wrapper thing `DataRequestInstant` https://github.com/goldendict/goldendict/commit/ecc4203247c223b404e51163cbd7e343c12da561

We display a `iframe` for the website which sadly against modern web, but it also has nothing to do with this code.