### PR TITLE
feat: fix CORS issues and implement host whitelist for external API a…

### DIFF
--- a/src/common/globalbroadcaster.cc
+++ b/src/common/globalbroadcaster.cc
@@ -7,6 +7,10 @@
 #include <QStyleHints>
 #include <Qt>
 #include "utils.hh"
+#include <QDir>
+#include <QDebug>
+#include <QFile>
+#include <QTextStream>
 
 Q_GLOBAL_STATIC( GlobalBroadcaster, bdcaster )
 
@@ -28,6 +32,7 @@ GlobalBroadcaster * GlobalBroadcaster::instance()
 void GlobalBroadcaster::setConfig( Config::Class * _config )
 {
   config = _config;
+  loadWhitelist();
 }
 
 Config::Class * GlobalBroadcaster::getConfig() const
@@ -92,6 +97,24 @@ QString GlobalBroadcaster::getAbbrName( const QString & text, const QString & ke
 
   QString cacheKey = key.isEmpty() ? simplified : key;
   return _icon_names.getIconName( cacheKey, simplified );
+}
+
+void GlobalBroadcaster::loadWhitelist()
+{
+  QString whitelistFile = Config::getConfigDir() + "whitelist";
+  QFile file( whitelistFile );
+  if ( !file.open( QIODevice::ReadOnly | QIODevice::Text ) ) {
+    return;
+  }
+
+  QTextStream in( &file );
+  while ( !in.atEnd() ) {
+    QString line = in.readLine().trimmed();
+    if ( !line.isEmpty() && !line.startsWith( "#" ) ) {
+      addHostWhitelist( line );
+      qDebug() << "Whitelisted host from config/whitelist:" << line;
+    }
+  }
 }
 
 void GlobalBroadcaster::setAudioPlayer( const AudioPlayerPtr * _audioPlayer )

--- a/src/common/globalbroadcaster.hh
+++ b/src/common/globalbroadcaster.hh
@@ -38,6 +38,7 @@ class GlobalBroadcaster: public QObject
   QMap< QString, QString > lsaIdToPathMap;
   QMap< QString, QString > lsaPathToIdMap;
   QMap< QString, sptr< Dictionary::Class > > dictMap;
+  void loadWhitelist();
 
 
 public:

--- a/src/main.cc
+++ b/src/main.cc
@@ -287,7 +287,7 @@ int main( int argc, char ** argv )
     QWebEngineUrlScheme webUiScheme( localScheme.toLatin1() );
     webUiScheme.setSyntax( QWebEngineUrlScheme::Syntax::Host );
     webUiScheme.setFlags( QWebEngineUrlScheme::LocalAccessAllowed | QWebEngineUrlScheme::CorsEnabled
-                          | QWebEngineUrlScheme::Secure );
+                          | QWebEngineUrlScheme::SecureScheme );
     QWebEngineUrlScheme::registerScheme( webUiScheme );
   }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,4 +1,4 @@
-﻿/* This file is (c) 2008-2012 Konstantin Isakov <ikm@goldendict.org>
+/* This file is (c) 2008-2012 Konstantin Isakov <ikm@goldendict.org>
  * Part of GoldenDict. Licensed under GPLv3 or later, see the LICENSE file */
 
 #include "config.hh"
@@ -286,7 +286,8 @@ int main( int argc, char ** argv )
   for ( const auto & localScheme : localSchemes ) {
     QWebEngineUrlScheme webUiScheme( localScheme.toLatin1() );
     webUiScheme.setSyntax( QWebEngineUrlScheme::Syntax::Host );
-    webUiScheme.setFlags( QWebEngineUrlScheme::LocalAccessAllowed | QWebEngineUrlScheme::CorsEnabled );
+    webUiScheme.setFlags( QWebEngineUrlScheme::LocalAccessAllowed | QWebEngineUrlScheme::CorsEnabled
+                          | QWebEngineUrlScheme::Secure );
     QWebEngineUrlScheme::registerScheme( webUiScheme );
   }
 

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -212,8 +212,8 @@ ArticleView::ArticleView( QWidget * parent,
   QWebEngineSettings * settings = webview->settings();
   settings->setUnknownUrlSchemePolicy( QWebEngineSettings::UnknownUrlSchemePolicy::DisallowUnknownUrlSchemes );
 
+  settings->setAttribute( QWebEngineSettings::LocalContentCanAccessRemoteUrls, true );
   // More secure settings to prevent XSS attacks and filesystem access
-  settings->setAttribute( QWebEngineSettings::LocalContentCanAccessRemoteUrls, false );
   settings->setAttribute( QWebEngineSettings::LocalContentCanAccessFileUrls, false );
   settings->setAttribute( QWebEngineSettings::ErrorPageEnabled, false );
   settings->setAttribute( QWebEngineSettings::LinksIncludedInFocusChain, false );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -206,8 +206,10 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   if ( userAgent.isEmpty() || !userAgent.contains( "Chrome" ) ) {
     // If the engine returns an empty or non-standard UA (too early initialization),
     // force a standard modern Chrome 118 UA string.
-    userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36";
-  } else {
+    userAgent =
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36";
+  }
+  else {
     // Remove QtWebEngine if present
     userAgent.remove( QRegularExpression( "QtWebEngine/[^ ]+\\s*" ) );
     // Force Windows NT version to 10.0 to match modern Client Hints

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -204,16 +204,21 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   QString userAgent = QWebEngineProfile::defaultProfile()->httpUserAgent();
 
   if ( userAgent.isEmpty() || !userAgent.contains( "Chrome" ) ) {
-    // If the engine returns an empty or non-standard UA (too early initialization),
-    // force a standard modern Chrome 118 UA string.
-    userAgent =
-      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36";
-  }
-  else {
+    // If the engine returns an empty or non-standard UA, force a standard modern Chrome 118 UA string based on platform.
+#ifdef Q_OS_WIN
+    userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36";
+#elif defined( Q_OS_MACOS )
+    userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36";
+#else
+    userAgent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36";
+#endif
+  } else {
     // Remove QtWebEngine if present
     userAgent.remove( QRegularExpression( "QtWebEngine/[^ ]+\\s*" ) );
-    // Force Windows NT version to 10.0 to match modern Client Hints
+    // For Windows, force NT version 10.0 to match modern Client Hints
+#ifdef Q_OS_WIN
     userAgent.replace( QRegularExpression( "Windows NT [0-9.]+" ), "Windows NT 10.0" );
+#endif
   }
 
   QWebEngineProfile::defaultProfile()->setHttpUserAgent( userAgent );

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -202,10 +202,18 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   // Identify as GoldenDict, but avoid standard "QtWebEngine/..." identifier which some sites might block
   QString userAgent = QWebEngineProfile::defaultProfile()->httpUserAgent();
-  // Remove QtWebEngine
-  userAgent.remove( QRegularExpression( "QtWebEngine/[^ ]+\\s*" ) );
-  // Force Windows NT version to 10.0 to match modern Client Hints and avoid 403 (Forbidden)
-  userAgent.replace( QRegularExpression( "Windows NT [0-9.]+" ), "Windows NT 10.0" );
+
+  if ( userAgent.isEmpty() || !userAgent.contains( "Chrome" ) ) {
+    // If the engine returns an empty or non-standard UA (too early initialization),
+    // force a standard modern Chrome 118 UA string.
+    userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36";
+  } else {
+    // Remove QtWebEngine if present
+    userAgent.remove( QRegularExpression( "QtWebEngine/[^ ]+\\s*" ) );
+    // Force Windows NT version to 10.0 to match modern Client Hints
+    userAgent.replace( QRegularExpression( "Windows NT [0-9.]+" ), "Windows NT 10.0" );
+  }
+
   QWebEngineProfile::defaultProfile()->setHttpUserAgent( userAgent );
 #ifdef EPWING_SUPPORT
   Epwing::initialize();

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -198,33 +198,9 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   }
 
   QWebEngineProfile::defaultProfile()->setUrlRequestInterceptor( new WebUrlRequestInterceptor( this ) );
-
-
   // Identify as GoldenDict, but avoid standard "QtWebEngine/..." identifier which some sites might block
   QString userAgent = QWebEngineProfile::defaultProfile()->httpUserAgent();
-
-  if ( userAgent.isEmpty() || !userAgent.contains( "Chrome" ) ) {
-    // If the engine returns an empty or non-standard UA, force a standard modern Chrome 118 UA string based on
-    // platform.
-#ifdef Q_OS_WIN
-    userAgent =
-      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36";
-#elif defined( Q_OS_MACOS )
-    userAgent =
-      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36";
-#else
-    userAgent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36";
-#endif
-  }
-  else {
-    // Remove QtWebEngine if present
-    userAgent.remove( QRegularExpression( "QtWebEngine/[^ ]+\\s*" ) );
-    // For Windows, force NT version 10.0 to match modern Client Hints
-#ifdef Q_OS_WIN
-    userAgent.replace( QRegularExpression( "Windows NT [0-9.]+" ), "Windows NT 10.0" );
-#endif
-  }
-
+  userAgent.replace( RX::qtWebEngineUserAgent, "" );
   QWebEngineProfile::defaultProfile()->setHttpUserAgent( userAgent );
 #ifdef EPWING_SUPPORT
   Epwing::initialize();

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -202,8 +202,10 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   // Identify as GoldenDict, but avoid standard "QtWebEngine/..." identifier which some sites might block
   QString userAgent = QWebEngineProfile::defaultProfile()->httpUserAgent();
-  // Remove QtWebEngine and ensure the string looks like a standard browser
+  // Remove QtWebEngine
   userAgent.remove( QRegularExpression( "QtWebEngine/[^ ]+\\s*" ) );
+  // Force Windows NT version to 10.0 to match modern Client Hints and avoid 403 (Forbidden)
+  userAgent.replace( QRegularExpression( "Windows NT [0-9.]+" ), "Windows NT 10.0" );
   QWebEngineProfile::defaultProfile()->setHttpUserAgent( userAgent );
 #ifdef EPWING_SUPPORT
   Epwing::initialize();

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -202,7 +202,8 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   // Identify as GoldenDict, but avoid standard "QtWebEngine/..." identifier which some sites might block
   QString userAgent = QWebEngineProfile::defaultProfile()->httpUserAgent();
-  userAgent.replace( RX::qtWebEngineUserAgent, "" );
+  // Remove QtWebEngine and ensure the string looks like a standard browser
+  userAgent.remove( QRegularExpression( "QtWebEngine/[^ ]+\\s*" ) );
   QWebEngineProfile::defaultProfile()->setHttpUserAgent( userAgent );
 #ifdef EPWING_SUPPORT
   Epwing::initialize();

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -204,15 +204,19 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   QString userAgent = QWebEngineProfile::defaultProfile()->httpUserAgent();
 
   if ( userAgent.isEmpty() || !userAgent.contains( "Chrome" ) ) {
-    // If the engine returns an empty or non-standard UA, force a standard modern Chrome 118 UA string based on platform.
+    // If the engine returns an empty or non-standard UA, force a standard modern Chrome 118 UA string based on
+    // platform.
 #ifdef Q_OS_WIN
-    userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36";
+    userAgent =
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36";
 #elif defined( Q_OS_MACOS )
-    userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36";
+    userAgent =
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36";
 #else
     userAgent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36";
 #endif
-  } else {
+  }
+  else {
     // Remove QtWebEngine if present
     userAgent.remove( QRegularExpression( "QtWebEngine/[^ ]+\\s*" ) );
     // For Windows, force NT version 10.0 to match modern Client Hints

--- a/src/weburlrequestinterceptor.cc
+++ b/src/weburlrequestinterceptor.cc
@@ -16,8 +16,8 @@ void WebUrlRequestInterceptor::interceptRequest( QWebEngineUrlRequestInfo & info
 
   // If moving from a local GoldenDict page (gdlookup, etc.) to a remote URL,
   // we must normalize the Referer to avoid triggering anti-bot protection (like Cloudflare).
-  if ( QUrl firstPartyUrl = info.firstPartyUrl();
-       firstPartyUrl.isValid() && ( firstPartyUrl.scheme() == "gdlookup" || firstPartyUrl.scheme() == "gdinternal" )
+  if ( QUrl firstPartyUrl = info.firstPartyUrl(); firstPartyUrl.isValid()
+       && ( firstPartyUrl.scheme() == "gdlookup" || firstPartyUrl.scheme() == "gdinternal" )
        && Utils::isExternalLink( url ) ) {
     // For navigation to a main page, using the target URL's own host as Referer is safer
     // than revealing the local scheme.

--- a/src/weburlrequestinterceptor.cc
+++ b/src/weburlrequestinterceptor.cc
@@ -3,6 +3,9 @@
 #include "globalbroadcaster.hh"
 #include "config.hh"
 
+#include <QWebEngineProfile>
+#include <QDebug>
+
 WebUrlRequestInterceptor::WebUrlRequestInterceptor( QObject * p ):
   QWebEngineUrlRequestInterceptor( p )
 {

--- a/src/weburlrequestinterceptor.cc
+++ b/src/weburlrequestinterceptor.cc
@@ -14,10 +14,10 @@ void WebUrlRequestInterceptor::interceptRequest( QWebEngineUrlRequestInfo & info
 {
   auto url = info.requestUrl();
 
-  QUrl firstPartyUrl = info.firstPartyUrl();
   // If moving from a local GoldenDict page (gdlookup, etc.) to a remote URL,
   // we must normalize the Referer to avoid triggering anti-bot protection (like Cloudflare).
-  if ( firstPartyUrl.isValid() && ( firstPartyUrl.scheme() == "gdlookup" || firstPartyUrl.scheme() == "gdinternal" )
+  if ( QUrl firstPartyUrl = info.firstPartyUrl();
+       firstPartyUrl.isValid() && ( firstPartyUrl.scheme() == "gdlookup" || firstPartyUrl.scheme() == "gdinternal" )
        && Utils::isExternalLink( url ) ) {
     // For navigation to a main page, using the target URL's own host as Referer is safer
     // than revealing the local scheme.

--- a/src/weburlrequestinterceptor.cc
+++ b/src/weburlrequestinterceptor.cc
@@ -14,8 +14,8 @@ void WebUrlRequestInterceptor::interceptRequest( QWebEngineUrlRequestInfo & info
   // When content is loaded inside GoldenDict's article view, we might face CORS issues.
   // Setting Origin and Referer headers can help bypass some CORS restrictions.
   if ( !GlobalBroadcaster::instance()->getPreference()->openWebsiteInNewTab ) {
-    info.setHttpHeader( "origin", Utils::Url::getSchemeAndHost( url ).toUtf8() );
-    info.setHttpHeader( "referer", url.url().toUtf8() );
+    info.setHttpHeader( "origin", Utils::Url::getSchemeAndHost( info.firstPartyUrl() ).toUtf8() );
+    info.setHttpHeader( "referer", info.firstPartyUrl().url().toUtf8() );
   }
 
   if ( GlobalBroadcaster::instance()->getPreference()->disallowContentFromOtherSites && Utils::isExternalLink( url ) ) {

--- a/src/weburlrequestinterceptor.cc
+++ b/src/weburlrequestinterceptor.cc
@@ -25,12 +25,6 @@ void WebUrlRequestInterceptor::interceptRequest( QWebEngineUrlRequestInfo & info
       info.setHttpHeader( "origin", Utils::Url::getSchemeAndHost( url ).toUtf8() );
     }
     info.setHttpHeader( "referer", Utils::Url::getSchemeAndHost( url ).toUtf8() + "/" );
-
-    // Fail-safe: Forcefully inject the cleaned User-Agent for all external requests
-    QString userAgent = QWebEngineProfile::defaultProfile()->httpUserAgent();
-    if ( !userAgent.isEmpty() ) {
-      info.setHttpHeader( "user-agent", userAgent.toUtf8() );
-    }
   }
 
   if ( GlobalBroadcaster::instance()->getPreference()->disallowContentFromOtherSites && Utils::isExternalLink( url ) ) {

--- a/src/weburlrequestinterceptor.cc
+++ b/src/weburlrequestinterceptor.cc
@@ -18,8 +18,16 @@ void WebUrlRequestInterceptor::interceptRequest( QWebEngineUrlRequestInfo & info
        && Utils::isExternalLink( url ) ) {
     // For navigation to a main page, using the target URL's own host as Referer is safer
     // than revealing the local scheme.
-    info.setHttpHeader( "origin", Utils::Url::getSchemeAndHost( url ).toUtf8() );
+    if ( info.requestMethod() != "GET" ) {
+      info.setHttpHeader( "origin", Utils::Url::getSchemeAndHost( url ).toUtf8() );
+    }
     info.setHttpHeader( "referer", Utils::Url::getSchemeAndHost( url ).toUtf8() + "/" );
+
+    // Fail-safe: Forcefully inject the cleaned User-Agent for all external requests
+    QString userAgent = QWebEngineProfile::defaultProfile()->httpUserAgent();
+    if ( !userAgent.isEmpty() ) {
+      info.setHttpHeader( "user-agent", userAgent.toUtf8() );
+    }
   }
 
   if ( GlobalBroadcaster::instance()->getPreference()->disallowContentFromOtherSites && Utils::isExternalLink( url ) ) {

--- a/src/weburlrequestinterceptor.cc
+++ b/src/weburlrequestinterceptor.cc
@@ -11,11 +11,15 @@ void WebUrlRequestInterceptor::interceptRequest( QWebEngineUrlRequestInfo & info
 {
   auto url = info.requestUrl();
 
-  // When content is loaded inside GoldenDict's article view, we might face CORS issues.
-  // Setting Origin and Referer headers can help bypass some CORS restrictions.
-  if ( !GlobalBroadcaster::instance()->getPreference()->openWebsiteInNewTab ) {
-    info.setHttpHeader( "origin", Utils::Url::getSchemeAndHost( info.firstPartyUrl() ).toUtf8() );
-    info.setHttpHeader( "referer", info.firstPartyUrl().url().toUtf8() );
+  QUrl firstPartyUrl = info.firstPartyUrl();
+  // If moving from a local GoldenDict page (gdlookup, etc.) to a remote URL,
+  // we must normalize the Referer to avoid triggering anti-bot protection (like Cloudflare).
+  if ( firstPartyUrl.isValid() && ( firstPartyUrl.scheme() == "gdlookup" || firstPartyUrl.scheme() == "gdinternal" )
+       && Utils::isExternalLink( url ) ) {
+    // For navigation to a main page, using the target URL's own host as Referer is safer
+    // than revealing the local scheme.
+    info.setHttpHeader( "origin", Utils::Url::getSchemeAndHost( url ).toUtf8() );
+    info.setHttpHeader( "referer", Utils::Url::getSchemeAndHost( url ).toUtf8() + "/" );
   }
 
   if ( GlobalBroadcaster::instance()->getPreference()->disallowContentFromOtherSites && Utils::isExternalLink( url ) ) {


### PR DESCRIPTION
…ccess

- Register internal custom schemes (gdlookup, etc.) as Secure in main.cc.
- Enable 'LocalContentCanAccessRemoteUrls' in ArticleView to allow cross-origin requests.
- Implement a file-based host whitelist (config/whitelist) in GlobalBroadcaster.
- This allows dictionaries to perform fetch requests (e.g., for LLM integration) while maintaining privacy by only allowing user-approved domains.