### PR TITLE
feat(ui): re-apply user font settings after palette reset

### DIFF
--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -1361,6 +1361,16 @@ void MainWindow::updateAppearances( const QString & addonStyle,
     qApp->setStyle( "WindowsVista" );
     qApp->setPalette( QPalette() );
   }
+
+  // Re-apply the user-configured font after resetting the palette
+  if ( cfg.preferences.enableInterfaceFont && !cfg.preferences.interfaceFont.isEmpty() ) {
+    QFont font = QApplication::font();
+    font.setFamily( cfg.preferences.interfaceFont );
+    if ( cfg.preferences.interfaceFontSize > 0 ) {
+      font.setPixelSize( cfg.preferences.interfaceFontSize );
+    }
+    QApplication::setFont( font );
+  }
 #endif
 
 #if !defined( Q_OS_WIN )


### PR DESCRIPTION
- Added logic to restore interface font configuration
- Ensure font family and size are reapplied post palette update



fix #2564