### PR TITLE
refactor(js): replace 'window' with 'globalThis' for global object ac…

### DIFF
--- a/src/scripts/gd-builtin.js
+++ b/src/scripts/gd-builtin.js
@@ -30,7 +30,7 @@ function gdMakeArticleActive(newId, noEvent) {
 var overIframeId = null;
 
 function gdSelectArticle(id) {
-  var selection = window.getSelection();
+  var selection = globalThis.getSelection();
   var range = document.createRange();
   range.selectNodeContents(document.getElementById("gdfrom-" + id));
   selection.removeAllRanges();
@@ -54,9 +54,9 @@ function processIframeClick() {
 }
 
 function init() {
-  window.addEventListener("blur", processIframeClick, false);
+  globalThis.addEventListener("blur", processIframeClick, false);
 }
-window.addEventListener("load", init, false);
+globalThis.addEventListener("load", init, false);
 
 function gdExpandOptPart(expanderId, optionalId) {
   const d1 = document.getElementById(expanderId);

--- a/src/scripts/gd-custom.js
+++ b/src/scripts/gd-custom.js
@@ -24,7 +24,7 @@ document.addEventListener("DOMContentLoaded", () => {
     emitClickedEvent("");
 
     let newLink;
-    const { href } = window.location;
+    const { href } = globalThis.location;
 
     if (link.startsWith("#")) {
       // the href may contain # fragment already. remove them before append the new #fragment
@@ -45,8 +45,8 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   // monitor iframe height.
-  if (window.iFrameResize) {
-    window.iFrameResize(
+  if (globalThis.iFrameResize) {
+    globalThis.iFrameResize(
       {
         checkOrigin: false,
         maxHeight: 800,

--- a/src/scripts/iframe-defer.js
+++ b/src/scripts/iframe-defer.js
@@ -1,6 +1,6 @@
 var start_time=new Date().getTime();
 
-var interval = setInterval(function () {
+var interval = globalThis.setInterval(function () {
     var end_time=new Date().getTime();
     //for 10 seconds.
     if(end_time-start_time>=10000){
@@ -13,7 +13,7 @@ var interval = setInterval(function () {
     const height = Math.max(body.scrollHeight, body.offsetHeight,
     html.clientHeight, html.scrollHeight, html.offsetHeight);
 
-    if ('parentIFrame' in window) {
+    if ('parentIFrame' in globalThis) {
         console.log("iframe set height to " + height);
         parentIFrame.size(height); 
     }


### PR DESCRIPTION
…cess

- Updated gd-custom.js, gd-builtin.js, and iframe-defer.js to use globalThis.
- Resolves SonarCloud warning: "Prefer `globalThis` over `window`".
- Improves consistency and alignment with ES2020+ standards.