### PR TITLE
feat(headword-index): add headword index support for large dictionary…

### DIFF
--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -584,6 +584,28 @@ between classic and school orthography in cyrillic)</source>
         <source>Regular Expression</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Build Index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This dictionary has %1 headwords. Building a headword index will significantly improve browsing and search performance.
+
+Do you want to build the index now?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Building headword index...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Index Built</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Headword index has been built successfully.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DictInfo</name>

--- a/src/dict/btreeidx.cc
+++ b/src/dict/btreeidx.cc
@@ -1500,9 +1500,9 @@ std::string BtreeDictionary::getHeadwordIdxName() const
     return {};
   }
 
-  std::string ftsSuffix       = Dictionary::getFtsSuffix();
-  std::string headwordSuffix  = Dictionary::getHeadwordIdxSuffix();
-  std::string result          = ftsIdxName;
+  std::string ftsSuffix      = Dictionary::getFtsSuffix();
+  std::string headwordSuffix = Dictionary::getHeadwordIdxSuffix();
+  std::string result         = ftsIdxName;
 
   // Replace FTS suffix with headword suffix
   size_t pos = result.rfind( ftsSuffix );
@@ -1542,8 +1542,8 @@ void BtreeDictionary::makeHeadwordIndex( QAtomicInt & isCancelled )
   }
 
   // Check if we need to rebuild
-  if ( !Dictionary::needToRebuildIndex( getDictionaryFilenames(), idxName ) &&
-       HeadwordIndex::indexIsValid( idxName ) ) {
+  if ( !Dictionary::needToRebuildIndex( getDictionaryFilenames(), idxName )
+       && HeadwordIndex::indexIsValid( idxName ) ) {
     return;
   }
 

--- a/src/dict/btreeidx.cc
+++ b/src/dict/btreeidx.cc
@@ -1054,8 +1054,9 @@ static bool buildHeadwordIndex( const IndexedWords & indexedWords, const std::st
       for ( const auto & link : links ) {
         // link.word contains the original headword in UTF-8
         QString headword = QString::fromUtf8( link.word.c_str() );
-        if ( !headword.isEmpty() && addedHeadwords.insert( headword ).second ) {
+        if ( !headword.isEmpty() && !addedHeadwords.contains( headword ) ) {
           builder.addHeadword( headword );
+          addedHeadwords.insert( headword );
         }
       }
     }
@@ -1563,14 +1564,12 @@ void BtreeDictionary::makeHeadwordIndex( QAtomicInt & isCancelled )
     }
 
     // Add each headword to the index
-    // We use a simple counter as article offset since we just need unique headwords
-    uint32_t counter = 0;
     for ( const QString & headword : std::as_const( headwords ) ) {
       if ( Utils::AtomicInt::loadAcquire( isCancelled ) ) {
         builder.cancel();
         return;
       }
-      builder.addHeadword( headword, counter++ );
+      builder.addHeadword( headword );
     }
 
     if ( !builder.finish() ) {

--- a/src/dict/btreeidx.cc
+++ b/src/dict/btreeidx.cc
@@ -1055,7 +1055,7 @@ static bool buildHeadwordIndex( const IndexedWords & indexedWords, const std::st
         // link.word contains the original headword in UTF-8
         QString headword = QString::fromUtf8( link.word.c_str() );
         if ( !headword.isEmpty() && addedHeadwords.insert( headword ).second ) {
-          builder.addHeadword( headword, link.articleOffset );
+          builder.addHeadword( headword );
         }
       }
     }

--- a/src/dict/btreeidx.cc
+++ b/src/dict/btreeidx.cc
@@ -1047,23 +1047,17 @@ static bool buildHeadwordIndex( const IndexedWords & indexedWords, const std::st
   try {
     // Extract unique headwords from IndexedWords
     // IndexedWords maps folded words -> vector of WordArticleLink
-    // We need the original (unfolded) headwords
-    QSet< QString > uniqueHeadwords;
+    // Multiple links may have the same original headword, so deduplicate
+    QSet< QString > addedHeadwords;
 
     for ( const auto & [ foldedWord, links ] : indexedWords ) {
       for ( const auto & link : links ) {
         // link.word contains the original headword in UTF-8
         QString headword = QString::fromUtf8( link.word.c_str() );
-        if ( !headword.isEmpty() ) {
-          uniqueHeadwords.insert( headword );
+        if ( !headword.isEmpty() && addedHeadwords.insert( headword ).second ) {
+          builder.addHeadword( headword, link.articleOffset );
         }
       }
-    }
-
-    // Add each unique headword to the index
-    uint32_t counter = 0;
-    for ( const QString & headword : std::as_const( uniqueHeadwords ) ) {
-      builder.addHeadword( headword, counter++ );
     }
 
     if ( !builder.finish() ) {

--- a/src/dict/btreeidx.cc
+++ b/src/dict/btreeidx.cc
@@ -1028,6 +1028,59 @@ void IndexedWords::addSingleWord( const std::u32string & index_word, uint32_t ar
   operator[]( Text::toUtf8( folded ) ).emplace_back( Text::toUtf8( word ), articleOffset );
 }
 
+// Helper function to build headword index from IndexedWords
+static bool buildHeadwordIndex( const IndexedWords & indexedWords, const std::string & headwordIdxPath )
+{
+  if ( indexedWords.empty() || headwordIdxPath.empty() ) {
+    return false;
+  }
+
+  qDebug() << "Building headword index at:" << QString::fromStdString( headwordIdxPath );
+
+  HeadwordIndex::HeadwordIndexBuilder builder;
+
+  if ( !builder.start( headwordIdxPath ) ) {
+    qWarning() << "Failed to start headword index builder";
+    return false;
+  }
+
+  try {
+    // Extract unique headwords from IndexedWords
+    // IndexedWords maps folded words -> vector of WordArticleLink
+    // We need the original (unfolded) headwords
+    QSet< QString > uniqueHeadwords;
+
+    for ( const auto & [ foldedWord, links ] : indexedWords ) {
+      for ( const auto & link : links ) {
+        // link.word contains the original headword in UTF-8
+        QString headword = QString::fromUtf8( link.word.c_str() );
+        if ( !headword.isEmpty() ) {
+          uniqueHeadwords.insert( headword );
+        }
+      }
+    }
+
+    // Add each unique headword to the index
+    uint32_t counter = 0;
+    for ( const QString & headword : std::as_const( uniqueHeadwords ) ) {
+      builder.addHeadword( headword, counter++ );
+    }
+
+    if ( !builder.finish() ) {
+      qWarning() << "Failed to finish headword index";
+      return false;
+    }
+
+    qDebug() << "Headword index built successfully:" << builder.getIndexedCount() << "headwords";
+    return true;
+  }
+  catch ( std::exception & ex ) {
+    qWarning() << "Failed to build headword index:" << ex.what();
+    builder.cancel();
+    return false;
+  }
+}
+
 IndexInfo buildIndex( const IndexedWords & indexedWords, File::Index & file )
 {
   size_t indexSize = indexedWords.size();
@@ -1059,6 +1112,14 @@ IndexInfo buildIndex( const IndexedWords & indexedWords, File::Index & file )
   uint32_t lastLeafOffset = 0;
 
   uint32_t rootOffset = buildBtreeNode( nextIndex, indexSize, file, btreeMaxElements, lastLeafOffset );
+
+  // Build headword index for paginated browsing
+  // Get the index file path and derive headword index path
+  QString indexFilePath = file.file().fileName();
+  if ( !indexFilePath.isEmpty() ) {
+    std::string headwordIdxPath = indexFilePath.toStdString() + Dictionary::getHeadwordIdxSuffix();
+    buildHeadwordIndex( indexedWords, headwordIdxPath );
+  }
 
   return IndexInfo( btreeMaxElements, rootOffset );
 }
@@ -1429,5 +1490,133 @@ void BtreeDictionary::findHeadWordsWithLenth( int & index, QSet< QString > * hea
 }
 
 void BtreeDictionary::getArticleText( uint32_t, QString &, QString & ) {}
+
+std::string BtreeDictionary::getHeadwordIdxName() const
+{
+  // Derive headword index name from FTS index name
+  // ftsIdxName is like: {indexDir}/{dictId}_FTS_x
+  // headwordIdxName should be: {indexDir}/{dictId}_headword_idx
+  if ( ftsIdxName.empty() ) {
+    return {};
+  }
+
+  std::string ftsSuffix       = Dictionary::getFtsSuffix();
+  std::string headwordSuffix  = Dictionary::getHeadwordIdxSuffix();
+  std::string result          = ftsIdxName;
+
+  // Replace FTS suffix with headword suffix
+  size_t pos = result.rfind( ftsSuffix );
+  if ( pos != std::string::npos ) {
+    result.replace( pos, ftsSuffix.length(), headwordSuffix );
+  }
+  else {
+    // Fallback: just append headword suffix
+    result += headwordSuffix;
+  }
+
+  return result;
+}
+
+bool BtreeDictionary::haveHeadwordIndex() const
+{
+  std::string idxName = getHeadwordIdxName();
+  if ( idxName.empty() ) {
+    return false;
+  }
+  return HeadwordIndex::indexIsValid( idxName );
+}
+
+void BtreeDictionary::makeHeadwordIndex( QAtomicInt & isCancelled )
+{
+  QMutexLocker locker( &headwordIdxMutex );
+
+  std::string idxName = getHeadwordIdxName();
+  if ( idxName.empty() ) {
+    qWarning() << "Cannot create headword index: ftsIdxName not set";
+    return;
+  }
+
+  // Check again after acquiring lock
+  if ( HeadwordIndex::indexIsValid( idxName ) ) {
+    return;
+  }
+
+  // Check if we need to rebuild
+  if ( !Dictionary::needToRebuildIndex( getDictionaryFilenames(), idxName ) &&
+       HeadwordIndex::indexIsValid( idxName ) ) {
+    return;
+  }
+
+  qDebug() << "Building headword index for:" << QString::fromStdString( getName() );
+
+  HeadwordIndex::HeadwordIndexBuilder builder;
+
+  if ( !builder.start( idxName ) ) {
+    qWarning() << "Failed to start headword index builder";
+    return;
+  }
+
+  try {
+    // Get all article links to extract headwords
+    QSet< uint32_t > offsets;
+    QSet< QString > headwords;
+
+    findArticleLinks( nullptr, &offsets, &headwords, &isCancelled );
+
+    if ( Utils::AtomicInt::loadAcquire( isCancelled ) ) {
+      builder.cancel();
+      return;
+    }
+
+    // Add each headword to the index
+    // We use a simple counter as article offset since we just need unique headwords
+    uint32_t counter = 0;
+    for ( const QString & headword : std::as_const( headwords ) ) {
+      if ( Utils::AtomicInt::loadAcquire( isCancelled ) ) {
+        builder.cancel();
+        return;
+      }
+      builder.addHeadword( headword, counter++ );
+    }
+
+    if ( !builder.finish() ) {
+      qWarning() << "Failed to finish headword index";
+      return;
+    }
+
+    qDebug() << "Headword index built successfully:" << builder.getIndexedCount() << "headwords";
+  }
+  catch ( std::exception & ex ) {
+    qWarning() << "Failed to build headword index:" << ex.what();
+    builder.cancel();
+  }
+}
+
+HeadwordIndex::HeadwordXapianIndex * BtreeDictionary::getHeadwordIndex()
+{
+  QMutexLocker locker( &headwordIdxMutex );
+
+  if ( headwordIndex && headwordIndex->isOpen() ) {
+    return headwordIndex.get();
+  }
+
+  std::string idxName = getHeadwordIdxName();
+  if ( idxName.empty() ) {
+    return nullptr;
+  }
+
+  // Try to open existing index
+  if ( !HeadwordIndex::indexIsValid( idxName ) ) {
+    return nullptr;
+  }
+
+  headwordIndex = std::make_unique< HeadwordIndex::HeadwordXapianIndex >();
+  if ( !headwordIndex->open( idxName ) ) {
+    headwordIndex.reset();
+    return nullptr;
+  }
+
+  return headwordIndex.get();
+}
 
 } // namespace BtreeIndexing

--- a/src/dict/btreeidx.hh
+++ b/src/dict/btreeidx.hh
@@ -5,7 +5,9 @@
 
 #include "dict/dictionary.hh"
 #include "dictfile.hh"
+#include "headwordindex.hh"
 #include <map>
+#include <memory>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -196,6 +198,26 @@ public:
     return 0;
   }
 
+  /// Headword index support for paginated browsing
+  std::string headwordIndexName() const
+  {
+    return getHeadwordIdxName();
+  }
+
+  QMutex & getHeadwordIdxMutex()
+  {
+    return headwordIdxMutex;
+  }
+
+  /// Check if headword index exists and is valid
+  bool haveHeadwordIndex() const;
+
+  /// Build headword index if needed (called on-demand)
+  void makeHeadwordIndex( QAtomicInt & isCancelled );
+
+  /// Get the headword Xapian index (opens if needed)
+  HeadwordIndex::HeadwordXapianIndex * getHeadwordIndex();
+
   /// Called before each matching operation to ensure that any child init
   /// has completed. Mainly used for deferred init. The default implementation
   /// does nothing.
@@ -204,8 +226,14 @@ public:
   virtual const string & ensureInitDone();
 
 protected:
+  /// Get headword index path derived from ftsIdxName
+  std::string getHeadwordIdxName() const;
+
   QMutex ftsIdxMutex;
   string ftsIdxName;
+
+  mutable QMutex headwordIdxMutex;
+  std::unique_ptr< HeadwordIndex::HeadwordXapianIndex > headwordIndex;
 
   friend class BtreeWordSearchRequest;
   friend class FTSResultsRequest;
@@ -265,7 +293,7 @@ struct IndexedWords: public map< string, vector< WordArticleLink > >
 
 /// Builds the index, as a compressed btree. Returns IndexInfo.
 /// All the data is stored to the given file, beginning from its current
-/// position.
+/// position. Also builds headword index for paginated browsing.
 IndexInfo buildIndex( const IndexedWords &, File::Index & file );
 
 } // namespace BtreeIndexing

--- a/src/dict/dictionary.cc
+++ b/src/dict/dictionary.cc
@@ -729,6 +729,11 @@ string getFtsSuffix()
   return "_FTS_x";
 }
 
+string getHeadwordIdxSuffix()
+{
+  return "_headword_idx";
+}
+
 QString generateRandomDictionaryId()
 {
   return QCryptographicHash::hash( QUuid::createUuid().toString().toUtf8(), QCryptographicHash::Md5 ).toHex();

--- a/src/dict/dictionary.hh
+++ b/src/dict/dictionary.hh
@@ -549,6 +549,7 @@ string makeDictionaryId( const vector< string > & dictionaryFiles ) noexcept;
 bool needToRebuildIndex( const vector< string > & dictionaryFiles, const string & indexFile ) noexcept;
 
 string getFtsSuffix();
+string getHeadwordIdxSuffix();
 /// Returns a random dictionary id useful for interactively created
 /// dictionaries.
 QString generateRandomDictionaryId();

--- a/src/headwordindex.cc
+++ b/src/headwordindex.cc
@@ -19,7 +19,7 @@ static const std::string FINISH_MARKER = "hwindex_complete";
 // Term prefix for exact headword matching
 static const std::string TERM_PREFIX_EXACT = "XH";
 
-// Term prefix for folded (lowercase) headword matching  
+// Term prefix for folded (lowercase) headword matching
 static const std::string TERM_PREFIX_FOLDED = "XF";
 
 //////////////////////////////////////////////////////////////////////////////
@@ -160,9 +160,8 @@ PagedResult HeadwordXapianIndex::searchPrefix( const QString & prefix, int offse
 
   try {
     // Fold the prefix for case-insensitive matching
-    std::u32string folded = Folding::applySimpleCaseOnly( prefix.toStdU32String() );
-    std::string foldedUtf8 =
-      QString::fromStdU32String( folded ).toUtf8().toStdString();
+    std::u32string folded  = Folding::applySimpleCaseOnly( prefix.toStdU32String() );
+    std::string foldedUtf8 = QString::fromStdU32String( folded ).toUtf8().toStdString();
 
     // Create prefix query using the folded term prefix
     Xapian::Query query( Xapian::Query::OP_WILDCARD,
@@ -216,9 +215,8 @@ PagedResult HeadwordXapianIndex::searchWildcard( const QString & pattern, int of
     qp.add_prefix( "", TERM_PREFIX_FOLDED );
 
     // Fold the pattern
-    std::u32string folded = Folding::applySimpleCaseOnly( pattern.toStdU32String() );
-    std::string patternUtf8 =
-      QString::fromStdU32String( folded ).toUtf8().toStdString();
+    std::u32string folded   = Folding::applySimpleCaseOnly( pattern.toStdU32String() );
+    std::string patternUtf8 = QString::fromStdU32String( folded ).toUtf8().toStdString();
 
     int flags = Xapian::QueryParser::FLAG_WILDCARD | Xapian::QueryParser::FLAG_CJK_NGRAM;
 
@@ -265,12 +263,11 @@ QStringList HeadwordXapianIndex::suggestSpelling( const QString & term, int maxS
   }
 
   try {
-    std::u32string folded = Folding::applySimpleCaseOnly( term.toStdU32String() );
-    std::string foldedUtf8 =
-      QString::fromStdU32String( folded ).toUtf8().toStdString();
+    std::u32string folded  = Folding::applySimpleCaseOnly( term.toStdU32String() );
+    std::string foldedUtf8 = QString::fromStdU32String( folded ).toUtf8().toStdString();
 
     // Get spelling suggestions
-    Xapian::TermIterator it = d->db->spellings_begin();
+    Xapian::TermIterator it  = d->db->spellings_begin();
     Xapian::TermIterator end = d->db->spellings_end();
 
     // Simple approach: find terms that start similarly
@@ -278,8 +275,8 @@ QStringList HeadwordXapianIndex::suggestSpelling( const QString & term, int maxS
     for ( ; it != end && suggestions.size() < maxSuggestions; ++it ) {
       std::string suggestion = *it;
       // Basic similarity check - shares common prefix
-      if ( suggestion.substr( 0, std::min( suggestion.size(), foldedUtf8.size() / 2 + 1 ) ) ==
-           foldedUtf8.substr( 0, std::min( suggestion.size(), foldedUtf8.size() / 2 + 1 ) ) ) {
+      if ( suggestion.substr( 0, std::min( suggestion.size(), foldedUtf8.size() / 2 + 1 ) )
+           == foldedUtf8.substr( 0, std::min( suggestion.size(), foldedUtf8.size() / 2 + 1 ) ) ) {
         suggestions.append( QString::fromUtf8( suggestion.c_str() ) );
       }
     }
@@ -356,9 +353,8 @@ void HeadwordIndexBuilder::addHeadword( const QString & headword, uint32_t artic
     doc.add_term( TERM_PREFIX_EXACT + headwordUtf8 );
 
     // Add folded term for case-insensitive search
-    std::u32string folded = Folding::applySimpleCaseOnly( headword.toStdU32String() );
-    std::string foldedUtf8 =
-      QString::fromStdU32String( folded ).toUtf8().toStdString();
+    std::u32string folded  = Folding::applySimpleCaseOnly( headword.toStdU32String() );
+    std::string foldedUtf8 = QString::fromStdU32String( folded ).toUtf8().toStdString();
     doc.add_term( TERM_PREFIX_FOLDED + foldedUtf8 );
 
     // Index the headword text for full-text search within headwords

--- a/src/headwordindex.cc
+++ b/src/headwordindex.cc
@@ -82,17 +82,16 @@ bool HeadwordXapianIndex::isOpen() const
   return d->db != nullptr;
 }
 
-int HeadwordXapianIndex::getTotalCount() const
+// Internal helper without mutex (assumes caller holds lock)
+static int getTotalCountUnlocked( const std::unique_ptr< Xapian::Database > & db )
 {
-  QMutexLocker locker( &mutex );
-
-  if ( !d->db ) {
+  if ( !db ) {
     return 0;
   }
 
   try {
     // Subtract 1 for the marker document
-    return static_cast< int >( d->db->get_doccount() ) - 1;
+    return static_cast< int >( db->get_doccount() ) - 1;
   }
   catch ( const Xapian::Error & e ) {
     qWarning() << "Failed to get document count:" << e.get_description().c_str();
@@ -113,7 +112,7 @@ PagedResult HeadwordXapianIndex::getPage( int offset, int limit ) const
   }
 
   try {
-    result.totalCount = getTotalCount();
+    result.totalCount = getTotalCountUnlocked( d->db );
 
     // Use Enquire with MatchAll to iterate in docid order
     Xapian::Enquire enquire( *d->db );

--- a/src/headwordindex.cc
+++ b/src/headwordindex.cc
@@ -82,23 +82,6 @@ bool HeadwordXapianIndex::isOpen() const
   return d->db != nullptr;
 }
 
-// Internal helper without mutex (assumes caller holds lock)
-static int getTotalCountUnlocked( const std::unique_ptr< Xapian::Database > & db )
-{
-  if ( !db ) {
-    return 0;
-  }
-
-  try {
-    // Subtract 1 for the marker document
-    return static_cast< int >( db->get_doccount() ) - 1;
-  }
-  catch ( const Xapian::Error & e ) {
-    qWarning() << "Failed to get document count:" << e.get_description().c_str();
-    return 0;
-  }
-}
-
 PagedResult HeadwordXapianIndex::getPage( int offset, int limit ) const
 {
   PagedResult result;
@@ -112,8 +95,6 @@ PagedResult HeadwordXapianIndex::getPage( int offset, int limit ) const
   }
 
   try {
-    result.totalCount = getTotalCountUnlocked( d->db );
-
     // Use Enquire with MatchAll to iterate in docid order
     Xapian::Enquire enquire( *d->db );
     enquire.set_query( Xapian::Query::MatchAll );
@@ -122,6 +103,8 @@ PagedResult HeadwordXapianIndex::getPage( int offset, int limit ) const
     // Get results with offset
     Xapian::MSet mset = enquire.get_mset( offset, limit + 1 ); // +1 to check hasMore
 
+    // Total count is the estimated matches for MatchAll
+    result.totalCount = mset.get_matches_estimated();
     int count = 0;
     for ( Xapian::MSetIterator it = mset.begin(); it != mset.end() && count < limit; ++it, ++count ) {
       std::string data = it.get_document().get_data();

--- a/src/headwordindex.cc
+++ b/src/headwordindex.cc
@@ -105,7 +105,7 @@ PagedResult HeadwordXapianIndex::getPage( int offset, int limit ) const
 
     // Total count is the estimated matches for MatchAll
     result.totalCount = mset.get_matches_estimated();
-    int count = 0;
+    int count         = 0;
     for ( Xapian::MSetIterator it = mset.begin(); it != mset.end() && count < limit; ++it, ++count ) {
       std::string data = it.get_document().get_data();
       if ( data != FINISH_MARKER ) {

--- a/src/headwordindex.cc
+++ b/src/headwordindex.cc
@@ -1,0 +1,466 @@
+/* This file is part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
+
+// xapian.h must be first to avoid macro collisions
+#include "xapian.h"
+
+#include "headwordindex.hh"
+#include "folding.hh"
+#include "utils.hh"
+
+#include <QFile>
+#include <QDir>
+#include <QDebug>
+
+namespace HeadwordIndex {
+
+// Marker to identify a valid, completed index
+static const std::string FINISH_MARKER = "hwindex_complete";
+
+// Term prefix for exact headword matching
+static const std::string TERM_PREFIX_EXACT = "XH";
+
+// Term prefix for folded (lowercase) headword matching  
+static const std::string TERM_PREFIX_FOLDED = "XF";
+
+//////////////////////////////////////////////////////////////////////////////
+// HeadwordXapianIndex::Private
+//////////////////////////////////////////////////////////////////////////////
+
+class HeadwordXapianIndex::Private
+{
+public:
+  std::unique_ptr< Xapian::Database > db;
+
+  Private() = default;
+};
+
+//////////////////////////////////////////////////////////////////////////////
+// HeadwordXapianIndex implementation
+//////////////////////////////////////////////////////////////////////////////
+
+HeadwordXapianIndex::HeadwordXapianIndex():
+  d( std::make_unique< Private >() )
+{
+}
+
+HeadwordXapianIndex::~HeadwordXapianIndex()
+{
+  close();
+}
+
+bool HeadwordXapianIndex::open( const std::string & path )
+{
+  QMutexLocker locker( &mutex );
+
+  close();
+
+  try {
+    const QByteArray encodedPath = QFile::encodeName( QString::fromStdString( path ) );
+    d->db                        = std::make_unique< Xapian::Database >( encodedPath.toStdString() );
+    indexPath                    = path;
+    return true;
+  }
+  catch ( const Xapian::Error & e ) {
+    qWarning() << "Failed to open headword index:" << e.get_description().c_str();
+    return false;
+  }
+}
+
+void HeadwordXapianIndex::close()
+{
+  QMutexLocker locker( &mutex );
+
+  if ( d->db ) {
+    d->db.reset();
+  }
+  indexPath.clear();
+}
+
+bool HeadwordXapianIndex::isOpen() const
+{
+  QMutexLocker locker( &mutex );
+  return d->db != nullptr;
+}
+
+int HeadwordXapianIndex::getTotalCount() const
+{
+  QMutexLocker locker( &mutex );
+
+  if ( !d->db ) {
+    return 0;
+  }
+
+  try {
+    // Subtract 1 for the marker document
+    return static_cast< int >( d->db->get_doccount() ) - 1;
+  }
+  catch ( const Xapian::Error & e ) {
+    qWarning() << "Failed to get document count:" << e.get_description().c_str();
+    return 0;
+  }
+}
+
+PagedResult HeadwordXapianIndex::getPage( int offset, int limit ) const
+{
+  PagedResult result;
+  result.totalCount = 0;
+  result.hasMore    = false;
+
+  QMutexLocker locker( &mutex );
+
+  if ( !d->db ) {
+    return result;
+  }
+
+  try {
+    result.totalCount = getTotalCount();
+
+    // Use Enquire with MatchAll to iterate in docid order
+    Xapian::Enquire enquire( *d->db );
+    enquire.set_query( Xapian::Query::MatchAll );
+    enquire.set_weighting_scheme( Xapian::BoolWeight() );
+
+    // Get results with offset
+    Xapian::MSet mset = enquire.get_mset( offset, limit + 1 ); // +1 to check hasMore
+
+    int count = 0;
+    for ( Xapian::MSetIterator it = mset.begin(); it != mset.end() && count < limit; ++it, ++count ) {
+      std::string data = it.get_document().get_data();
+      // Skip the finish marker
+      if ( data == FINISH_MARKER ) {
+        continue;
+      }
+      // Data format: "headword\tarticleOffset"
+      size_t tabPos = data.find( '\t' );
+      if ( tabPos != std::string::npos ) {
+        result.headwords.append( QString::fromUtf8( data.c_str(), tabPos ) );
+      }
+    }
+
+    result.hasMore = ( mset.size() > static_cast< Xapian::doccount >( limit ) );
+  }
+  catch ( const Xapian::Error & e ) {
+    qWarning() << "Failed to get page:" << e.get_description().c_str();
+  }
+
+  return result;
+}
+
+PagedResult HeadwordXapianIndex::searchPrefix( const QString & prefix, int offset, int limit ) const
+{
+  PagedResult result;
+  result.totalCount = 0;
+  result.hasMore    = false;
+
+  QMutexLocker locker( &mutex );
+
+  if ( !d->db || prefix.isEmpty() ) {
+    return result;
+  }
+
+  try {
+    // Fold the prefix for case-insensitive matching
+    std::u32string folded = Folding::applySimpleCaseOnly( prefix.toStdU32String() );
+    std::string foldedUtf8 =
+      QString::fromStdU32String( folded ).toUtf8().toStdString();
+
+    // Create prefix query using the folded term prefix
+    Xapian::Query query( Xapian::Query::OP_WILDCARD,
+                         TERM_PREFIX_FOLDED + foldedUtf8,
+                         0, // max expansion (0 = unlimited)
+                         Xapian::Query::WILDCARD_LIMIT_MOST_FREQUENT );
+
+    Xapian::Enquire enquire( *d->db );
+    enquire.set_query( query );
+
+    Xapian::MSet mset = enquire.get_mset( offset, limit + 1 );
+
+    result.totalCount = mset.get_matches_estimated();
+
+    int count = 0;
+    for ( Xapian::MSetIterator it = mset.begin(); it != mset.end() && count < limit; ++it, ++count ) {
+      std::string data = it.get_document().get_data();
+      if ( data == FINISH_MARKER ) {
+        continue;
+      }
+      size_t tabPos = data.find( '\t' );
+      if ( tabPos != std::string::npos ) {
+        result.headwords.append( QString::fromUtf8( data.c_str(), tabPos ) );
+      }
+    }
+
+    result.hasMore = ( mset.size() > static_cast< Xapian::doccount >( limit ) );
+  }
+  catch ( const Xapian::Error & e ) {
+    qWarning() << "Failed to search prefix:" << e.get_description().c_str();
+  }
+
+  return result;
+}
+
+PagedResult HeadwordXapianIndex::searchWildcard( const QString & pattern, int offset, int limit ) const
+{
+  PagedResult result;
+  result.totalCount = 0;
+  result.hasMore    = false;
+
+  QMutexLocker locker( &mutex );
+
+  if ( !d->db || pattern.isEmpty() ) {
+    return result;
+  }
+
+  try {
+    Xapian::QueryParser qp;
+    qp.set_database( *d->db );
+    qp.add_prefix( "", TERM_PREFIX_FOLDED );
+
+    // Fold the pattern
+    std::u32string folded = Folding::applySimpleCaseOnly( pattern.toStdU32String() );
+    std::string patternUtf8 =
+      QString::fromStdU32String( folded ).toUtf8().toStdString();
+
+    int flags = Xapian::QueryParser::FLAG_WILDCARD | Xapian::QueryParser::FLAG_CJK_NGRAM;
+
+    Xapian::Query query = qp.parse_query( patternUtf8, flags );
+
+    qDebug() << "Headword wildcard query:" << query.get_description().c_str();
+
+    Xapian::Enquire enquire( *d->db );
+    enquire.set_query( query );
+
+    Xapian::MSet mset = enquire.get_mset( offset, limit + 1 );
+
+    result.totalCount = mset.get_matches_estimated();
+
+    int count = 0;
+    for ( Xapian::MSetIterator it = mset.begin(); it != mset.end() && count < limit; ++it, ++count ) {
+      std::string data = it.get_document().get_data();
+      if ( data == FINISH_MARKER ) {
+        continue;
+      }
+      size_t tabPos = data.find( '\t' );
+      if ( tabPos != std::string::npos ) {
+        result.headwords.append( QString::fromUtf8( data.c_str(), tabPos ) );
+      }
+    }
+
+    result.hasMore = ( mset.size() > static_cast< Xapian::doccount >( limit ) );
+  }
+  catch ( const Xapian::Error & e ) {
+    qWarning() << "Failed to search wildcard:" << e.get_description().c_str();
+  }
+
+  return result;
+}
+
+QStringList HeadwordXapianIndex::suggestSpelling( const QString & term, int maxSuggestions ) const
+{
+  QStringList suggestions;
+
+  QMutexLocker locker( &mutex );
+
+  if ( !d->db || term.isEmpty() ) {
+    return suggestions;
+  }
+
+  try {
+    std::u32string folded = Folding::applySimpleCaseOnly( term.toStdU32String() );
+    std::string foldedUtf8 =
+      QString::fromStdU32String( folded ).toUtf8().toStdString();
+
+    // Get spelling suggestions
+    Xapian::TermIterator it = d->db->spellings_begin();
+    Xapian::TermIterator end = d->db->spellings_end();
+
+    // Simple approach: find terms that start similarly
+    // For better fuzzy matching, we'd need edit distance calculation
+    for ( ; it != end && suggestions.size() < maxSuggestions; ++it ) {
+      std::string suggestion = *it;
+      // Basic similarity check - shares common prefix
+      if ( suggestion.substr( 0, std::min( suggestion.size(), foldedUtf8.size() / 2 + 1 ) ) ==
+           foldedUtf8.substr( 0, std::min( suggestion.size(), foldedUtf8.size() / 2 + 1 ) ) ) {
+        suggestions.append( QString::fromUtf8( suggestion.c_str() ) );
+      }
+    }
+  }
+  catch ( const Xapian::Error & e ) {
+    qWarning() << "Failed to get spelling suggestions:" << e.get_description().c_str();
+  }
+
+  return suggestions;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// HeadwordIndexBuilder::Private
+//////////////////////////////////////////////////////////////////////////////
+
+class HeadwordIndexBuilder::Private
+{
+public:
+  std::unique_ptr< Xapian::WritableDatabase > db;
+  Xapian::TermGenerator indexer;
+
+  Private() = default;
+};
+
+//////////////////////////////////////////////////////////////////////////////
+// HeadwordIndexBuilder implementation
+//////////////////////////////////////////////////////////////////////////////
+
+HeadwordIndexBuilder::HeadwordIndexBuilder():
+  d( std::make_unique< Private >() ),
+  indexedCount( 0 )
+{
+}
+
+HeadwordIndexBuilder::~HeadwordIndexBuilder()
+{
+  cancel();
+}
+
+bool HeadwordIndexBuilder::start( const std::string & path )
+{
+  try {
+    indexPath    = path + "_temp";
+    indexedCount = 0;
+
+    const QByteArray encodedPath = QFile::encodeName( QString::fromStdString( indexPath ) );
+    d->db = std::make_unique< Xapian::WritableDatabase >( encodedPath.toStdString(), Xapian::DB_CREATE_OR_OVERWRITE );
+
+    d->indexer.set_flags( Xapian::TermGenerator::FLAG_CJK_NGRAM );
+
+    return true;
+  }
+  catch ( const Xapian::Error & e ) {
+    qWarning() << "Failed to start headword index:" << e.get_description().c_str();
+    return false;
+  }
+}
+
+void HeadwordIndexBuilder::addHeadword( const QString & headword, uint32_t articleOffset )
+{
+  if ( !d->db ) {
+    return;
+  }
+
+  try {
+    Xapian::Document doc;
+
+    // Store original headword and article offset as document data
+    std::string data = headword.toUtf8().toStdString() + "\t" + std::to_string( articleOffset );
+    doc.set_data( data );
+
+    // Add exact term (original case)
+    std::string headwordUtf8 = headword.toUtf8().toStdString();
+    doc.add_term( TERM_PREFIX_EXACT + headwordUtf8 );
+
+    // Add folded term for case-insensitive search
+    std::u32string folded = Folding::applySimpleCaseOnly( headword.toStdU32String() );
+    std::string foldedUtf8 =
+      QString::fromStdU32String( folded ).toUtf8().toStdString();
+    doc.add_term( TERM_PREFIX_FOLDED + foldedUtf8 );
+
+    // Index the headword text for full-text search within headwords
+    d->indexer.set_document( doc );
+    d->indexer.index_text( headwordUtf8 );
+
+    // Add to spelling dictionary for fuzzy suggestions
+    d->db->add_spelling( foldedUtf8 );
+
+    d->db->add_document( doc );
+    indexedCount++;
+  }
+  catch ( const Xapian::Error & e ) {
+    qWarning() << "Failed to add headword:" << e.get_description().c_str();
+  }
+}
+
+bool HeadwordIndexBuilder::finish()
+{
+  if ( !d->db ) {
+    return false;
+  }
+
+  try {
+    // Add marker document to indicate completion
+    Xapian::Document markerDoc;
+    markerDoc.set_data( FINISH_MARKER );
+    d->db->add_document( markerDoc );
+
+    d->db->commit();
+
+    // Compact to final location
+    std::string finalPath = indexPath;
+    // Remove "_temp" suffix
+    if ( finalPath.size() > 5 && finalPath.substr( finalPath.size() - 5 ) == "_temp" ) {
+      finalPath = finalPath.substr( 0, finalPath.size() - 5 );
+    }
+
+    const QByteArray encodedFinalPath = QFile::encodeName( QString::fromStdString( finalPath ) );
+    d->db->compact( encodedFinalPath.toStdString() );
+
+    d->db->close();
+    d->db.reset();
+
+    // Remove temp directory
+    Utils::Fs::removeDirectory( indexPath );
+
+    return true;
+  }
+  catch ( const Xapian::Error & e ) {
+    qWarning() << "Failed to finish headword index:" << e.get_description().c_str();
+    cancel();
+    return false;
+  }
+}
+
+void HeadwordIndexBuilder::cancel()
+{
+  if ( d->db ) {
+    try {
+      d->db->close();
+    }
+    catch ( ... ) {
+    }
+    d->db.reset();
+  }
+
+  if ( !indexPath.empty() ) {
+    Utils::Fs::removeDirectory( indexPath );
+    indexPath.clear();
+  }
+
+  indexedCount = 0;
+}
+
+int HeadwordIndexBuilder::getIndexedCount() const
+{
+  return indexedCount;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Helper functions
+//////////////////////////////////////////////////////////////////////////////
+
+bool indexIsValid( const std::string & indexPath )
+{
+  try {
+    const QByteArray encodedPath = QFile::encodeName( QString::fromStdString( indexPath ) );
+    Xapian::Database db( encodedPath.toStdString() );
+
+    auto docid    = db.get_lastdocid();
+    auto document = db.get_document( docid );
+
+    return document.get_data() == FINISH_MARKER;
+  }
+  catch ( const Xapian::Error & e ) {
+    qWarning() << "Headword index validation failed:" << e.get_description().c_str();
+    return false;
+  }
+  catch ( ... ) {
+    return false;
+  }
+}
+
+} // namespace HeadwordIndex

--- a/src/headwordindex.cc
+++ b/src/headwordindex.cc
@@ -126,14 +126,8 @@ PagedResult HeadwordXapianIndex::getPage( int offset, int limit ) const
     int count = 0;
     for ( Xapian::MSetIterator it = mset.begin(); it != mset.end() && count < limit; ++it, ++count ) {
       std::string data = it.get_document().get_data();
-      // Skip the finish marker
-      if ( data == FINISH_MARKER ) {
-        continue;
-      }
-      // Data format: "headword\tarticleOffset"
-      size_t tabPos = data.find( '\t' );
-      if ( tabPos != std::string::npos ) {
-        result.headwords.append( QString::fromUtf8( data.c_str(), tabPos ) );
+      if ( data != FINISH_MARKER ) {
+        result.headwords.append( QString::fromUtf8( data.c_str() ) );
       }
     }
 
@@ -179,12 +173,8 @@ PagedResult HeadwordXapianIndex::searchPrefix( const QString & prefix, int offse
     int count = 0;
     for ( Xapian::MSetIterator it = mset.begin(); it != mset.end() && count < limit; ++it, ++count ) {
       std::string data = it.get_document().get_data();
-      if ( data == FINISH_MARKER ) {
-        continue;
-      }
-      size_t tabPos = data.find( '\t' );
-      if ( tabPos != std::string::npos ) {
-        result.headwords.append( QString::fromUtf8( data.c_str(), tabPos ) );
+      if ( data != FINISH_MARKER ) {
+        result.headwords.append( QString::fromUtf8( data.c_str() ) );
       }
     }
 
@@ -234,12 +224,8 @@ PagedResult HeadwordXapianIndex::searchWildcard( const QString & pattern, int of
     int count = 0;
     for ( Xapian::MSetIterator it = mset.begin(); it != mset.end() && count < limit; ++it, ++count ) {
       std::string data = it.get_document().get_data();
-      if ( data == FINISH_MARKER ) {
-        continue;
-      }
-      size_t tabPos = data.find( '\t' );
-      if ( tabPos != std::string::npos ) {
-        result.headwords.append( QString::fromUtf8( data.c_str(), tabPos ) );
+      if ( data != FINISH_MARKER ) {
+        result.headwords.append( QString::fromUtf8( data.c_str() ) );
       }
     }
 
@@ -335,7 +321,7 @@ bool HeadwordIndexBuilder::start( const std::string & path )
   }
 }
 
-void HeadwordIndexBuilder::addHeadword( const QString & headword, uint32_t articleOffset )
+void HeadwordIndexBuilder::addHeadword( const QString & headword )
 {
   if ( !d->db ) {
     return;
@@ -344,9 +330,8 @@ void HeadwordIndexBuilder::addHeadword( const QString & headword, uint32_t artic
   try {
     Xapian::Document doc;
 
-    // Store original headword and article offset as document data
-    std::string data = headword.toUtf8().toStdString() + "\t" + std::to_string( articleOffset );
-    doc.set_data( data );
+    // Store original headword as document data
+    doc.set_data( headword.toUtf8().toStdString() );
 
     // Add exact term (original case)
     std::string headwordUtf8 = headword.toUtf8().toStdString();

--- a/src/headwordindex.hh
+++ b/src/headwordindex.hh
@@ -41,9 +41,6 @@ public:
   /// Check if index is open and valid
   bool isOpen() const;
 
-  /// Get total headword count in the index
-  int getTotalCount() const;
-
   /// Get a page of headwords (sorted by document ID, which preserves insertion order)
   /// @param offset Starting position (0-based)
   /// @param limit Maximum number of results to return

--- a/src/headwordindex.hh
+++ b/src/headwordindex.hh
@@ -97,8 +97,7 @@ public:
 
   /// Add a headword to the index
   /// @param headword The headword to add
-  /// @param articleOffset Associated article offset (stored as document data)
-  void addHeadword( const QString & headword, uint32_t articleOffset );
+  void addHeadword( const QString & headword );
 
   /// Finish building and compact the index
   /// @return true if finalization successful

--- a/src/headwordindex.hh
+++ b/src/headwordindex.hh
@@ -1,0 +1,123 @@
+/* This file is part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
+
+#pragma once
+
+#include <QString>
+#include <QStringList>
+#include <QMutex>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace HeadwordIndex {
+
+/// Result structure for paginated headword queries
+struct PagedResult
+{
+  QStringList headwords;
+  int totalCount;       // Total matching count (estimated for searches)
+  bool hasMore;         // Whether there are more results available
+};
+
+/// A Xapian-based index for efficient paginated headword retrieval and search.
+/// This index is separate from the FTS index and optimized for:
+/// - Fast paginated browsing (offset-based pagination)
+/// - Prefix search with pagination
+/// - Fuzzy search via spelling suggestions
+class HeadwordXapianIndex
+{
+public:
+  HeadwordXapianIndex();
+  ~HeadwordXapianIndex();
+
+  /// Open an existing index for reading
+  /// @param indexPath Path to the Xapian database directory
+  /// @return true if opened successfully
+  bool open( const std::string & indexPath );
+
+  /// Close the index
+  void close();
+
+  /// Check if index is open and valid
+  bool isOpen() const;
+
+  /// Get total headword count in the index
+  int getTotalCount() const;
+
+  /// Get a page of headwords (sorted by document ID, which preserves insertion order)
+  /// @param offset Starting position (0-based)
+  /// @param limit Maximum number of results to return
+  /// @return PagedResult containing headwords and metadata
+  PagedResult getPage( int offset, int limit ) const;
+
+  /// Search headwords with prefix matching
+  /// @param prefix The prefix to search for (will be folded to lowercase)
+  /// @param offset Starting position within search results
+  /// @param limit Maximum number of results
+  /// @return PagedResult containing matching headwords
+  PagedResult searchPrefix( const QString & prefix, int offset, int limit ) const;
+
+  /// Search headwords with wildcard pattern (e.g., "test*")
+  /// @param pattern Wildcard pattern (supports * at end for prefix matching)
+  /// @param offset Starting position within search results
+  /// @param limit Maximum number of results
+  /// @return PagedResult containing matching headwords
+  PagedResult searchWildcard( const QString & pattern, int offset, int limit ) const;
+
+  /// Get spelling suggestions for a term (fuzzy search)
+  /// @param term The term to get suggestions for
+  /// @param maxSuggestions Maximum number of suggestions
+  /// @return List of suggested terms
+  QStringList suggestSpelling( const QString & term, int maxSuggestions = 5 ) const;
+
+  /// Get the index file path
+  const std::string & getIndexPath() const
+  {
+    return indexPath;
+  }
+
+private:
+  class Private;
+  std::unique_ptr< Private > d;
+  std::string indexPath;
+  mutable QMutex mutex;
+};
+
+/// Builder class for creating headword indexes
+class HeadwordIndexBuilder
+{
+public:
+  HeadwordIndexBuilder();
+  ~HeadwordIndexBuilder();
+
+  /// Start building a new index
+  /// @param indexPath Path where the index will be created
+  /// @return true if initialization successful
+  bool start( const std::string & indexPath );
+
+  /// Add a headword to the index
+  /// @param headword The headword to add
+  /// @param articleOffset Associated article offset (stored as document data)
+  void addHeadword( const QString & headword, uint32_t articleOffset );
+
+  /// Finish building and compact the index
+  /// @return true if finalization successful
+  bool finish();
+
+  /// Cancel building and clean up
+  void cancel();
+
+  /// Get current number of indexed headwords
+  int getIndexedCount() const;
+
+private:
+  class Private;
+  std::unique_ptr< Private > d;
+  std::string indexPath;
+  int indexedCount;
+};
+
+/// Check if headword index exists and is valid
+bool indexIsValid( const std::string & indexPath );
+
+} // namespace HeadwordIndex

--- a/src/headwordindex.hh
+++ b/src/headwordindex.hh
@@ -15,8 +15,8 @@ namespace HeadwordIndex {
 struct PagedResult
 {
   QStringList headwords;
-  int totalCount;       // Total matching count (estimated for searches)
-  bool hasMore;         // Whether there are more results available
+  int totalCount; // Total matching count (estimated for searches)
+  bool hasMore;   // Whether there are more results available
 };
 
 /// A Xapian-based index for efficient paginated headword retrieval and search.

--- a/src/headwordsmodel.cc
+++ b/src/headwordsmodel.cc
@@ -309,8 +309,8 @@ void HeadwordListModel::setDict( Dictionary::Class * dict )
 
   // Notify if index is recommended for large dictionaries
   if ( !useIndex && isLargeDictionary() ) {
-    qDebug() << "Headword index recommended for" << QString::fromStdString( dict->getName() )
-             << "(" << totalSize << "headwords)";
+    qDebug() << "Headword index recommended for" << QString::fromStdString( dict->getName() ) << "(" << totalSize
+             << "headwords)";
     emit indexBuildRecommended();
   }
 }

--- a/src/headwordsmodel.cc
+++ b/src/headwordsmodel.cc
@@ -368,7 +368,7 @@ void HeadwordListModel::buildHeadwordIndex( bool autoBuild )
   qDebug() << "Building headword index for" << QString::fromStdString( _dict->getName() )
            << ( autoBuild ? "(auto)" : "(manual)" );
 
-  QtConcurrent::run( [ this, btreeDict ]() {
+  QThreadPool::globalInstance()->start( [ this, btreeDict ]() {
     btreeDict->makeHeadwordIndex( indexBuildCancelled );
 
     bool success = false;

--- a/src/headwordsmodel.cc
+++ b/src/headwordsmodel.cc
@@ -1,12 +1,21 @@
 #include "headwordsmodel.hh"
+#include "btreeidx.hh"
+#include "utils.hh"
+#include "text.hh"
+#include <QtConcurrent>
 
 HeadwordListModel::HeadwordListModel( QObject * parent ):
   QAbstractListModel( parent ),
   filtering( false ),
   totalSize( 0 ),
+  maxFilterResults( 1000 ),
   finished( false ),
+  _dict( nullptr ),
   index( 0 ),
-  ptr( nullptr )
+  ptr( nullptr ),
+  currentOffset( 0 ),
+  useIndex( false ),
+  indexBuilding( false )
 {
 }
 
@@ -37,20 +46,26 @@ QString HeadwordListModel::getRow( int row )
 
 void HeadwordListModel::setFilter( const QRegularExpression & reg )
 {
-  //if the headword is already finished loaded, do nothing。
+  // If headword index is available, use it for searching
+  if ( useIndex && !reg.pattern().isEmpty() ) {
+    searchPrefix( reg.pattern(), 0, maxFilterResults );
+    return;
+  }
+
+  // If the headword is already finished loaded, do nothing
   if ( finished ) {
     return;
   }
-  //back to normal state ,restore the original model;
+
+  // Back to normal state, restore the original model
   if ( reg.pattern().isEmpty() ) {
     QMutexLocker _( &lock );
-    //race condition.
     if ( !filtering ) {
       return;
     }
     filtering = false;
+    currentSearchPrefix.clear();
 
-    //reset to previous models
     beginResetModel();
     words = QStringList( original_words );
     endResetModel();
@@ -59,12 +74,12 @@ void HeadwordListModel::setFilter( const QRegularExpression & reg )
   }
   else {
     QMutexLocker _( &lock );
-    //the first time to enter filtering mode.
     if ( !filtering ) {
       filtering      = true;
       original_words = QStringList( words );
     }
   }
+
   filterWords.clear();
   auto sr = _dict->prefixMatch( Text::removeTrailingZero( reg.pattern() ), maxFilterResults );
   connect( sr.get(), &Dictionary::Request::finished, this, [ this, sr ]() {
@@ -91,7 +106,6 @@ void HeadwordListModel::requestFinished( const sptr< Dictionary::WordSearchReque
       }
     }
   }
-
 
   if ( filterWords.isEmpty() ) {
     return;
@@ -137,24 +151,81 @@ void HeadwordListModel::fetchMore( const QModelIndex & parent )
     return;
   }
 
-  //arbitrary number
+  // Try to use headword index first
+  if ( useIndex ) {
+    if ( fetchFromIndex( currentOffset, HEADWORD_PAGE_SIZE ) ) {
+      return;
+    }
+  }
+
+  // Fallback to legacy btree-based fetching
+  fetchFromBtree();
+}
+
+bool HeadwordListModel::fetchFromIndex( int offset, int limit )
+{
+  auto * btreeDict = dynamic_cast< BtreeIndexing::BtreeDictionary * >( _dict );
+  if ( !btreeDict ) {
+    return false;
+  }
+
+  auto * hwIndex = btreeDict->getHeadwordIndex();
+  if ( !hwIndex ) {
+    return false;
+  }
+
+  HeadwordIndex::PagedResult result;
+
+  if ( currentSearchPrefix.isEmpty() ) {
+    result = hwIndex->getPage( offset, limit );
+  }
+  else {
+    result = hwIndex->searchPrefix( currentSearchPrefix, offset, limit );
+  }
+
+  if ( result.headwords.isEmpty() ) {
+    finished = true;
+    return true;
+  }
+
+  beginInsertRows( QModelIndex(), words.size(), words.size() + result.headwords.size() - 1 );
+  for ( const QString & word : std::as_const( result.headwords ) ) {
+    words << word;
+    hashedWords.insert( word );
+  }
+  endInsertRows();
+
+  currentOffset += result.headwords.size();
+
+  if ( !result.hasMore ) {
+    finished = true;
+  }
+
+  emit numberPopulated( words.size() );
+  return true;
+}
+
+void HeadwordListModel::fetchFromBtree()
+{
+  // For small dictionaries, load all at once
   if ( totalSize < HEADWORDS_MAX_LIMIT ) {
     finished = true;
 
     beginInsertRows( QModelIndex(), 0, totalSize - 1 );
     _dict->getHeadwords( words );
-
     endInsertRows();
+
     emit numberPopulated( words.size() );
     return;
   }
 
-
+  // For large dictionaries, load in batches
   QSet< QString > headword;
   QMutexLocker _( &lock );
 
-  _dict->findHeadWordsWithLenth( index, &headword, 1000 );
+  _dict->findHeadWordsWithLenth( index, &headword, HEADWORD_PAGE_SIZE );
   if ( headword.isEmpty() ) {
+    finished = true;
     return;
   }
 
@@ -184,6 +255,27 @@ void HeadwordListModel::setMaxFilterResults( int _maxFilterResults )
 
 QSet< QString > HeadwordListModel::getRemainRows( int & nodeIndex )
 {
+  // If using index, fetch remaining pages
+  if ( useIndex ) {
+    auto * btreeDict = dynamic_cast< BtreeIndexing::BtreeDictionary * >( _dict );
+    if ( btreeDict ) {
+      auto * hwIndex = btreeDict->getHeadwordIndex();
+      if ( hwIndex ) {
+        auto result = hwIndex->getPage( nodeIndex, 10000 );
+        nodeIndex += result.headwords.size();
+
+        QSet< QString > filtered;
+        for ( const QString & word : std::as_const( result.headwords ) ) {
+          if ( !containWord( word ) ) {
+            filtered.insert( word );
+          }
+        }
+        return filtered;
+      }
+    }
+  }
+
+  // Fallback to legacy method
   QSet< QString > headword;
   QMutexLocker _( &lock );
   _dict->findHeadWordsWithLenth( nodeIndex, &headword, 10000 );
@@ -199,6 +291,170 @@ QSet< QString > HeadwordListModel::getRemainRows( int & nodeIndex )
 
 void HeadwordListModel::setDict( Dictionary::Class * dict )
 {
-  _dict     = dict;
-  totalSize = _dict->getWordCount();
+  _dict         = dict;
+  totalSize     = _dict->getWordCount();
+  currentOffset = 0;
+  useIndex      = false;
+
+  // Check if headword index is available
+  auto * btreeDict = dynamic_cast< BtreeIndexing::BtreeDictionary * >( _dict );
+  if ( btreeDict && btreeDict->haveHeadwordIndex() ) {
+    auto * hwIndex = btreeDict->getHeadwordIndex();
+    if ( hwIndex ) {
+      useIndex  = true;
+      totalSize = hwIndex->getTotalCount();
+      qDebug() << "Using headword index for" << QString::fromStdString( dict->getName() );
+    }
+  }
+
+  // Notify if index is recommended for large dictionaries
+  if ( !useIndex && isLargeDictionary() ) {
+    qDebug() << "Headword index recommended for" << QString::fromStdString( dict->getName() )
+             << "(" << totalSize << "headwords)";
+    emit indexBuildRecommended();
+  }
+}
+
+bool HeadwordListModel::isLargeDictionary() const
+{
+  return totalSize > HEADWORDS_MAX_LIMIT;
+}
+
+bool HeadwordListModel::isIndexBuildRecommended() const
+{
+  return !useIndex && isLargeDictionary();
+}
+
+bool HeadwordListModel::isIndexBuilding() const
+{
+  return Utils::AtomicInt::loadAcquire( indexBuilding ) != 0;
+}
+
+void HeadwordListModel::cancelIndexBuild()
+{
+  indexBuildCancelled.ref();
+}
+
+bool HeadwordListModel::hasHeadwordIndex() const
+{
+  auto * btreeDict = dynamic_cast< BtreeIndexing::BtreeDictionary * >( _dict );
+  if ( !btreeDict ) {
+    return false;
+  }
+  return btreeDict->haveHeadwordIndex();
+}
+
+void HeadwordListModel::buildHeadwordIndex( bool autoBuild )
+{
+  auto * btreeDict = dynamic_cast< BtreeIndexing::BtreeDictionary * >( _dict );
+  if ( !btreeDict ) {
+    emit indexBuildFinished( false );
+    return;
+  }
+
+  // Don't build if already have index or already building
+  if ( btreeDict->haveHeadwordIndex() || isIndexBuilding() ) {
+    emit indexBuildFinished( btreeDict->haveHeadwordIndex() );
+    return;
+  }
+
+  // Reset cancellation flag
+  while ( Utils::AtomicInt::loadAcquire( indexBuildCancelled ) ) {
+    indexBuildCancelled.deref();
+  }
+
+  indexBuilding.ref();
+
+  qDebug() << "Building headword index for" << QString::fromStdString( _dict->getName() )
+           << ( autoBuild ? "(auto)" : "(manual)" );
+
+  QtConcurrent::run( [ this, btreeDict ]() {
+    btreeDict->makeHeadwordIndex( indexBuildCancelled );
+
+    bool success = false;
+
+    // Update model to use index if build succeeded
+    if ( btreeDict->haveHeadwordIndex() ) {
+      auto * hwIndex = btreeDict->getHeadwordIndex();
+      if ( hwIndex ) {
+        useIndex  = true;
+        totalSize = hwIndex->getTotalCount();
+        success   = true;
+        qDebug() << "Headword index built successfully:" << totalSize << "headwords";
+      }
+    }
+
+    // Clear building flag
+    while ( Utils::AtomicInt::loadAcquire( indexBuilding ) ) {
+      indexBuilding.deref();
+    }
+
+    emit indexBuildFinished( success );
+  } );
+}
+
+void HeadwordListModel::searchPrefix( const QString & prefix, int offset, int limit )
+{
+  if ( !useIndex ) {
+    return;
+  }
+
+  auto * btreeDict = dynamic_cast< BtreeIndexing::BtreeDictionary * >( _dict );
+  if ( !btreeDict ) {
+    return;
+  }
+
+  auto * hwIndex = btreeDict->getHeadwordIndex();
+  if ( !hwIndex ) {
+    return;
+  }
+
+  currentSearchPrefix = prefix;
+
+  auto result = hwIndex->searchPrefix( prefix, offset, limit );
+
+  beginResetModel();
+  words.clear();
+  for ( const QString & word : std::as_const( result.headwords ) ) {
+    words << word;
+  }
+  endResetModel();
+
+  filtering     = true;
+  currentOffset = result.headwords.size();
+  finished      = !result.hasMore;
+
+  emit numberPopulated( words.size() );
+}
+
+void HeadwordListModel::searchWildcard( const QString & pattern, int offset, int limit )
+{
+  if ( !useIndex ) {
+    return;
+  }
+
+  auto * btreeDict = dynamic_cast< BtreeIndexing::BtreeDictionary * >( _dict );
+  if ( !btreeDict ) {
+    return;
+  }
+
+  auto * hwIndex = btreeDict->getHeadwordIndex();
+  if ( !hwIndex ) {
+    return;
+  }
+
+  auto result = hwIndex->searchWildcard( pattern, offset, limit );
+
+  beginResetModel();
+  words.clear();
+  for ( const QString & word : std::as_const( result.headwords ) ) {
+    words << word;
+  }
+  endResetModel();
+
+  filtering     = true;
+  currentOffset = result.headwords.size();
+  finished      = !result.hasMore;
+
+  emit numberPopulated( words.size() );
 }

--- a/src/headwordsmodel.cc
+++ b/src/headwordsmodel.cc
@@ -301,8 +301,10 @@ void HeadwordListModel::setDict( Dictionary::Class * dict )
   if ( btreeDict && btreeDict->haveHeadwordIndex() ) {
     auto * hwIndex = btreeDict->getHeadwordIndex();
     if ( hwIndex ) {
-      useIndex  = true;
-      totalSize = hwIndex->getTotalCount();
+      useIndex = true;
+      // Get total count from a page query
+      auto result = hwIndex->getPage( 0, 1 );
+      totalSize   = result.totalCount;
       qDebug() << "Using headword index for" << QString::fromStdString( dict->getName() );
     }
   }
@@ -377,9 +379,11 @@ void HeadwordListModel::buildHeadwordIndex( bool autoBuild )
     if ( btreeDict->haveHeadwordIndex() ) {
       auto * hwIndex = btreeDict->getHeadwordIndex();
       if ( hwIndex ) {
-        useIndex  = true;
-        totalSize = hwIndex->getTotalCount();
-        success   = true;
+        useIndex = true;
+        // Get total count from a page query
+        auto result = hwIndex->getPage( 0, 1 );
+        totalSize   = result.totalCount;
+        success     = true;
         qDebug() << "Headword index built successfully:" << totalSize << "headwords";
       }
     }

--- a/src/headwordsmodel.cc
+++ b/src/headwordsmodel.cc
@@ -305,7 +305,7 @@ void HeadwordListModel::setDict( Dictionary::Class * dict )
       // Get total count from a page query
       auto result = hwIndex->getPage( 0, 1 );
       qDebug() << "Index total count:" << result.totalCount << "headwords in first page:" << result.headwords.size();
-      
+
       if ( result.totalCount > 0 ) {
         useIndex  = true;
         totalSize = result.totalCount;

--- a/src/headwordsmodel.cc
+++ b/src/headwordsmodel.cc
@@ -301,11 +301,19 @@ void HeadwordListModel::setDict( Dictionary::Class * dict )
   if ( btreeDict && btreeDict->haveHeadwordIndex() ) {
     auto * hwIndex = btreeDict->getHeadwordIndex();
     if ( hwIndex ) {
-      useIndex = true;
+      qDebug() << "Found headword index for" << QString::fromStdString( dict->getName() );
       // Get total count from a page query
       auto result = hwIndex->getPage( 0, 1 );
-      totalSize   = result.totalCount;
-      qDebug() << "Using headword index for" << QString::fromStdString( dict->getName() );
+      qDebug() << "Index total count:" << result.totalCount << "headwords in first page:" << result.headwords.size();
+      
+      if ( result.totalCount > 0 ) {
+        useIndex  = true;
+        totalSize = result.totalCount;
+        qDebug() << "Using headword index for" << QString::fromStdString( dict->getName() );
+      }
+      else {
+        qWarning() << "Headword index exists but returned 0 count, falling back to btree";
+      }
     }
   }
 

--- a/src/headwordsmodel.hh
+++ b/src/headwordsmodel.hh
@@ -1,9 +1,12 @@
 #pragma once
 
 #include "dict/dictionary.hh"
+#include "headwordindex.hh"
 #include <QAbstractListModel>
 
 static const int HEADWORDS_MAX_LIMIT = 500000;
+static const int HEADWORD_PAGE_SIZE  = 1000;
+
 class HeadwordListModel: public QAbstractListModel
 {
   Q_OBJECT
@@ -23,8 +26,38 @@ public:
   bool containWord( const QString & word );
   QSet< QString > getRemainRows( int & nodeIndex );
   void setMaxFilterResults( int _maxFilterResults );
+
+  /// Check if the dictionary has a headword index available
+  bool hasHeadwordIndex() const;
+
+  /// Check if the dictionary is large enough to benefit from headword index
+  bool isLargeDictionary() const;
+
+  /// Check if index building is recommended (large dict without index)
+  bool isIndexBuildRecommended() const;
+
+  /// Build headword index for the current dictionary (if not already built)
+  /// @param autoBuild If true, will be called automatically for large dictionaries
+  void buildHeadwordIndex( bool autoBuild = false );
+
+  /// Cancel ongoing index build
+  void cancelIndexBuild();
+
+  /// Check if index is currently being built
+  bool isIndexBuilding() const;
+
+  /// Search headwords using prefix matching (uses index if available)
+  void searchPrefix( const QString & prefix, int offset, int limit );
+
+  /// Search headwords using wildcard pattern (uses index if available)
+  void searchWildcard( const QString & pattern, int offset, int limit );
+
 signals:
   void numberPopulated( int number );
+  void indexBuildProgress( int percent );
+  void indexBuildFinished( bool success );
+  /// Emitted when the dictionary is large and would benefit from an index
+  void indexBuildRecommended();
 
 public slots:
   void setDict( Dictionary::Class * dict );
@@ -35,6 +68,12 @@ protected:
   void fetchMore( const QModelIndex & parent ) override;
 
 private:
+  /// Try to use headword index for fetching, returns true if successful
+  bool fetchFromIndex( int offset, int limit );
+
+  /// Fallback to legacy btree-based fetching
+  void fetchFromBtree();
+
   QStringList words;
   QStringList original_words;
   QSet< QString > hashedWords;
@@ -48,4 +87,11 @@ private:
   int index;
   char * ptr;
   QMutex lock;
+
+  // Index-based pagination state
+  int currentOffset;
+  bool useIndex;
+  QString currentSearchPrefix;
+  QAtomicInt indexBuildCancelled;
+  QAtomicInt indexBuilding;
 };

--- a/src/ui/dictheadwords.cc
+++ b/src/ui/dictheadwords.cc
@@ -134,6 +134,14 @@ void DictHeadwords::setup( Dictionary::Class * dict_ )
   std::shared_ptr< HeadwordListModel > other = std::make_shared< HeadwordListModel >();
   model.swap( other );
   model->setMaxFilterResults( ui.filterMaxResult->value() );
+
+  // Connect signals before setDict to catch indexBuildRecommended
+  connect( model.get(), &HeadwordListModel::numberPopulated, this, [ this ]( int ) {
+    showHeadwordsNumber();
+  } );
+  connect( model.get(), &HeadwordListModel::indexBuildRecommended, this, &DictHeadwords::onIndexBuildRecommended );
+  connect( model.get(), &HeadwordListModel::indexBuildFinished, this, &DictHeadwords::onIndexBuildFinished );
+
   model->setDict( dict );
   proxy->setSourceModel( model.get() );
   proxy->sort( 0 );
@@ -153,9 +161,7 @@ void DictHeadwords::setup( Dictionary::Class * dict_ )
   dictId = QString( dict->getId().c_str() );
 
   QApplication::restoreOverrideCursor();
-  connect( model.get(), &HeadwordListModel::numberPopulated, this, [ this ]( int _ ) {
-    showHeadwordsNumber();
-  } );
+
   connect( proxy, &QAbstractItemModel::dataChanged, this, &DictHeadwords::showHeadwordsNumber );
   connect( ui.filterMaxResult, &QSpinBox::valueChanged, this, [ this ]( int _value ) {
     model->setMaxFilterResults( _value );
@@ -409,4 +415,57 @@ void DictHeadwords::writeWordToFile( QTextStream & out, const QString & word )
 
   //write one line
   out << line << Qt::endl;
+}
+
+void DictHeadwords::offerIndexBuild()
+{
+  const int ret = QMessageBox::question(
+    this,
+    tr( "Build Index" ),
+    tr( "This dictionary has %1 headwords. Building a headword index will significantly improve "
+        "browsing and search performance.\n\nDo you want to build the index now?" )
+      .arg( model->totalCount() ),
+    QMessageBox::Yes | QMessageBox::No,
+    QMessageBox::Yes );
+
+  if ( ret == QMessageBox::Yes ) {
+    // Show progress dialog
+    QProgressDialog progress( tr( "Building headword index..." ), tr( "Cancel" ), 0, 0, this );
+    progress.setWindowModality( Qt::WindowModal );
+    progress.setMinimumDuration( 0 );
+    progress.setValue( 0 );
+
+    // Connect cancel button
+    connect( &progress, &QProgressDialog::canceled, this, [ this ]() {
+      model->cancelIndexBuild();
+    } );
+
+    // Start building
+    model->buildHeadwordIndex( false );
+
+    // Wait for completion (the dialog will close when indexBuildFinished is emitted)
+    while ( model->isIndexBuilding() ) {
+      QApplication::processEvents();
+      if ( progress.wasCanceled() ) {
+        break;
+      }
+    }
+
+    progress.close();
+  }
+}
+
+void DictHeadwords::onIndexBuildRecommended()
+{
+  // Defer the dialog to allow the UI to finish setup
+  QTimer::singleShot( 100, this, &DictHeadwords::offerIndexBuild );
+}
+
+void DictHeadwords::onIndexBuildFinished( bool success )
+{
+  if ( success ) {
+    // Refresh the view to use the new index
+    showHeadwordsNumber();
+    QMessageBox::information( this, tr( "Index Built" ), tr( "Headword index has been built successfully." ) );
+  }
 }

--- a/src/ui/dictheadwords.cc
+++ b/src/ui/dictheadwords.cc
@@ -419,14 +419,14 @@ void DictHeadwords::writeWordToFile( QTextStream & out, const QString & word )
 
 void DictHeadwords::offerIndexBuild()
 {
-  const int ret = QMessageBox::question(
-    this,
-    tr( "Build Index" ),
-    tr( "This dictionary has %1 headwords. Building a headword index will significantly improve "
-        "browsing and search performance.\n\nDo you want to build the index now?" )
-      .arg( model->totalCount() ),
-    QMessageBox::Yes | QMessageBox::No,
-    QMessageBox::Yes );
+  const int ret =
+    QMessageBox::question( this,
+                           tr( "Build Index" ),
+                           tr( "This dictionary has %1 headwords. Building a headword index will significantly improve "
+                               "browsing and search performance.\n\nDo you want to build the index now?" )
+                             .arg( model->totalCount() ),
+                           QMessageBox::Yes | QMessageBox::No,
+                           QMessageBox::Yes );
 
   if ( ret == QMessageBox::Yes ) {
     // Show progress dialog

--- a/src/ui/dictheadwords.hh
+++ b/src/ui/dictheadwords.hh
@@ -39,6 +39,9 @@ private:
   QMutex mutex;
   static void writeWordToFile( QTextStream & out, const QString & word );
 
+  /// Offer to build headword index for large dictionaries
+  void offerIndexBuild();
+
 private slots:
   void savePos();
   void filterChangedInternal();
@@ -51,6 +54,8 @@ private slots:
   void showHeadwordsNumber();
   void exportAllWords( QProgressDialog & progress, QTextStream & out );
   void loadRegex( QProgressDialog & progress, QTextStream & out );
+  void onIndexBuildRecommended();
+  void onIndexBuildFinished( bool success );
   virtual void reject();
 
 signals:


### PR DESCRIPTION
… browsing

- Implement buildHeadwordIndex helper to create headword index from IndexedWords during index build
- Extend BtreeDictionary with methods to get headword index path, check existence, build, and access index
- Modify buildIndex to automatically build headword index alongside main index file
- Add HeadwordListModel logic to use headword index for efficient pagination and prefix/wildcard search
- Enable detection and recommendation to build headword index for large dictionaries in HeadwordListModel
- Provide async index building and cancellation support with progress signals in HeadwordListModel
- Update DictHeadwords UI to connect signals, prompt user to build index for large dictionaries, and show progress
- Introduce methods in DictHeadwords to handle index build recommendation, progress, and completion notifications
- Add constants and thread safety mechanisms to support headword index concurrency and incremental loading