### PR TITLE
fix(keyboardstate.cc): forgotten `Win` modifier + Qt >= 6.2 optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ if (WITH_TTS)
     list(APPEND GD_QT_COMPONENTS TextToSpeech)
 endif ()
 
-find_package(Qt6 REQUIRED COMPONENTS ${GD_QT_COMPONENTS})
+find_package(Qt6 6.2 REQUIRED COMPONENTS ${GD_QT_COMPONENTS})
 
 qt_standard_project_setup()
 set(CMAKE_AUTORCC ON) # not included in the qt_standard_project_setup

--- a/src/keyboardstate.cc
+++ b/src/keyboardstate.cc
@@ -8,8 +8,8 @@
 bool KeyboardState::checkModifiersPressed( int mask )
 {
   auto modifiers = QApplication::queryKeyboardModifiers();
-
-  return !( ( mask & Alt && !( modifiers.testFlag( Qt::AltModifier ) ) )
-            || ( mask & Ctrl && !( modifiers.testFlag( Qt::ControlModifier ) ) )
-            || ( mask & Shift && !( modifiers.testFlag( Qt::ShiftModifier ) ) ) );
+  return modifiers.testFlags( { ( mask & Alt ? Qt::AltModifier : Qt::NoModifier )
+                                | ( mask & Win ? Qt::MetaModifier : Qt::NoModifier )
+                                | ( mask & Ctrl ? Qt::ControlModifier : Qt::NoModifier )
+                                | ( mask & Shift ? Qt::ShiftModifier : Qt::NoModifier ) } );
 }


### PR DESCRIPTION
The original code didn't check for the `Win` modifier. I left the previous implementation untouched[^1] and rewrote it for Qt 6.2 and later, where the `QFlags::testFlags()` method was introduced.

[^1]: cuz it doesn't work for me, even updated 🤔