### PR TITLE
feat(gd-builtin.js): Add DOM attribute monitoring functionality

### DIFF
--- a/src/scripts/gd-builtin.js
+++ b/src/scripts/gd-builtin.js
@@ -325,7 +325,9 @@ function gdInitAttributeMonitoring() {
   // Automatically monitor all image src attribute changes - only for relative paths
   monitorOnlyRelativePaths("img", "src", (attr, oldVal, newVal, element) => {
     // Default image src change handling logic
-    console.log(`Image resource changed: ${element.src},old value:${oldVal}, new val:${newVal}`);
+    console.log(
+      `Image resource changed: ${element.src},old value:${oldVal}, new val:${newVal}`,
+    );
 
     // Process relative links for images
     processRelativeLink(element, newVal);


### PR DESCRIPTION
Added DOM element attribute monitoring related methods, including monitoring single element attributes, tracking image src attribute changes, monitoring link href attribute changes, and more. The new methods can monitor attribute changes of both existing elements and dynamically added elements, and provide callback handling.

New features include:
1. gdMonitorElementAttributes - Monitor specified attributes of a single element
2. gdMonitorImageSources - Monitor src attributes of all images
3. gdMonitorLinkHrefs - Monitor href attributes of all links
4. gdMonitorElementsBySelector - Monitor element attributes via CSS selectors
5. gdStopAllAttributeMonitoring - Stop all active monitoring
6. gdInitAttributeMonitoring - Initialize default monitoring

Also added usage example documentation.