### PR TITLE
fix(mdx): improve srcset parsing and support responsive images

### DIFF
--- a/src/common/globalregex.cc
+++ b/src/common/globalregex.cc
@@ -55,11 +55,11 @@ QRegularExpression Mdx::srcRe2(
   R"(([\s"']src\s*=)\s*(?![\s"']|\b(?:(?:bres|https?|ftp)://|(?:data|javascript):))(?:file://)?[\x00-\x1f\x7f]*\.*/?([^\s">]+))",
   QRegularExpression::CaseInsensitiveOption );
 // matches srcset in <img srcset="text">
-QRegularExpression Mdx::srcset( R"((?<before>[\s]srcset\s*=\s*["'])\s*(?<text>[\s\S]*)(?<after>["']))",
+QRegularExpression Mdx::srcset( R"((?<before>[\s]srcset\s*=\s*(?<q>["']))(?<text>[^">]*?)(?<after>\k<q>))",
                                 QRegularExpression::CaseInsensitiveOption );
 
 // matches data in <object data="text">
-QRegularExpression Mdx::objectdata( R"((?<before>[\s]data\s*=\s*["'])\s*(?<text>[\s\S]*)(?<after>["']))",
+QRegularExpression Mdx::objectdata( R"((?<before>[\s]data\s*=\s*(?<q>["']))(?<text>[^">]*?)(?<after>\k<q>))",
                                     QRegularExpression::CaseInsensitiveOption );
 
 QRegularExpression Mdx::links( R"(url\(\s*(['"]?)([^'"]*)(['"]?)\s*\))", QRegularExpression::CaseInsensitiveOption );

--- a/src/common/globalregex.cc
+++ b/src/common/globalregex.cc
@@ -49,10 +49,10 @@ QRegularExpression Mdx::inlineScriptRe( R"(<\s*script(?:(?=\s)(?:(?![\s"']src\s*
                                         QRegularExpression::CaseInsensitiveOption );
 QRegularExpression Mdx::closeScriptTagRe( R"(<\s*/script\s*>)", QRegularExpression::CaseInsensitiveOption );
 QRegularExpression Mdx::srcRe(
-  R"(([\s"'](?:src|srcset)\s*=)\s*(["'])(?!\s*\b(?:(?:bres|https?|ftp)://|(?:data|javascript):))(?:file://)?[\x00-\x1f\x7f]*\.*/?([^">]+)\2)",
+  R"(([\s"']src\s*=)\s*(["'])(?!\s*\b(?:(?:bres|https?|ftp)://|(?:data|javascript):))(?:file://)?[\x00-\x1f\x7f]*\.*/?([^">]+)\2)",
   QRegularExpression::CaseInsensitiveOption );
 QRegularExpression Mdx::srcRe2(
-  R"(([\s"'](?:src|srcset)\s*=)\s*(?![\s"']|\b(?:(?:bres|https?|ftp)://|(?:data|javascript):))(?:file://)?[\x00-\x1f\x7f]*\.*/?([^\s">]+))",
+  R"(([\s"']src\s*=)\s*(?![\s"']|\b(?:(?:bres|https?|ftp)://|(?:data|javascript):))(?:file://)?[\x00-\x1f\x7f]*\.*/?([^\s">]+))",
   QRegularExpression::CaseInsensitiveOption );
 // matches srcset in <img srcset="text">
 QRegularExpression Mdx::srcset( R"((?<before>[\s]srcset\s*=\s*["'])\s*(?<text>[\s\S]*)(?<after>["']))",

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -1027,45 +1027,49 @@ void MdxDictionary::replaceLinks( QString & id, QString & article )
       if ( linkType.compare( "img" ) == 0 || linkType.compare( "source" ) == 0 ) {
         match = RX::Mdx::srcset.match( newLink );
         if ( match.hasMatch() ) {
-          auto srcsetOriginalText   = match.captured( "text" );
-          QStringList srcsetNewText = {};
+          auto srcsetOriginalText = match.captured( "text" );
 
-          // According to HTML spec: a comma is a separator only if followed by whitespace.
-          // This allows commas inside URLs (query params, data URIs) if not followed by space.
-          QStringList chunks = srcsetOriginalText.split( QRegularExpression( R"(,\s+)" ), Qt::SkipEmptyParts );
+          // PERFORMANCE & SAFETY: If the whole text is an absolute URL, don't even try to split/parse it.
+          // This prevents issues with complex URLs containing commas.
+          if ( srcsetOriginalText.contains( "//" ) || srcsetOriginalText.contains( ":" ) ) {
+            // Keep as is
+          }
+          else {
+            QStringList srcsetNewText = {};
+            // Split only when a comma is followed by whitespace, as per HTML Living Standard.
+            QStringList chunks = srcsetOriginalText.split( QRegularExpression( R"(,\s+)" ), Qt::SkipEmptyParts );
 
-          for ( QString chunk : chunks ) {
-            chunk = chunk.trimmed();
-            if ( chunk.isEmpty() )
-              continue;
+            for ( QString chunk : chunks ) {
+              chunk = chunk.trimmed();
+              if ( chunk.isEmpty() )
+                continue;
 
-            // First non-whitespace block is the URL, the rest is the descriptor
-            QString url, desc;
-            int firstSpace = chunk.indexOf( QRegularExpression( R"(\s)" ) );
-            if ( firstSpace != -1 ) {
-              url  = chunk.left( firstSpace );
-              desc = chunk.mid( firstSpace ).trimmed();
-            }
-            else {
-              url = chunk;
-            }
-
-            if ( !url.isEmpty() ) {
-              // Convert only relative local paths. External (//), protocols (:), or already prefixed paths are skipped.
-              if ( !url.contains( "//" ) && !url.contains( ":" ) ) {
-                QString converted = QString( R"(bres://%1/%2)" ).arg( id, url );
-                srcsetNewText.append( desc.isEmpty() ? converted : converted + " " + desc );
+              QString url, desc;
+              int firstSpace = chunk.indexOf( QRegularExpression( R"(\s)" ) );
+              if ( firstSpace != -1 ) {
+                url  = chunk.left( firstSpace );
+                desc = chunk.mid( firstSpace ).trimmed();
               }
               else {
-                // Keep external links, Data URIs, etc.
-                srcsetNewText.append( desc.isEmpty() ? url : url + " " + desc );
+                url = chunk;
+              }
+
+              if ( !url.isEmpty() ) {
+                if ( !url.contains( "//" ) && !url.contains( ":" ) ) {
+                  QString converted = QString( R"(bres://%1/%2)" ).arg( id, url );
+                  srcsetNewText.append( desc.isEmpty() ? converted : converted + " " + desc );
+                }
+                else {
+                  srcsetNewText.append( desc.isEmpty() ? url : url + " " + desc );
+                }
               }
             }
+            if ( !srcsetNewText.isEmpty() ) {
+              newLink.replace( match.capturedStart(),
+                               match.capturedLength(),
+                               match.captured( "before" ) % srcsetNewText.join( ',' ) % match.captured( "after" ) );
+            }
           }
-
-          newLink.replace( match.capturedStart(),
-                           match.capturedLength(),
-                           match.captured( "before" ) % srcsetNewText.join( ',' ) % match.captured( "after" ) );
         }
       }
 

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -1024,23 +1024,41 @@ void MdxDictionary::replaceLinks( QString & id, QString & article )
       // convert <img src="bres://{id}/a.png" srcset="a-1x.png 1x, b-2x.png 2x, c.png">
       // into    <img src="bres://{id}/a.png" srcset="bres://{id}/a-1x.png 1x,bres://{id}/b-2x.png 2x,bres://{id}/c.png">
 
-      if ( linkType.compare( "img" ) == 0 ) {
-        match = RX::Mdx::srcset.match( newLink ); // have to use newLink since linkTxt may already be modified
+      if ( linkType.compare( "img" ) == 0 || linkType.compare( "source" ) == 0 ) {
+        match = RX::Mdx::srcset.match( newLink );
         if ( match.hasMatch() ) {
           auto srcsetOriginalText   = match.captured( "text" );
           QStringList srcsetNewText = {};
 
-          auto ImageList = srcsetOriginalText.split( u',', Qt::SkipEmptyParts );
+          // According to HTML spec: a comma is a separator only if followed by whitespace.
+          // This allows commas inside URLs (query params, data URIs) if not followed by space.
+          QStringList chunks = srcsetOriginalText.split( QRegularExpression( R"(,\s+)" ), Qt::SkipEmptyParts );
 
-          for ( auto & img : ImageList ) {
-            auto imgPair = img.split( RX::whiteSpace );
+          for ( QString chunk : chunks ) {
+            chunk = chunk.trimmed();
+            if ( chunk.isEmpty() )
+              continue;
 
-            if ( !imgPair.empty() && !imgPair.at( 0 ).contains( "//" ) ) {
-              if ( imgPair.length() == 1 ) {
-                srcsetNewText.append( QString( R"(bres://%1/%2)" ).arg( id, imgPair.at( 0 ) ) );
+            // First non-whitespace block is the URL, the rest is the descriptor
+            QString url, desc;
+            int firstSpace = chunk.indexOf( QRegularExpression( R"(\s)" ) );
+            if ( firstSpace != -1 ) {
+              url  = chunk.left( firstSpace );
+              desc = chunk.mid( firstSpace ).trimmed();
+            }
+            else {
+              url = chunk;
+            }
+
+            if ( !url.isEmpty() ) {
+              // Convert only relative local paths. External (//), protocols (:), or already prefixed paths are skipped.
+              if ( !url.contains( "//" ) && !url.contains( ":" ) ) {
+                QString converted = QString( R"(bres://%1/%2)" ).arg( id, url );
+                srcsetNewText.append( desc.isEmpty() ? converted : converted + " " + desc );
               }
-              else if ( imgPair.length() == 2 ) {
-                srcsetNewText.append( QString( R"(bres://%1/%2 %3)" ).arg( id, imgPair.at( 0 ), imgPair.at( 1 ) ) );
+              else {
+                // Keep external links, Data URIs, etc.
+                srcsetNewText.append( desc.isEmpty() ? url : url + " " + desc );
               }
             }
           }
@@ -1056,8 +1074,12 @@ void MdxDictionary::replaceLinks( QString & id, QString & article )
         if ( match.hasMatch() ) {
           auto srcsetOriginalText = match.captured( "text" );
           QString srcsetNewText;
-          if ( !srcsetOriginalText.contains( "//" ) ) {
+          if ( !srcsetOriginalText.contains( "//" ) && !srcsetOriginalText.contains( ":" ) ) {
             srcsetNewText = QString( R"(bres://%1/%2)" ).arg( id, srcsetOriginalText );
+          }
+          else {
+            // Fix: Keep external URLs for object data
+            srcsetNewText = srcsetOriginalText;
           }
 
           newLink.replace( match.capturedStart(),


### PR DESCRIPTION
- Refactor srcset parsing to follow HTML standard (handle commas in URLs).
- Prevent discarding external links and Data URIs.
- Add support for <source> tags and fix <object> data conversion.