### PR TITLE
refactor: Use random ID generation for groups

### DIFF
--- a/src/common/globalbroadcaster.hh
+++ b/src/common/globalbroadcaster.hh
@@ -13,7 +13,7 @@
 
 struct ActiveDictIds
 {
-  unsigned groupId;
+  quint64 groupId;
   QString word;
   QStringList dictIds;
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -555,31 +555,26 @@ Class load()
 
   if ( !groups.isNull() ) {
     QDomNodeList nl = groups.toElement().elementsByTagName( "group" );
+    QSet<quint64> usedIds;
 
     for ( int x = 0; x < nl.length(); ++x ) {
       QDomElement grp = nl.item( x ).toElement();
+      Group g = loadGroup( grp );
 
-      c.groups.push_back( loadGroup( grp ) );
-    }
-
-    // Check for duplicate group IDs and regenerate if found
-    QSet< quint64 > usedIds;
-    for ( int i = 0; i < c.groups.size(); ++i ) {
-      quint64 currentId = c.groups[ i ].id;
-      if ( usedIds.contains( currentId ) ) {
+      // Check for duplicate group ID and regenerate if found
+      if ( usedIds.contains( g.id ) ) {
         // Generate a new random ID
         quint64 newId;
         do {
           qint64 timestamp = QDateTime::currentMSecsSinceEpoch();
-          quint64 random   = QRandomGenerator::global()->generate();
-          newId            = ( static_cast< quint64 >( timestamp ) << 24 ) | ( random & 0xFFFFFF );
+          quint64 random = QRandomGenerator::global()->generate();
+          newId = (static_cast<quint64>(timestamp) << 24) | (random & 0xFFFFFF);
         } while ( usedIds.contains( newId ) );
-        c.groups[ i ].id = newId;
-        usedIds.insert( newId );
+        g.id = newId;
       }
-      else {
-        usedIds.insert( currentId );
-      }
+
+      usedIds.insert( g.id );
+      c.groups.push_back( g );
     }
   }
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -332,15 +332,18 @@ void applyBoolOption( bool & option, const QDomNode & node )
   }
 }
 
-Group loadGroup( QDomElement grp, unsigned * nextId = 0 )
+Group loadGroup( QDomElement grp )
 {
   Group g;
 
   if ( grp.hasAttribute( "id" ) ) {
-    g.id = grp.attribute( "id" ).toUInt();
+    g.id = grp.attribute( "id" ).toULongLong();
   }
   else {
-    g.id = nextId ? ( *nextId )++ : 0;
+    // Generate a random ID using timestamp and random number
+    qint64 timestamp = QDateTime::currentMSecsSinceEpoch();
+    quint64 random = QRandomGenerator::global()->generate();
+    g.id = (static_cast<quint64>(timestamp) << 24) | (random & 0xFFFFFF);
   }
 
   g.name            = grp.attribute( "name" );
@@ -551,14 +554,12 @@ Class load()
   QDomNode groups = root.namedItem( "groups" );
 
   if ( !groups.isNull() ) {
-    c.groups.nextId = groups.toElement().attribute( "nextId", "1" ).toUInt();
-
     QDomNodeList nl = groups.toElement().elementsByTagName( "group" );
 
     for ( int x = 0; x < nl.length(); ++x ) {
       QDomElement grp = nl.item( x ).toElement();
 
-      c.groups.push_back( loadGroup( grp, &c.groups.nextId ) );
+      c.groups.push_back( loadGroup( grp ) );
     }
   }
 
@@ -1337,9 +1338,7 @@ void save( const Class & c )
     QDomElement groups = dd.createElement( "groups" );
     root.appendChild( groups );
 
-    QDomAttr nextId = dd.createAttribute( "nextId" );
-    nextId.setValue( QString::number( c.groups.nextId ) );
-    groups.setAttributeNode( nextId );
+
 
     for ( const auto & i : c.groups ) {
       QDomElement group = dd.createElement( "group" );

--- a/src/config.cc
+++ b/src/config.cc
@@ -180,7 +180,7 @@ Romaji::Romaji():
 {
 }
 
-Group * Class::getGroup( unsigned id )
+Group * Class::getGroup( quint64 id )
 {
   for ( auto & group : groups ) {
     if ( group.id == id ) {
@@ -190,7 +190,7 @@ Group * Class::getGroup( unsigned id )
   return 0;
 }
 
-const Group * Class::getGroup( unsigned id ) const
+const Group * Class::getGroup( quint64 id ) const
 {
   for ( const auto & group : groups ) {
     if ( group.id == id ) {

--- a/src/config.cc
+++ b/src/config.cc
@@ -342,8 +342,8 @@ Group loadGroup( QDomElement grp )
   else {
     // Generate a random ID using timestamp and random number
     qint64 timestamp = QDateTime::currentMSecsSinceEpoch();
-    quint64 random = QRandomGenerator::global()->generate();
-    g.id = (static_cast<quint64>(timestamp) << 24) | (random & 0xFFFFFF);
+    quint64 random   = QRandomGenerator::global()->generate();
+    g.id             = ( static_cast< quint64 >( timestamp ) << 24 ) | ( random & 0xFFFFFF );
   }
 
   g.name            = grp.attribute( "name" );
@@ -1337,7 +1337,6 @@ void save( const Class & c )
   {
     QDomElement groups = dd.createElement( "groups" );
     root.appendChild( groups );
-
 
 
     for ( const auto & i : c.groups ) {

--- a/src/config.cc
+++ b/src/config.cc
@@ -561,6 +561,25 @@ Class load()
 
       c.groups.push_back( loadGroup( grp ) );
     }
+
+    // Check for duplicate group IDs and regenerate if found
+    QSet<quint64> usedIds;
+    for ( int i = 0; i < c.groups.size(); ++i ) {
+      quint64 currentId = c.groups[i].id;
+      if ( usedIds.contains( currentId ) ) {
+        // Generate a new random ID
+        quint64 newId;
+        do {
+          qint64 timestamp = QDateTime::currentMSecsSinceEpoch();
+          quint64 random = QRandomGenerator::global()->generate();
+          newId = (static_cast<quint64>(timestamp) << 24) | (random & 0xFFFFFF);
+        } while ( usedIds.contains( newId ) );
+        c.groups[i].id = newId;
+        usedIds.insert( newId );
+      } else {
+        usedIds.insert( currentId );
+      }
+    }
   }
 
   QDomNode hunspell = root.namedItem( "hunspell" );

--- a/src/config.cc
+++ b/src/config.cc
@@ -555,11 +555,11 @@ Class load()
 
   if ( !groups.isNull() ) {
     QDomNodeList nl = groups.toElement().elementsByTagName( "group" );
-    QSet<quint64> usedIds;
+    QSet< quint64 > usedIds;
 
     for ( int x = 0; x < nl.length(); ++x ) {
       QDomElement grp = nl.item( x ).toElement();
-      Group g = loadGroup( grp );
+      Group g         = loadGroup( grp );
 
       // Check for duplicate group ID and regenerate if found
       if ( usedIds.contains( g.id ) ) {
@@ -567,8 +567,8 @@ Class load()
         quint64 newId;
         do {
           qint64 timestamp = QDateTime::currentMSecsSinceEpoch();
-          quint64 random = QRandomGenerator::global()->generate();
-          newId = (static_cast<quint64>(timestamp) << 24) | (random & 0xFFFFFF);
+          quint64 random   = QRandomGenerator::global()->generate();
+          newId            = ( static_cast< quint64 >( timestamp ) << 24 ) | ( random & 0xFFFFFF );
         } while ( usedIds.contains( newId ) );
         g.id = newId;
       }

--- a/src/config.cc
+++ b/src/config.cc
@@ -563,20 +563,21 @@ Class load()
     }
 
     // Check for duplicate group IDs and regenerate if found
-    QSet<quint64> usedIds;
+    QSet< quint64 > usedIds;
     for ( int i = 0; i < c.groups.size(); ++i ) {
-      quint64 currentId = c.groups[i].id;
+      quint64 currentId = c.groups[ i ].id;
       if ( usedIds.contains( currentId ) ) {
         // Generate a new random ID
         quint64 newId;
         do {
           qint64 timestamp = QDateTime::currentMSecsSinceEpoch();
-          quint64 random = QRandomGenerator::global()->generate();
-          newId = (static_cast<quint64>(timestamp) << 24) | (random & 0xFFFFFF);
+          quint64 random   = QRandomGenerator::global()->generate();
+          newId            = ( static_cast< quint64 >( timestamp ) << 24 ) | ( random & 0xFFFFFF );
         } while ( usedIds.contains( newId ) );
-        c.groups[i].id = newId;
+        c.groups[ i ].id = newId;
         usedIds.insert( newId );
-      } else {
+      }
+      else {
         usedIds.insert( currentId );
       }
     }

--- a/src/config.hh
+++ b/src/config.hh
@@ -868,8 +868,8 @@ struct Class
     maxHeadwordsToExpand( 0 )
   {
   }
-  Group * getGroup( unsigned id );
-  const Group * getGroup( unsigned id ) const;
+  Group * getGroup( quint64 id );
+  const Group * getGroup( quint64 id ) const;
   //disable tts dictionary. does not need to save to persistent file
   bool notts      = false;
   bool resetState = false;

--- a/src/config.hh
+++ b/src/config.hh
@@ -112,7 +112,7 @@ struct DictionaryRef
 /// A dictionary group
 struct Group
 {
-  unsigned id;
+  quint64 id;
   QString name, icon;
   QByteArray iconData;
   QKeySequence shortcut;
@@ -141,15 +141,7 @@ struct Group
 };
 
 /// All the groups
-struct Groups: public QList< Group >
-{
-  unsigned nextId; // Id to use to create the group next time
-
-  Groups():
-    nextId( 1 )
-  {
-  }
-};
+typedef QList< Group > Groups;
 
 /// Proxy server configuration
 struct ProxyServer
@@ -828,8 +820,8 @@ struct Class
   VoiceEngines voiceEngines;
 #endif
 
-  unsigned lastMainGroupId;  // Last used group in main window
-  unsigned lastPopupGroupId; // Last used group in popup window
+  quint64 lastMainGroupId;  // Last used group in main window
+  quint64 lastPopupGroupId; // Last used group in popup window
 
   QByteArray popupWindowState;           // Binary state saved by QMainWindow
   QByteArray popupWindowGeometry;        // Geometry saved by QMainWindow

--- a/src/instances.cc
+++ b/src/instances.cc
@@ -58,7 +58,7 @@ Group::Group():
 {
 }
 
-Group::Group( unsigned id_, QString name_ ):
+Group::Group( quint64 id_, QString name_ ):
   id( id_ ),
   name( std::move( name_ ) )
 {
@@ -112,7 +112,7 @@ void Group::checkMutedDictionaries( QSet< QString > * mutedDictionaries ) const
   *mutedDictionaries = temp;
 }
 
-const Group * Groups::findGroup( unsigned id ) const
+const Group * Groups::findGroup( quint64 id ) const
 {
   for ( unsigned x = 0; x < size(); ++x ) {
     if ( operator[]( x ).id == id ) {

--- a/src/instances.hh
+++ b/src/instances.hh
@@ -18,7 +18,7 @@ using std::vector;
 
 struct Group
 {
-  unsigned id;
+  quint64 id;
   QString name, icon, favoritesFolder;
   QIcon iconData;
   QKeySequence shortcut;
@@ -33,7 +33,7 @@ struct Group
   /// Creates an empty group.
   explicit Group();
 
-  Group( unsigned id, QString name_ );
+  Group( quint64 id, QString name_ );
 
   /// Makes the configuration group from the current contents.
   Config::Group makeConfigGroup();
@@ -49,7 +49,7 @@ struct Groups: vector< Group >
 {
   /// Tries finding the given group by its id.
   /// @return The group found, or nullptr if there's no such group.
-  const Group * findGroup( unsigned id ) const;
+  const Group * findGroup( quint64 id ) const;
 };
 
 /// Adds any dictionaries not already present in the given group or in

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -284,7 +284,7 @@ ArticleView::~ArticleView()
 }
 
 void ArticleView::showDefinition( const QString & word,
-                                  unsigned group,
+                                  quint64 group,
                                   const QString & scrollTo,
                                   const Contexts & contexts_ )
 {
@@ -359,7 +359,7 @@ void ArticleView::showDefinition( const QString & word,
 void ArticleView::showDefinition( const QString & word,
                                   const QStringList & dictIDs,
                                   const QRegularExpression & searchRegExp,
-                                  unsigned group,
+                                  quint64 group,
                                   bool ignoreDiacritics )
 {
   if ( dictIDs.isEmpty() ) {
@@ -414,7 +414,7 @@ void ArticleView::showDefinition( const QString & word,
 
 void ArticleView::showDefinition( const QString & word,
                                   const QStringList & dictIDs,
-                                  unsigned group,
+                                  quint64 group,
                                   bool ignoreDiacritics )
 {
   showDefinition( word, dictIDs, {}, group, ignoreDiacritics );
@@ -1293,7 +1293,7 @@ void ArticleView::updateMutedContents()
     return;
   }
 
-  unsigned group = getGroup( currentUrl );
+  quint64 group = getGroup( currentUrl );
 
   if ( !group ) {
     return; // No group in url -- do nothing
@@ -1885,7 +1885,7 @@ void ArticleView::pasteTriggered()
   QString word = cfg.preferences.sanitizeInputPhrase( QApplication::clipboard()->text() );
 
   if ( !word.isEmpty() ) {
-    unsigned groupId = getGroup( webview->url() ); // Try to get group from the current article URL
+    quint64 groupId = getGroup( webview->url() ); // Try to get group from the current article URL
 
     // If the group couldn't be determined from the URL (e.g., on internal or external pages),
     // fall back to the currently selected group in the UI.

--- a/src/ui/articleview.hh
+++ b/src/ui/articleview.hh
@@ -302,10 +302,8 @@ signals:
   /// Signals that the following link was requested to be opened in new tab
   void openLinkInNewTab( const QUrl &, const QUrl & referrer, const QString & fromArticle, const Contexts & contexts );
   /// Signals that the following definition was requested to be showed in new tab
-  void showDefinitionInNewTab( const QString & word,
-                               quint64 group,
-                               const QString & fromArticle,
-                               const Contexts & contexts );
+  void
+  showDefinitionInNewTab( const QString & word, quint64 group, const QString & fromArticle, const Contexts & contexts );
 
   /// Put translated word into history
   void sendWordToHistory( const QString & word );

--- a/src/ui/articleview.hh
+++ b/src/ui/articleview.hh
@@ -128,16 +128,16 @@ public:
   /// The only values to pass here are ones obtained from showDefinitionInNewTab()
   /// signal or none at all.
   void showDefinition( const QString & word,
-                       unsigned group,
+                       quint64 group,
                        const QString & scrollTo  = QString(),
                        const Contexts & contexts = Contexts() );
 
   void showDefinition( const QString & word,
                        const QStringList & dictIDs,
                        const QRegularExpression & searchRegExp,
-                       unsigned group,
+                       quint64 group,
                        bool ignoreDiacritics );
-  void showDefinition( const QString & word, const QStringList & dictIDs, unsigned group, bool ignoreDiacritics );
+  void showDefinition( const QString & word, const QStringList & dictIDs, quint64 group, bool ignoreDiacritics );
 
   void sendToAnki( const QString & word, const QString & text, const QString & sentence );
   /// Clears the view and sets the application-global waiting cursor,
@@ -303,7 +303,7 @@ signals:
   void openLinkInNewTab( const QUrl &, const QUrl & referrer, const QString & fromArticle, const Contexts & contexts );
   /// Signals that the following definition was requested to be showed in new tab
   void showDefinitionInNewTab( const QString & word,
-                               unsigned group,
+                               quint64 group,
                                const QString & fromArticle,
                                const Contexts & contexts );
 

--- a/src/ui/edit_dictionaries.cc
+++ b/src/ui/edit_dictionaries.cc
@@ -70,7 +70,7 @@ EditDictionaries::EditDictionaries( QWidget * parent,
   connect( ui.tabs, &QTabWidget::currentChanged, this, &EditDictionaries::currentChanged );
 }
 
-void EditDictionaries::editGroup( unsigned id )
+void EditDictionaries::editGroup( quint64 id )
 {
   ui.tabs->setTabVisible( 0, false );
 

--- a/src/ui/edit_dictionaries.hh
+++ b/src/ui/edit_dictionaries.hh
@@ -29,7 +29,7 @@ public:
   ~EditDictionaries();
 
   /// Instructs the dialog to position itself on editing the given group.
-  void editGroup( unsigned id );
+  void editGroup( quint64 id );
 
   /// Returns true if any changes to the 'dictionaries' vector passed were done.
   bool areDictionariesChanged() const

--- a/src/ui/edit_groups.cc
+++ b/src/ui/edit_groups.cc
@@ -68,10 +68,10 @@ void Groups::resetData( const vector< sptr< Dictionary::Class > > & dicts_,
   ui.dictionaries->populate( Instances::Group( order, dicts_, Config::Group() ).dictionaries, dicts_ );
 
   // Populate groups' widget
-  ui.groups->populate( groups_, dicts_, ui.dictionaries->getCurrentDictionaries() );
+  ui.groups->populate( groups_, 1, dicts_, ui.dictionaries->getCurrentDictionaries() );
 }
 
-void Groups::editGroup( unsigned id )
+void Groups::editGroup( quint64 id )
 {
   for ( int x = 0; x < groups.size(); ++x ) {
     if ( groups[ x ].id == id ) {

--- a/src/ui/edit_groups.cc
+++ b/src/ui/edit_groups.cc
@@ -68,7 +68,7 @@ void Groups::resetData( const vector< sptr< Dictionary::Class > > & dicts_,
   ui.dictionaries->populate( Instances::Group( order, dicts_, Config::Group() ).dictionaries, dicts_ );
 
   // Populate groups' widget
-  ui.groups->populate( groups_, 1, dicts_, ui.dictionaries->getCurrentDictionaries() );
+  ui.groups->populate( groups_, dicts_, ui.dictionaries->getCurrentDictionaries() );
 }
 
 void Groups::editGroup( quint64 id )

--- a/src/ui/edit_groups.hh
+++ b/src/ui/edit_groups.hh
@@ -21,7 +21,7 @@ public:
                   const Config::Groups & groups_,
                   const Config::Group & order );
   /// Instructs the dialog to position itself on editing the given group.
-  void editGroup( unsigned id );
+  void editGroup( quint64 id );
 
   /// Should be called when the dictionary order has changed to reflect on
   /// that changes. It would only do anything if the order has actually

--- a/src/ui/edit_groups_widgets.cc
+++ b/src/ui/edit_groups_widgets.cc
@@ -656,8 +656,8 @@ int DictGroupsWidget::addNewGroup( const QString & name )
 
   // Generate a random ID using timestamp and random number
   qint64 timestamp = QDateTime::currentMSecsSinceEpoch();
-  quint64 random = QRandomGenerator::global()->generate();
-  newGroup.id = (static_cast<quint64>(timestamp) << 24) | (random & 0xFFFFFF);
+  quint64 random   = QRandomGenerator::global()->generate();
+  newGroup.id      = ( static_cast< quint64 >( timestamp ) << 24 ) | ( random & 0xFFFFFF );
   newGroup.name = name;
 
   const auto gr = new DictGroupWidget( this, *allDicts, newGroup );

--- a/src/ui/edit_groups_widgets.cc
+++ b/src/ui/edit_groups_widgets.cc
@@ -532,7 +532,6 @@ void DictListWidget::rowsAboutToBeRemoved( const QModelIndex & parent, int start
 
 DictGroupsWidget::DictGroupsWidget( QWidget * parent ):
   QTabWidget( parent ),
-  nextId( 1 ),
   allDicts( nullptr ),
   activeDicts( nullptr )
 {
@@ -573,8 +572,6 @@ void DictGroupsWidget::populate( const Config::Groups & groups,
     QString toolTipStr = tr( "Dictionaries: " ) + QString::number( getDictionaryCountAt( x ) );
     setTabToolTip( x, toolTipStr );
   }
-
-  nextId = groups.nextId;
 
   setCurrentIndex( 0 );
 }
@@ -657,7 +654,10 @@ int DictGroupsWidget::addNewGroup( const QString & name )
 
   Config::Group newGroup;
 
-  newGroup.id   = nextId++;
+  // Generate a random ID using timestamp and random number
+  qint64 timestamp = QDateTime::currentMSecsSinceEpoch();
+  quint64 random = QRandomGenerator::global()->generate();
+  newGroup.id = (static_cast<quint64>(timestamp) << 24) | (random & 0xFFFFFF);
   newGroup.name = name;
 
   const auto gr = new DictGroupWidget( this, *allDicts, newGroup );

--- a/src/ui/edit_groups_widgets.cc
+++ b/src/ui/edit_groups_widgets.cc
@@ -17,6 +17,7 @@
 #include <QMap>
 #include <QMenu>
 #include <QMessageBox>
+#include <QRandomGenerator>
 #include <QTimer>
 #include <QList>
 #include <QToolButton>
@@ -580,8 +581,6 @@ void DictGroupsWidget::populate( const Config::Groups & groups,
 Config::Groups DictGroupsWidget::makeGroups() const
 {
   Config::Groups result;
-
-  result.nextId = nextId;
 
   for ( int x = 0; x < count(); ++x ) {
     result.push_back( dynamic_cast< DictGroupWidget & >( *widget( x ) ).makeGroup() );

--- a/src/ui/edit_groups_widgets.hh
+++ b/src/ui/edit_groups_widgets.hh
@@ -145,7 +145,7 @@ private slots:
 
 private:
   Ui::DictGroupWidget ui;
-  unsigned groupId;
+  quint64 groupId;
   QString groupName;
 
 signals:

--- a/src/ui/edit_groups_widgets.hh
+++ b/src/ui/edit_groups_widgets.hh
@@ -162,9 +162,9 @@ public:
   DictGroupsWidget( QWidget * parent );
 
   /// Creates all the tabs with the groups
-  void populate( const Config::Groups &,
-                 const std::vector< sptr< Dictionary::Class > > & allDicts,
-                 const std::vector< sptr< Dictionary::Class > > & activeDicts );
+  void populate( const Config::Groups & groups,
+                 const std::vector< sptr< Dictionary::Class > > & allDicts_,
+                 const std::vector< sptr< Dictionary::Class > > & activeDicts_ );
 
   /// Creates new empty group with the given name
   int addNewGroup( const QString & );
@@ -213,7 +213,7 @@ private:
   /// Add source group to target group
   void combineGroups( int source, int target );
 
-  unsigned nextId;
+
   const std::vector< sptr< Dictionary::Class > > * allDicts;
   const std::vector< sptr< Dictionary::Class > > * activeDicts;
 

--- a/src/ui/groupcombobox.cc
+++ b/src/ui/groupcombobox.cc
@@ -33,10 +33,10 @@ GroupComboBox::GroupComboBox( QWidget * parent ):
 
 void GroupComboBox::fill( const Instances::Groups & groups )
 {
-  unsigned prevId = 0;
+  quint64 prevId = 0;
 
   if ( count() ) {
-    prevId = itemData( currentIndex() ).toUInt();
+    prevId = itemData( currentIndex() ).toULongLong();
   }
 
   clear();
@@ -116,23 +116,23 @@ QList< QAction * > GroupComboBox::getExternActions()
   return list;
 }
 
-void GroupComboBox::setCurrentGroup( unsigned id )
+void GroupComboBox::setCurrentGroup( quint64 id )
 {
   for ( int x = 0; x < count(); ++x ) {
-    if ( itemData( x ).toUInt() == id ) {
+    if ( itemData( x ).toULongLong() == id ) {
       setCurrentIndex( x );
       break;
     }
   }
 }
 
-unsigned GroupComboBox::getCurrentGroup() const
+quint64 GroupComboBox::getCurrentGroup() const
 {
   if ( !count() ) {
     return 0;
   }
 
-  return itemData( currentIndex() ).toUInt();
+  return itemData( currentIndex() ).toULongLong();
 }
 
 void GroupComboBox::popupGroups()

--- a/src/ui/groupcombobox.hh
+++ b/src/ui/groupcombobox.hh
@@ -22,11 +22,11 @@ public:
 
   /// Chooses the given group in the combobox. If there's no such group,
   /// does nothing.
-  void setCurrentGroup( unsigned id );
+  void setCurrentGroup( quint64 id );
 
 
   /// Returns current group.
-  unsigned getCurrentGroup() const;
+  quint64 getCurrentGroup() const;
 
   /// Return actions which should be accessible from FTS and Headwords dialogs
   QList< QAction * > getExternActions();

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -2180,7 +2180,7 @@ void MainWindow::updatePronounceAvailability()
   }
 }
 
-void MainWindow::editDictionaries( unsigned editDictionaryGroup )
+void MainWindow::editDictionaries( quint64 editDictionaryGroup )
 {
   hotkeyWrapper.reset(); // No hotkeys while we're editing dictionaries
   closeHeadwordsDialog();
@@ -2211,7 +2211,7 @@ void MainWindow::editDictionaries( unsigned editDictionaryGroup )
       ftsIndexing.clearDictionaries();
       // Set muted dictionaries from old groups
       for ( auto & group : newCfg.groups ) {
-        unsigned id = group.id;
+        quint64 id = group.id;
         if ( id != GroupId::NoGroupId ) {
           const Config::Group * grp = cfg.getGroup( id );
           if ( grp ) {
@@ -2369,7 +2369,7 @@ void MainWindow::editPreferences()
 
 void MainWindow::currentGroupChanged( int )
 {
-  unsigned grg_id               = groupList->getCurrentGroup();
+  quint64 grg_id               = groupList->getCurrentGroup();
   cfg.lastMainGroupId           = grg_id;
   const Instances::Group * igrp = groupInstances.findGroup( grg_id );
   if ( grg_id == GroupId::AllGroupId ) {
@@ -2805,7 +2805,7 @@ void MainWindow::openLinkInNewTab( const QUrl & url,
 }
 
 void MainWindow::showDefinitionInNewTab( const QString & word,
-                                         unsigned group,
+                                         quint64 group,
                                          const QString & fromArticle,
                                          const Contexts & contexts )
 {
@@ -2920,7 +2920,7 @@ void MainWindow::showTranslationFor( const QString & word, unsigned inGroup, con
 
   navPronounce->setEnabled( false );
 
-  unsigned group = inGroup;
+  quint64 group = inGroup;
   if ( group == 0 ) {
     group = groupInstances.empty() ? 0 : groupInstances[ groupList->currentIndex() ].id;
   }
@@ -4226,7 +4226,7 @@ void MainWindow::showFullTextSearchDialog()
              Qt::QueuedConnection );
     connect( &configEvents, SIGNAL( mutedDictionariesChanged() ), ftsDlg, SLOT( updateDictionaries() ) );
 
-    unsigned group = groupInstances.empty() ? 0 : groupInstances[ groupList->currentIndex() ].id;
+    quint64 group = groupInstances.empty() ? 0 : groupInstances[ groupList->currentIndex() ].id;
     ftsDlg->setCurrentGroup( group );
   }
 

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -2369,7 +2369,7 @@ void MainWindow::editPreferences()
 
 void MainWindow::currentGroupChanged( int )
 {
-  quint64 grg_id               = groupList->getCurrentGroup();
+  quint64 grg_id                = groupList->getCurrentGroup();
   cfg.lastMainGroupId           = grg_id;
   const Instances::Group * igrp = groupInstances.findGroup( grg_id );
   if ( grg_id == GroupId::AllGroupId ) {

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -330,7 +330,7 @@ private slots:
 
   /// If editDictionaryGroup is specified, the dialog positions on that group
   /// initially.
-  void editDictionaries( unsigned editDictionaryGroup = GroupId::NoGroupId );
+  void editDictionaries( quint64 editDictionaryGroup = GroupId::NoGroupId );
   /// Edits current group when triggered from the dictionary bar.
   void editCurrentGroup();
   void editPreferences();
@@ -364,7 +364,7 @@ private slots:
 
   void openLinkInNewTab( const QUrl &, const QUrl &, const QString &, const Contexts & contexts );
   void showDefinitionInNewTab( const QString & word,
-                               unsigned group,
+                               quint64 group,
                                const QString & fromArticle,
                                const Contexts & contexts );
   void typingEvent( const QString & );

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -363,10 +363,8 @@ private slots:
   ArticleView * findArticleViewByDictId( const QString & dictId );
 
   void openLinkInNewTab( const QUrl &, const QUrl &, const QString &, const Contexts & contexts );
-  void showDefinitionInNewTab( const QString & word,
-                               quint64 group,
-                               const QString & fromArticle,
-                               const Contexts & contexts );
+  void
+  showDefinitionInNewTab( const QString & word, quint64 group, const QString & fromArticle, const Contexts & contexts );
   void typingEvent( const QString & );
 
   void activeArticleChanged( const ArticleView *, const QString & id );

--- a/src/ui/scanpopup.hh
+++ b/src/ui/scanpopup.hh
@@ -59,7 +59,7 @@ public:
 signals:
 
   /// Forwarded from the dictionary bar, so that main window could act on this.
-  void editGroupRequest( unsigned id );
+  void editGroupRequest( quint64 id );
   /// Send word to main window
   void sendPhraseToMainWindow( const QString & word );
   /// Close opened menus when window hide


### PR DESCRIPTION
- Changed Group::id type to quint64
- Replaced Groups struct with QList<Group> alias
- Removed nextGroupId tracking
- Updated ID generation to use timestamp + random number
- Simplified config loading/saving