### PR TITLE
refactor: extract nested conditional operators into independent state…

### DIFF
--- a/src/article_netmgr.cc
+++ b/src/article_netmgr.cc
@@ -199,9 +199,14 @@ sptr< Dictionary::DataRequest > ArticleNetworkAccessManager::handleLookupScheme(
   else if ( const Config::Class * cfg = GlobalBroadcaster::instance()->getConfig() ) {
     bool isPopup              = Utils::Url::queryItemValue( url, "popup" ) == "1";
     const Config::Group * grp = cfg->getGroup( group );
-    const auto * ms           = ( group == GroupId::AllGroupId ) ?
-      ( isPopup ? &cfg->popupMutedDictionaries : &cfg->mutedDictionaries ) :
-      ( grp ? ( isPopup ? &grp->popupMutedDictionaries : &grp->mutedDictionaries ) : nullptr );
+    const QSet< QString > * ms = nullptr;
+    if ( group == GroupId::AllGroupId ) {
+      ms = isPopup ? &cfg->popupMutedDictionaries : &cfg->mutedDictionaries;
+    }
+    else if ( grp ) {
+      ms = isPopup ? &grp->popupMutedDictionaries : &grp->mutedDictionaries;
+    }
+
     if ( ms ) {
       mutedDicts = *ms;
     }

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -2920,7 +2920,10 @@ void MainWindow::showTranslationFor( const QString & word, unsigned inGroup, con
 
   navPronounce->setEnabled( false );
 
-  unsigned group = inGroup ? inGroup : ( groupInstances.empty() ? 0 : groupInstances[ groupList->currentIndex() ].id );
+  unsigned group = inGroup;
+  if ( group == 0 ) {
+    group = groupInstances.empty() ? 0 : groupInstances[ groupList->currentIndex() ].id;
+  }
 
   view->showDefinition( word, group, scrollTo );
 


### PR DESCRIPTION
…ments

- Refactor nested ternary operators in `ArticleNetworkAccessManager::handleLookupScheme` and `MainWindow::showTranslationFor` to improve readability.
- Address SonarCloud static analysis warnings regarding complex nested conditionals.
- Improve code mountainability by using explicit if-else blocks for selection logic.