### PR TITLE
feat: send to anki audio, style and system url handler

### DIFF
--- a/src/article_netmgr.cc
+++ b/src/article_netmgr.cc
@@ -1,11 +1,13 @@
 /* This file is (c) 2008-2012 Konstantin Isakov <ikm@goldendict.org>
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
+#include <QtNetwork/qnetworkreply.h>
+#include <stdint.h>
+#include <QUrl>
 #include "article_netmgr.hh"
 #include "globalbroadcaster.hh"
 #include "utils.hh"
 #include <QNetworkAccessManager>
-#include <QUrl>
 #include <QWebEngineUrlRequestJob>
 #include <stdint.h>
 

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -1010,61 +1010,6 @@ void ArticleView::onAllAudioResourcesReady(std::shared_ptr<QVector<GdauTagInfo>>
 }
 
 
-void findGdauTags(const QString& html)
-{
-  QRegularExpression tagRegex(R"(<(\w+)([^>]*?gdau://[^>]*?)>)");
-  QRegularExpressionMatchIterator i = tagRegex.globalMatch(html);
-
-  while (i.hasNext()) {
-    QRegularExpressionMatch match = i.next();
-    QString tagName = match.captured(1);   // e.g. "a"
-    QString fullTag = match.captured(0);   // the whole tag, e.g. <a ... >
-
-    qDebug() << "Found tag:" << tagName << "\nFull tag text:" << fullTag << "\n";
-  }
-}
-
-
-QString embedAudioBase64(QString html)
-{
-  // Regex to match gdau:// URLs in href or data-src-mp3 attributes
-
-  QRegularExpression regex(R"delim((href|data-src-mp3)="gdau://([^"]+)")delim");
-  QRegularExpressionMatchIterator i = regex.globalMatch(html);
-
-  while (i.hasNext()) {
-    QRegularExpressionMatch match = i.next();
-    QString attr = match.captured(1);    // href or data-src-mp3
-    QString resourcePath = match.captured(2); // path after gdau://
-
-    // Construct resource path according to your resource system
-    // For example, if resourcePath is "64b124f9ac24cfde2acffccb4523068c/media/english/breProns/ld41ai.mp3"
-    // you need to map this to your Qt resource or file path
-    QString qrcPath = QString(":/%1").arg(resourcePath); // Adjust this if needed
-
-    QFile file(qrcPath);
-    if (!file.open(QIODevice::ReadOnly)) {
-      qWarning() << "Failed to open resource:" << qrcPath;
-      continue;
-    }
-
-    QByteArray data = file.readAll();
-    QString base64Data = QString::fromLatin1(data.toBase64());
-
-    QString dataUrl = QString("data:audio/mpeg;base64,%1").arg(base64Data);
-
-    // Replace the old URL with data URL in html
-    // Note: Use exact match from captured text
-    QString oldUrl = QString("%1=\"gdau://%2\"").arg(attr, resourcePath);
-    QString newUrl = QString("%1=\"%2\"").arg(attr, dataUrl);
-
-    html.replace(oldUrl, newUrl);
-  }
-
-  return html;
-}
-
-
 void ArticleView::makeAnkiCardFromArticle( const QString & article_id )
 {
   const auto js_code = QString( R"EOF(document.getElementById("gdarticlefrom-%1").innerHTML)EOF" ).arg( article_id );

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -971,6 +971,11 @@ void ArticleView::onAudioRequestFinished(sptr<Dictionary::DataRequest> req, std:
   }
 }
 
+void ArticleView::replaceGdLookUpToSystemHandler(QString &originalHtml)
+{
+  originalHtml.replace("gdlookup://localhost/","goldendict://");
+}
+
 void ArticleView::onAllAudioResourcesReady(std::shared_ptr<QVector<GdauTagInfo>> ptags,QString &originalHtml) {
   //return when any tag are unfinished
   for(auto & tag:*ptags) {
@@ -999,6 +1004,7 @@ void ArticleView::onAllAudioResourcesReady(std::shared_ptr<QVector<GdauTagInfo>>
     // Replace all occurrences of gdau URL with base64 URL in your HTML string
     originalHtml.replace(tag.fullTag, newTag);
   }
+  replaceGdLookUpToSystemHandler(originalHtml);
 
   sendToAnki(webview->title(), originalHtml, translateLine->text());
 }

--- a/src/ui/articleview.hh
+++ b/src/ui/articleview.hh
@@ -76,23 +76,25 @@ class ArticleView: public QWidget
   QString delayedHighlightText;
 
 
-  struct AudioResource {
+  struct AudioResource
+  {
     QString base64Data;
     bool finished = false;
-    sptr<Dictionary::DataRequest> req;
-    std::shared_ptr<QMutex> mutex;
+    sptr< Dictionary::DataRequest > req;
+    std::shared_ptr< QMutex > mutex;
   };
 
-  struct GdauTagInfo {
+  struct GdauTagInfo
+  {
     int id;
     QString fullTag;
     QString url;
     AudioResource resource;
   };
 
-  bool race=false;
+  bool race = false;
 
-  bool resourceLocked=false;
+  bool resourceLocked = false;
 
   void highlightFTSResults();
   void performFtsFindOperation( bool backwards );
@@ -185,15 +187,21 @@ public:
 
   QString getCurrentWord();
 
-  QString replaceTags(QString &html);
+  QString replaceTags( QString & html );
 
-  void ArticleViewonAudioRequestFinished(sptr<Dictionary::DataRequest> req, QVector<AudioResource> &resources, QString url);
+  void ArticleViewonAudioRequestFinished( sptr< Dictionary::DataRequest > req,
+                                          QVector< AudioResource > & resources,
+                                          QString url );
 
-  void onAudioRequestFinished(sptr<Dictionary::DataRequest> req, std::shared_ptr<QVector<GdauTagInfo>> tags, int ,QString html);
+  void onAudioRequestFinished( sptr< Dictionary::DataRequest > req,
+                               std::shared_ptr< QVector< GdauTagInfo > > tags,
+                               int,
+                               QString html );
 
-  void onAllAudioResourcesReady(std::shared_ptr<QVector<GdauTagInfo>> tags,QString & html);
+  void onAllAudioResourcesReady( std::shared_ptr< QVector< GdauTagInfo > > tags, QString & html );
 
-  void replaceGdLookUpToSystemHandler(QString & originalHtml);
+  void replaceGdLookUpToSystemHandler( QString & originalHtml );
+
 private:
   // widgets
   ArticleWebView * webview;

--- a/src/ui/articleview.hh
+++ b/src/ui/articleview.hh
@@ -75,6 +75,25 @@ class ArticleView: public QWidget
 
   QString delayedHighlightText;
 
+
+  struct AudioResource {
+    QString base64Data;
+    bool finished = false;
+    sptr<Dictionary::DataRequest> req;
+    std::shared_ptr<QMutex> mutex;
+  };
+
+  struct GdauTagInfo {
+    int id;
+    QString fullTag;
+    QString url;
+    AudioResource resource;
+  };
+
+  bool race=false;
+
+  bool resourceLocked=false;
+
   void highlightFTSResults();
   void performFtsFindOperation( bool backwards );
 
@@ -165,6 +184,14 @@ public:
   void syncBackgroundColorWithCfgDarkReader() const;
 
   QString getCurrentWord();
+
+  QString replaceTags(QString &html);
+
+  void ArticleViewonAudioRequestFinished(sptr<Dictionary::DataRequest> req, QVector<AudioResource> &resources, QString url);
+
+  void onAudioRequestFinished(sptr<Dictionary::DataRequest> req, std::shared_ptr<QVector<GdauTagInfo>> tags, int ,QString html);
+
+  void onAllAudioResourcesReady(std::shared_ptr<QVector<GdauTagInfo>> tags,QString & html);
 
 private:
   // widgets

--- a/src/ui/articleview.hh
+++ b/src/ui/articleview.hh
@@ -193,6 +193,7 @@ public:
 
   void onAllAudioResourcesReady(std::shared_ptr<QVector<GdauTagInfo>> tags,QString & html);
 
+  void replaceGdLookUpToSystemHandler(QString & originalHtml);
 private:
   // widgets
   ArticleWebView * webview;


### PR DESCRIPTION
This PR extracts styles from the article page and encodes audio as base64, change gdlookup:// url to goldendict://.

<img width="928" height="786" alt="image" src="https://github.com/user-attachments/assets/c938b278-89f7-46db-a40f-7f29b494da5f" />

- This is my first open-source contribution. I’ve tried to follow the developer guide and C++ guidelines, but there might still be minor issues—thanks in advance for any feedback!  

- Some dictionaries with different audio systems may not work perfectly. I’ve tested popular ones like Longman 5th Edition and Oxford Learner’s. Any issues would just revert playback to the previous basic behavior, so I think it is still safe to merge and gather user feedback about different dictionaries.

- Encoding audio as base64 seems to eliminate playback latency (sometimes ~5s). This could be a useful approach for the article viewer going forward.