### PR TITLE
fix(mdx): handle protocol-relative URLs correctly in articles and CSS

### DIFF
--- a/src/common/globalregex.cc
+++ b/src/common/globalregex.cc
@@ -40,19 +40,19 @@ QRegularExpression Mdx::anchorLinkRe( R"(([\s"']href\s*=\s*["'])entry://#)",
 const QRegularExpression Mdx::audioRe( R"(([\s"']href\s*=)\s*(["'])sound://([^">]+)\2)",
                                        QRegularExpression::CaseInsensitiveOption );
 const QRegularExpression Mdx::stylesRe(
-  R"(([\s"']href\s*=)\s*(["'])(?!\s*\b(?:(?:bres|https?|ftp)://|(?:data|javascript):))(?:file://)?[\x00-\x1f\x7f]*\.*/?([^">]+)\2)",
+  R"(([\s"']href\s*=)\s*(["'])(?!\s*(?:\b(?:bres|https?|ftp)://|(?:data|javascript):|//))(?:file://)?[\x00-\x1f\x7f]*\.*/?([^">]+)\2)",
   QRegularExpression::CaseInsensitiveOption );
 QRegularExpression Mdx::stylesRe2(
-  R"(([\s"']href\s*=)\s*(?![\s"']|\b(?:(?:bres|https?|ftp)://|(?:data|javascript):))(?:file://)?[\x00-\x1f\x7f]*\.*/?([^\s">]+))",
+  R"(([\s"']href\s*=)\s*(?![\s"']|\b(?:(?:bres|https?|ftp)://|(?:data|javascript):)|//)(?:file://)?[\x00-\x1f\x7f]*\.*/?([^\s">]+))",
   QRegularExpression::CaseInsensitiveOption );
 QRegularExpression Mdx::inlineScriptRe( R"(<\s*script(?:(?=\s)(?:(?![\s"']src\s*=)[^>])+|\s*)>)",
                                         QRegularExpression::CaseInsensitiveOption );
 QRegularExpression Mdx::closeScriptTagRe( R"(<\s*/script\s*>)", QRegularExpression::CaseInsensitiveOption );
 QRegularExpression Mdx::srcRe(
-  R"(([\s"']src\s*=)\s*(["'])(?!\s*\b(?:(?:bres|https?|ftp)://|(?:data|javascript):))(?:file://)?[\x00-\x1f\x7f]*\.*/?([^">]+)\2)",
+  R"(([\s"']src\s*=)\s*(["'])(?!\s*(?:\b(?:bres|https?|ftp)://|(?:data|javascript):|//))(?:file://)?[\x00-\x1f\x7f]*\.*/?([^">]+)\2)",
   QRegularExpression::CaseInsensitiveOption );
 QRegularExpression Mdx::srcRe2(
-  R"(([\s"']src\s*=)\s*(?![\s"']|\b(?:(?:bres|https?|ftp)://|(?:data|javascript):))(?:file://)?[\x00-\x1f\x7f]*\.*/?([^\s">]+))",
+  R"(([\s"']src\s*=)\s*(?![\s"']|\b(?:(?:bres|https?|ftp)://|(?:data|javascript):)|//)(?:file://)?[\x00-\x1f\x7f]*\.*/?([^\s">]+))",
   QRegularExpression::CaseInsensitiveOption );
 // matches srcset in <img srcset="text">
 QRegularExpression Mdx::srcset( R"((?<before>[\s]srcset\s*=\s*(?<q>["']))(?<text>[^">]*?)(?<after>\k<q>))",

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -724,7 +724,11 @@ QByteArray MddResourceRequest::isolate_css()
     if ( url.indexOf( ":/" ) >= 0 || url.indexOf( "data:" ) >= 0 ) {
       // External link or base64-encoded data
       newCSS += match.captured();
+      continue;
+    }
 
+    if ( url.startsWith( "//" ) ) {
+      newCSS += "url(" + match.captured( 1 ) + "https:" + url + match.captured( 3 ) + ")";
       continue;
     }
 
@@ -914,6 +918,12 @@ void MdxDictionary::loadArticle( uint32_t offset, string & articleText, bool noF
 QString & MdxDictionary::filterResource( QString & article )
 {
   QString id = QString::fromStdString( getId() );
+
+  // Handle protocol-relative URLs (//) - Replace them with https://
+  // This must be done before replaceLinks so they are seen as absolute URLs
+  article.replace( QRegularExpression( R"(([\s"'](?:src|href|data)\s*=\s*["'])\/\/)" ), R"(\1https://)" );
+  article.replace( QRegularExpression( R"(([\s"'](?:src|href|data)\s*=\s*)(?!\s*["'])\/\/)" ), R"(\1https://)" );
+
   replaceLinks( id, article );
 
   // Replace html/body/head with section to avoid hoisting by browser
@@ -1220,8 +1230,11 @@ void MdxDictionary::replaceFontLinks( QString & id, QString & article )
     QString linkType = allLinksMatch.captured( 1 );
     QString newLink  = linkTxt;
 
-    //skip remote url
-    if ( !linkType.contains( ":" ) ) {
+    //skip remote url and handle protocol-relative urls
+    if ( linkType.startsWith( "//" ) ) {
+      newLink = QString( "url(\"https:%1\")" ).arg( linkType );
+    }
+    else if ( !linkType.contains( ":" ) ) {
       newLink = QString( "url(\"bres://%1/%2\")" ).arg( id, linkType );
     }
     articleNewText += newLink;

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -1230,7 +1230,7 @@ void MdxDictionary::replaceFontLinks( QString & id, QString & article )
     QString linkType = allLinksMatch.captured( 1 );
     QString newLink  = linkTxt;
 
-    //skip remote url and handle protocol-relative urls
+    // skip remote url and handle protocol-relative urls
     if ( linkType.startsWith( "//" ) ) {
       newLink = QString( "url(\"https:%1\")" ).arg( linkType );
     }


### PR DESCRIPTION
Fixes a bug where protocol-relative URLs (starting with //) in MDX dictionaries were incorrectly prepended with bres://{id}/.