### PR TITLE
opt: remove qtwebengine/version text in the user-agent

### DIFF
--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -3262,15 +3262,6 @@ you are browsing. If some site breaks because of this, try disabling this.</sour
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Some sites detect GoldenDict via HTTP headers and block the requests.
-Enable this option to workaround the problem.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Do not identify GoldenDict in HTTP headers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Maximum network cache size:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/article_netmgr.cc
+++ b/src/article_netmgr.cc
@@ -88,9 +88,8 @@ QNetworkReply * ArticleNetworkAccessManager::getArticleReply( const QNetworkRequ
   QNetworkRequest newReq;
   newReq.setUrl( url );
   newReq.setAttribute( QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy );
-  if ( hideGoldenDictHeader && url.scheme().startsWith( "http", Qt::CaseInsensitive ) ) {
+  if ( url.scheme().startsWith( "http", Qt::CaseInsensitive ) ) {
     QString userAgent = req.rawHeader( "User-Agent" );
-    userAgent.replace( qApp->applicationName(), "" );
     userAgent.replace( RX::qtWebEngineUserAgent, "" );
     newReq.setRawHeader( "User-Agent", userAgent.toUtf8() );
   }

--- a/src/article_netmgr.cc
+++ b/src/article_netmgr.cc
@@ -11,6 +11,7 @@
 #include <stdint.h>
 
 #include <QRegularExpression>
+#include "globalregex.hh"
 
 using std::string;
 
@@ -90,7 +91,7 @@ QNetworkReply * ArticleNetworkAccessManager::getArticleReply( const QNetworkRequ
   if ( hideGoldenDictHeader && url.scheme().startsWith( "http", Qt::CaseInsensitive ) ) {
     QString userAgent = req.rawHeader( "User-Agent" );
     userAgent.replace( qApp->applicationName(), "" );
-    userAgent.replace( QRegularExpression( "QtWebEngine/[\\d.]+\\s*" ), "" );
+    userAgent.replace( RX::qtWebEngineUserAgent, "" );
     newReq.setRawHeader( "User-Agent", userAgent.toUtf8() );
   }
 

--- a/src/article_netmgr.cc
+++ b/src/article_netmgr.cc
@@ -10,6 +10,8 @@
 #include <QWebEngineUrlRequestJob>
 #include <stdint.h>
 
+#include <QRegularExpression>
+
 using std::string;
 
 
@@ -86,7 +88,10 @@ QNetworkReply * ArticleNetworkAccessManager::getArticleReply( const QNetworkRequ
   newReq.setUrl( url );
   newReq.setAttribute( QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy );
   if ( hideGoldenDictHeader && url.scheme().startsWith( "http", Qt::CaseInsensitive ) ) {
-    newReq.setRawHeader( "User-Agent", req.rawHeader( "User-Agent" ).replace( qApp->applicationName().toUtf8(), "" ) );
+    QString userAgent = req.rawHeader( "User-Agent" );
+    userAgent.replace( qApp->applicationName(), "" );
+    userAgent.replace( QRegularExpression( "QtWebEngine/[\\d.]+\\s*" ), "" );
+    newReq.setRawHeader( "User-Agent", userAgent.toUtf8() );
   }
 
   QNetworkReply * reply = QNetworkAccessManager::createRequest( op, newReq, nullptr );

--- a/src/article_netmgr.hh
+++ b/src/article_netmgr.hh
@@ -30,7 +30,6 @@ class ArticleNetworkAccessManager: public QNetworkAccessManager
   const vector< sptr< Dictionary::Class > > & dictionaries;
   const ArticleMaker & articleMaker;
   const bool & disallowContentFromOtherSites;
-  const bool & hideGoldenDictHeader;
   QMimeDatabase db;
 
 public:
@@ -38,13 +37,11 @@ public:
   ArticleNetworkAccessManager( QObject * parent,
                                const vector< sptr< Dictionary::Class > > & dictionaries_,
                                const ArticleMaker & articleMaker_,
-                               const bool & disallowContentFromOtherSites_,
-                               const bool & hideGoldenDictHeader_ ):
+                               const bool & disallowContentFromOtherSites_ ):
     QNetworkAccessManager( parent ),
     dictionaries( dictionaries_ ),
     articleMaker( articleMaker_ ),
-    disallowContentFromOtherSites( disallowContentFromOtherSites_ ),
-    hideGoldenDictHeader( hideGoldenDictHeader_ )
+    disallowContentFromOtherSites( disallowContentFromOtherSites_ )
   {
   }
 

--- a/src/common/globalregex.cc
+++ b/src/common/globalregex.cc
@@ -74,7 +74,7 @@ QRegularExpression Mdx::styleElement( R"((<style[^>]*>)([\w\W]*?)(<\/style>))",
 
 QRegularExpression Epwing::refWord( R"([r|p](\d+)at(\d+))", QRegularExpression::CaseInsensitiveOption );
 
-const QRegularExpression RX::qtWebEngineUserAgent( R"(QtWebEngine/[\d.]+\s*)" );
+const QRegularExpression RX::qtWebEngineUserAgent( R"(QtWebEngine\/[\d.]+\s*)" );
 
 bool Html::containHtmlEntity( const std::string & text )
 {

--- a/src/common/globalregex.cc
+++ b/src/common/globalregex.cc
@@ -74,6 +74,7 @@ QRegularExpression Mdx::styleElement( R"((<style[^>]*>)([\w\W]*?)(<\/style>))",
 
 QRegularExpression Epwing::refWord( R"([r|p](\d+)at(\d+))", QRegularExpression::CaseInsensitiveOption );
 
+const QRegularExpression RX::qtWebEngineUserAgent( R"(QtWebEngine/[\d.]+\s*)" );
 
 bool Html::containHtmlEntity( const std::string & text )
 {

--- a/src/common/globalregex.hh
+++ b/src/common/globalregex.hh
@@ -76,4 +76,6 @@ const static QRegularExpression markSpace( R"([\p{M}\p{Z}])", QRegularExpression
 
 const static QRegularExpression whiteSpace( "\\s+" );
 
+extern const QRegularExpression qtWebEngineUserAgent;
+
 } // namespace RX

--- a/src/config.cc
+++ b/src/config.cc
@@ -952,7 +952,6 @@ Class load()
     }
 
 
-
     if ( !preferences.namedItem( "maxNetworkCacheSize" ).isNull() ) {
       c.preferences.maxNetworkCacheSize = preferences.namedItem( "maxNetworkCacheSize" ).toElement().text().toInt();
     }
@@ -1982,7 +1981,6 @@ void save( const Class & c )
     opt = dd.createElement( "disallowContentFromOtherSites" );
     opt.appendChild( dd.createTextNode( c.preferences.disallowContentFromOtherSites ? "1" : "0" ) );
     preferences.appendChild( opt );
-
 
 
     opt = dd.createElement( "maxNetworkCacheSize" );

--- a/src/config.cc
+++ b/src/config.cc
@@ -144,7 +144,7 @@ Preferences::Preferences():
   useInternalPlayer( InternalPlayerBackend::anyAvailable() ),
   checkForNewReleases( true ),
   disallowContentFromOtherSites( false ),
-  hideGoldenDictHeader( false ),
+
   maxNetworkCacheSize( 50 ),
   clearNetworkCacheOnExit( true ),
   zoomFactor( 1 ),
@@ -951,10 +951,7 @@ Class load()
         ( preferences.namedItem( "disallowContentFromOtherSites" ).toElement().text() == "1" );
     }
 
-    if ( !preferences.namedItem( "hideGoldenDictHeader" ).isNull() ) {
-      c.preferences.hideGoldenDictHeader =
-        ( preferences.namedItem( "hideGoldenDictHeader" ).toElement().text() == "1" );
-    }
+
 
     if ( !preferences.namedItem( "maxNetworkCacheSize" ).isNull() ) {
       c.preferences.maxNetworkCacheSize = preferences.namedItem( "maxNetworkCacheSize" ).toElement().text().toInt();
@@ -1986,9 +1983,7 @@ void save( const Class & c )
     opt.appendChild( dd.createTextNode( c.preferences.disallowContentFromOtherSites ? "1" : "0" ) );
     preferences.appendChild( opt );
 
-    opt = dd.createElement( "hideGoldenDictHeader" );
-    opt.appendChild( dd.createTextNode( c.preferences.hideGoldenDictHeader ? "1" : "0" ) );
-    preferences.appendChild( opt );
+
 
     opt = dd.createElement( "maxNetworkCacheSize" );
     opt.appendChild( dd.createTextNode( QString::number( c.preferences.maxNetworkCacheSize ) ) );

--- a/src/config.hh
+++ b/src/config.hh
@@ -344,7 +344,7 @@ struct Preferences
 
   bool checkForNewReleases;
   bool disallowContentFromOtherSites;
-  bool hideGoldenDictHeader;
+
   int maxNetworkCacheSize;
   bool clearNetworkCacheOnExit;
   bool removeInvalidIndexOnExit = false;

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -12,6 +12,7 @@
 #include "edit_dictionaries.hh"
 #include "dict/loaddictionaries.hh"
 #include "preferences.hh"
+#include "globalregex.hh"
 #include "about.hh"
 #include "mruqmenu.hh"
 #include "gestures.hh"
@@ -205,6 +206,10 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   QWebEngineProfile::defaultProfile()->setUrlRequestInterceptor( new WebUrlRequestInterceptor( this ) );
 
 
+  // Identify as GoldenDict, but avoid standard "QtWebEngine/..." identifier which some sites might block
+  QString userAgent = QWebEngineProfile::defaultProfile()->httpUserAgent();
+  userAgent.replace( RX::qtWebEngineUserAgent, "" );
+  QWebEngineProfile::defaultProfile()->setHttpUserAgent( userAgent );
 #ifdef EPWING_SUPPORT
   Epwing::initialize();
 #endif

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -158,8 +158,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   history( cfg_.preferences.maxStringsInHistory, cfg_.maxHeadwordSize ),
   dictionaryBar( this, configEvents, cfg.preferences.maxDictionaryRefsInContextMenu ),
   articleMaker( dictionaries, groupInstances, cfg.preferences ),
-  articleNetMgr(
-    this, dictionaries, articleMaker, dictionaries, articleMaker, cfg.preferences.disallowContentFromOtherSites ),
+  articleNetMgr( this, dictionaries, articleMaker, cfg.preferences.disallowContentFromOtherSites ),
   dictNetMgr( this ),
   audioPlayerFactory(
     cfg.preferences.useInternalPlayer, cfg.preferences.internalPlayerBackend, cfg.preferences.audioPlaybackProgram ),

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -157,12 +157,8 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   history( cfg_.preferences.maxStringsInHistory, cfg_.maxHeadwordSize ),
   dictionaryBar( this, configEvents, cfg.preferences.maxDictionaryRefsInContextMenu ),
   articleMaker( dictionaries, groupInstances, cfg.preferences ),
-  articleNetMgr( this,
-                 dictionaries,
-                 articleMaker,
-                 dictionaries,
-                 articleMaker,
-                 cfg.preferences.disallowContentFromOtherSites ),
+  articleNetMgr(
+    this, dictionaries, articleMaker, dictionaries, articleMaker, cfg.preferences.disallowContentFromOtherSites ),
   dictNetMgr( this ),
   audioPlayerFactory(
     cfg.preferences.useInternalPlayer, cfg.preferences.internalPlayerBackend, cfg.preferences.audioPlaybackProgram ),

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -160,8 +160,9 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   articleNetMgr( this,
                  dictionaries,
                  articleMaker,
-                 cfg.preferences.disallowContentFromOtherSites,
-                 cfg.preferences.hideGoldenDictHeader ),
+                 dictionaries,
+                 articleMaker,
+                 cfg.preferences.disallowContentFromOtherSites ),
   dictNetMgr( this ),
   audioPlayerFactory(
     cfg.preferences.useInternalPlayer, cfg.preferences.internalPlayerBackend, cfg.preferences.audioPlaybackProgram ),
@@ -207,10 +208,6 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   QWebEngineProfile::defaultProfile()->setUrlRequestInterceptor( new WebUrlRequestInterceptor( this ) );
 
-  if ( !cfg.preferences.hideGoldenDictHeader ) {
-    QWebEngineProfile::defaultProfile()->setHttpUserAgent( QWebEngineProfile::defaultProfile()->httpUserAgent()
-                                                           + " GoldenDict/WebEngine" );
-  }
 
 #ifdef EPWING_SUPPORT
   Epwing::initialize();

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -365,7 +365,7 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
 
   ui.checkForNewReleases->setChecked( p.checkForNewReleases );
   ui.disallowContentFromOtherSites->setChecked( p.disallowContentFromOtherSites );
-  ui.hideGoldenDictHeader->setChecked( p.hideGoldenDictHeader );
+
   ui.maxNetworkCacheSize->setValue( p.maxNetworkCacheSize );
   ui.clearNetworkCacheOnExit->setChecked( p.clearNetworkCacheOnExit );
 
@@ -557,7 +557,7 @@ Config::Preferences Preferences::getPreferences()
 
   p.checkForNewReleases           = ui.checkForNewReleases->isChecked();
   p.disallowContentFromOtherSites = ui.disallowContentFromOtherSites->isChecked();
-  p.hideGoldenDictHeader          = ui.hideGoldenDictHeader->isChecked();
+
   p.maxNetworkCacheSize           = ui.maxNetworkCacheSize->value();
   p.clearNetworkCacheOnExit       = ui.clearNetworkCacheOnExit->isChecked();
 

--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -1344,17 +1344,6 @@ you are browsing. If some site breaks because of this, try disabling this.</stri
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="hideGoldenDictHeader">
-         <property name="toolTip">
-          <string>Some sites detect GoldenDict via HTTP headers and block the requests.
-Enable this option to workaround the problem.</string>
-         </property>
-         <property name="text">
-          <string>Do not identify GoldenDict in HTTP headers</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <layout class="QHBoxLayout" name="horizontalLayout_11">
          <item>
           <widget class="QLabel" name="label_20">


### PR DESCRIPTION
Current user-agent in gd-ng
```
Mozilla/5.0 (Windows NT 6.2; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/6.7.2 Chrome/118.0.5993.220 Safari/537.36
```