### PR TITLE
fix(ui): Add quit action to dialogs

### DIFF
--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1197,6 +1197,7 @@ void MainWindow::addGlobalActionsToDialog( QDialog * dialog )
   dialog->addAction( &focusHeadwordsDlgAction );
   dialog->addAction( &focusArticleViewAction );
   dialog->addAction( ui.fullTextSearchAction );
+  dialog->addAction( ui.quit );
 }
 
 void MainWindow::addGroupComboBoxActionsToDialog( QDialog * dialog, GroupComboBox * pGroupComboBox )


### PR DESCRIPTION
Add quit action to the global actions list for dialogs to ensure users can exit the application via shortcut