### PR TITLE
fix(macos): resolve redundant main window popup when using Cmd+C+C

### DIFF
--- a/src/hotkey/hotkeywrapper.hh
+++ b/src/hotkey/hotkeywrapper.hh
@@ -115,6 +115,8 @@ private:
 
 public:
   void activated( int hkId );
+  void suspendHotkeys();
+  void resumeHotkeys();
 
 #endif
 

--- a/src/hotkey/machotkeywrapper.mm
+++ b/src/hotkey/machotkeywrapper.mm
@@ -12,6 +12,7 @@
 
 #import <Appkit/Appkit.h>
 #import <ApplicationServices/ApplicationServices.h>
+#import <Carbon/Carbon.h>
 #include <QClipboard>
 #include <QGuiApplication>
 
@@ -107,7 +108,7 @@ static QString getSelectedTextViaAXAPI()
         return result;
 
     AXUIElementRef focusedElement = NULL;
-    AXError err = AXUIElementCopyAttributeValue(systemWide, kAXFocusedElementAttribute, (CFTypeRef*)&focusedElement);
+    AXError err = AXUIElementCopyAttributeValue(systemWide, kAXFocusedUIElementAttribute, (CFTypeRef*)&focusedElement);
     if (err == kAXErrorSuccess && focusedElement) {
         CFTypeRef selectedText = NULL;
         err = AXUIElementCopyAttributeValue(focusedElement, kAXSelectedTextAttribute, (CFTypeRef*)&selectedText);

--- a/src/hotkey/machotkeywrapper.mm
+++ b/src/hotkey/machotkeywrapper.mm
@@ -103,23 +103,23 @@ static QString getSelectedTextViaAXAPI()
 {
     QString result;
     AXUIElementRef systemWide = AXUIElementCreateSystemWide();
-    if ( !systemWide )
+    if (!systemWide)
         return result;
 
     AXUIElementRef focusedElement = NULL;
-    AXError err = AXUIElementCopyAttributeValue( systemWide, kAXFocusedElementAttribute, (CFTypeRef *)&focusedElement );
-    if ( err == kAXErrorSuccess && focusedElement ) {
+    AXError err = AXUIElementCopyAttributeValue(systemWide, kAXFocusedElementAttribute, (CFTypeRef*)&focusedElement);
+    if (err == kAXErrorSuccess && focusedElement) {
         CFTypeRef selectedText = NULL;
-        err = AXUIElementCopyAttributeValue( focusedElement, kAXSelectedTextAttribute, (CFTypeRef *)&selectedText );
-        if ( err == kAXErrorSuccess && selectedText ) {
-            if ( CFGetTypeID( selectedText ) == CFStringGetTypeID() ) {
-                result = QString::fromCFString( (CFStringRef)selectedText );
+        err = AXUIElementCopyAttributeValue(focusedElement, kAXSelectedTextAttribute, (CFTypeRef*)&selectedText);
+        if (err == kAXErrorSuccess && selectedText) {
+            if (CFGetTypeID(selectedText) == CFStringGetTypeID()) {
+                result = QString::fromCFString((CFStringRef)selectedText);
             }
-            CFRelease( selectedText );
+            CFRelease(selectedText);
         }
-        CFRelease( focusedElement );
+        CFRelease(focusedElement);
     }
-    CFRelease( systemWide );
+    CFRelease(systemWide);
     return result;
 }
 
@@ -196,8 +196,8 @@ void HotkeyWrapper::activated(int hkId)
                 // Strategy: Try AXAPI first for instant result and no clipboard pollution.
                 // If it fails, fallback to simulated Cmd+C.
                 QString text = MacKeyMapping::getSelectedTextViaAXAPI();
-                if ( !text.isEmpty() ) {
-                    QGuiApplication::clipboard()->setText( text );
+                if (!text.isEmpty()) {
+                    QGuiApplication::clipboard()->setText(text);
                 } else {
                     // If that was a copy-to-clipboard shortcut, re-emit it back so it could
                     // reach its original destination so it could be acted upon.
@@ -227,14 +227,14 @@ void HotkeyWrapper::activated(int hkId)
 
 void HotkeyWrapper::suspendHotkeys()
 {
-    for ( int j = 0; j < hotkeys.count(); j++ ) {
-        HotkeyStruct & h = hotkeys[j];
-        if ( h.hkRef ) {
-            UnregisterEventHotKey( h.hkRef );
+    for (int j = 0; j < hotkeys.count(); j++) {
+        HotkeyStruct& h = hotkeys[j];
+        if (h.hkRef) {
+            UnregisterEventHotKey(h.hkRef);
             h.hkRef = nullptr;
         }
-        if ( h.hkRef2 ) {
-            UnregisterEventHotKey( h.hkRef2 );
+        if (h.hkRef2) {
+            UnregisterEventHotKey(h.hkRef2);
             h.hkRef2 = nullptr;
         }
     }
@@ -242,18 +242,18 @@ void HotkeyWrapper::suspendHotkeys()
 
 void HotkeyWrapper::resumeHotkeys()
 {
-    for ( int j = 0; j < hotkeys.count(); j++ ) {
-        HotkeyStruct & h = hotkeys[j];
+    for (int j = 0; j < hotkeys.count(); j++) {
+        HotkeyStruct& h = hotkeys[j];
 
         EventHotKeyID hotKeyID;
         hotKeyID.signature = 'GDHK';
         hotKeyID.id = h.id;
 
-        RegisterEventHotKey( h.key, h.modifier, hotKeyID, GetApplicationEventTarget(), 0, &h.hkRef );
+        RegisterEventHotKey(h.key, h.modifier, hotKeyID, GetApplicationEventTarget(), 0, &h.hkRef);
 
-        if ( h.key2 && h.key2 != h.key ) {
+        if (h.key2 && h.key2 != h.key) {
             hotKeyID.id = h.id + 1;
-            RegisterEventHotKey( h.key2, h.modifier, hotKeyID, GetApplicationEventTarget(), 0, &h.hkRef2 );
+            RegisterEventHotKey(h.key2, h.modifier, hotKeyID, GetApplicationEventTarget(), 0, &h.hkRef2);
         }
     }
 }

--- a/src/hotkey/machotkeywrapper.mm
+++ b/src/hotkey/machotkeywrapper.mm
@@ -11,6 +11,9 @@
 #include <vector>
 
 #import <Appkit/Appkit.h>
+#import <ApplicationServices/ApplicationServices.h>
+#include <QClipboard>
+#include <QGuiApplication>
 
 ///
 /// Implementation of the Cmd+C+C trick:
@@ -96,6 +99,30 @@ quint32 qtKeyToNativeKey(UniChar key)
     return 0;
 }
 
+static QString getSelectedTextViaAXAPI()
+{
+    QString result;
+    AXUIElementRef systemWide = AXUIElementCreateSystemWide();
+    if ( !systemWide )
+        return result;
+
+    AXUIElementRef focusedElement = NULL;
+    AXError err = AXUIElementCopyAttributeValue( systemWide, kAXFocusedElementAttribute, (CFTypeRef *)&focusedElement );
+    if ( err == kAXErrorSuccess && focusedElement ) {
+        CFTypeRef selectedText = NULL;
+        err = AXUIElementCopyAttributeValue( focusedElement, kAXSelectedTextAttribute, (CFTypeRef *)&selectedText );
+        if ( err == kAXErrorSuccess && selectedText ) {
+            if ( CFGetTypeID( selectedText ) == CFStringGetTypeID() ) {
+                result = QString::fromCFString( (CFStringRef)selectedText );
+            }
+            CFRelease( selectedText );
+        }
+        CFRelease( focusedElement );
+    }
+    CFRelease( systemWide );
+    return result;
+}
+
 } // namespace MacKeyMapping
 
 static pascal OSStatus hotKeyHandler(EventHandlerCallRef /* nextHandler */, EventRef theEvent, void* userData)
@@ -166,17 +193,20 @@ void HotkeyWrapper::activated(int hkId)
             if (hs.key == keyC && hs.modifier == cmdKey) {
                 checkAndRequestAccessibilityPermission();
 
-                // If that was a copy-to-clipboard shortcut, re-emit it back so it could
-                // reach its original destination so it could be acted upon.
-                UnregisterEventHotKey(hs.hkRef);
-
-                sendCmdC();
-
-                EventHotKeyID hotKeyID;
-                hotKeyID.signature = 'GDHK';
-                hotKeyID.id = hs.id;
-
-                RegisterEventHotKey(hs.key, hs.modifier, hotKeyID, GetApplicationEventTarget(), 0, &hs.hkRef);
+                // Strategy: Try AXAPI first for instant result and no clipboard pollution.
+                // If it fails, fallback to simulated Cmd+C.
+                QString text = MacKeyMapping::getSelectedTextViaAXAPI();
+                if ( !text.isEmpty() ) {
+                    QGuiApplication::clipboard()->setText( text );
+                } else {
+                    // If that was a copy-to-clipboard shortcut, re-emit it back so it could
+                    // reach its original destination so it could be acted upon.
+                    // We unregister all our hotkeys before emitting so they wouldn't be
+                    // triggered by the emitted event.
+                    suspendHotkeys();
+                    sendCmdC();
+                    resumeHotkeys();
+                }
             }
 
             if (hs.key2 == 0) {
@@ -193,6 +223,39 @@ void HotkeyWrapper::activated(int hkId)
 
     state2 = false;
     return;
+}
+
+void HotkeyWrapper::suspendHotkeys()
+{
+    for ( int j = 0; j < hotkeys.count(); j++ ) {
+        HotkeyStruct & h = hotkeys[j];
+        if ( h.hkRef ) {
+            UnregisterEventHotKey( h.hkRef );
+            h.hkRef = nullptr;
+        }
+        if ( h.hkRef2 ) {
+            UnregisterEventHotKey( h.hkRef2 );
+            h.hkRef2 = nullptr;
+        }
+    }
+}
+
+void HotkeyWrapper::resumeHotkeys()
+{
+    for ( int j = 0; j < hotkeys.count(); j++ ) {
+        HotkeyStruct & h = hotkeys[j];
+
+        EventHotKeyID hotKeyID;
+        hotKeyID.signature = 'GDHK';
+        hotKeyID.id = h.id;
+
+        RegisterEventHotKey( h.key, h.modifier, hotKeyID, GetApplicationEventTarget(), 0, &h.hkRef );
+
+        if ( h.key2 && h.key2 != h.key ) {
+            hotKeyID.id = h.id + 1;
+            RegisterEventHotKey( h.key2, h.modifier, hotKeyID, GetApplicationEventTarget(), 0, &h.hkRef2 );
+        }
+    }
 }
 
 void HotkeyWrapper::unregister()


### PR DESCRIPTION
Improve hotkey handling logic on macOS to prevent the main window from appearing alongside the scan popup when the clipboard shortcut is triggered.