### PR TITLE
fix(dict): fix potential crash in MediaWiki on macOS

### DIFF
--- a/src/dict/mediawiki.cc
+++ b/src/dict/mediawiki.cc
@@ -480,9 +480,9 @@ void MediaWikiArticleRequest::requestFinished( QNetworkReply * r )
     QNetworkReply * netReply = netReplies.front().first;
     netReplies.pop_front();
 
-    // Disconnect and schedule deletion early so we can safely use 'continue'
-    disconnect( netReply, nullptr, nullptr, nullptr );
-    netReply->deleteLater();
+    if ( !netReply ) {
+      continue;
+    }
 
     if ( netReply->error() != QNetworkReply::NoError ) {
       setErrorString( netReply->errorString() );


### PR DESCRIPTION
- Remove redundant and potentially unsafe disconnect() call in MediaWikiArticleRequest::requestFinished