### PR TITLE
ci: optimize build workflows with ccache and dependency caching

### DIFF
--- a/.github/workflows/Manual-Build-Action.yml
+++ b/.github/workflows/Manual-Build-Action.yml
@@ -23,18 +23,18 @@ jobs:
     strategy:
       matrix:
         os: [macos-14]
-        qt_ver: [ 6.7.2 ]
+        qt_ver: [ 6.8.3 ]
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Update brew
-        run: |
-          brew update
       - name: Install dependencies
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
         run: |
           brew install --force --overwrite \
-            bzip2  \
+            bzip2 \
             create-dmg \
             hunspell \
             libiconv \
@@ -43,14 +43,29 @@ jobs:
             libzim \
             lzip \
             ninja \
+            ccache \
             opencc \
             fmt \
             tomlplusplus \
             xapian || true
-      - name: Install eb
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ runner.os }}-${{ matrix.qt_ver }}
+      - name: Cache EB
+        id: cache-eb
+        uses: actions/cache@v4
+        with:
+          path: |
+            /usr/local/lib/libeb*
+            /usr/local/include/eb
+            /usr/local/bin/eb*
+          key: ${{ runner.os }}-eb-custom
+      - name: Install EB
+        if: steps.cache-eb.outputs.cache-hit != 'true'
         run: |
-          git clone https://github.com/xiaoyifang/eb.git
-          cd eb && ./configure && make -j 8 && sudo make install && cd ..         
+          git clone --depth 1 https://github.com/xiaoyifang/eb.git
+          cd eb && ./configure && make -j 8 && sudo make install && cd ..
       - uses: jurplel/install-qt-action@v4.2.1
         with:
           version: ${{ matrix.qt_ver }}
@@ -61,6 +76,8 @@ jobs:
           mkdir build_dir
           cmake -S . -B build_dir \
             -G Ninja \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DWITH_FFMPEG_PLAYER=OFF \
             -DWITH_TTS=OFF \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \

--- a/.github/workflows/PR-check-cmake.yml
+++ b/.github/workflows/PR-check-cmake.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           sudo apt-get update
 
-          sudo apt-get install build-essential ninja-build \
+          sudo apt-get install build-essential ninja-build ccache \
           libvorbis-dev zlib1g-dev libhunspell-dev x11proto-record-dev \
           libxtst-dev liblzo2-dev libbz2-dev \
           libavutil-dev libavformat-dev libeb16-dev \
@@ -40,6 +40,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: false
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ runner.os }}-ubuntu
       - name: Run build
         run: |
           export CXXFLAGS="-Wall"
@@ -47,6 +51,8 @@ jobs:
           cmake -S . \
             -B ./build_dir \
             -DCMAKE_COMPILE_WARNING_AS_ERROR=ON \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -G Ninja
           cd ./build_dir
           ninja -k 0
@@ -59,13 +65,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: false
-      - name: Update brew
-        run: |
-          brew update
       - name: Install dependencies
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
         run: |
           brew install --force --overwrite \
           ninja \
+          ccache \
           opencc \
           ffmpeg@6 \
           libao \
@@ -79,7 +86,21 @@ jobs:
           libzim \
           tomlplusplus \
           qt || true
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ runner.os }}-macos
+      - name: Cache EB
+        id: cache-eb
+        uses: actions/cache@v4
+        with:
+          path: |
+            /usr/local/lib/libeb*
+            /usr/local/include/eb
+            /usr/local/bin/eb*
+          key: ${{ runner.os }}-eb-v4.4.3
       - name: Install eb
+        if: steps.cache-eb.outputs.cache-hit != 'true'
         run: |
           wget https://github.com/mistydemeo/eb/releases/download/v4.4.3/eb-4.4.3.tar.bz2
           tar xvjf eb-4.4.3.tar.bz2
@@ -92,6 +113,8 @@ jobs:
           cmake -S . \
             -B ./build_dir \
             -G Ninja \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DWITH_FFMPEG_PLAYER=ON \
             -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
           cd ./build_dir

--- a/.github/workflows/Release-all.yml
+++ b/.github/workflows/Release-all.yml
@@ -30,13 +30,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Update brew
-        run: |
-          brew update
       - name: Install dependencies
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
         run: |
           brew install --force --overwrite \
-            bzip2  \
+            bzip2 \
             create-dmg \
             hunspell \
             libiconv \
@@ -45,14 +45,29 @@ jobs:
             libzim \
             lzip \
             ninja \
+            ccache \
             opencc \
             fmt \
             ffmpeg@6 \
             tomlplusplus \
             xapian || true
-      - name: Install eb
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ runner.os }}-${{ matrix.qt_ver }}
+      - name: Cache EB
+        id: cache-eb
+        uses: actions/cache@v4
+        with:
+          path: |
+            /usr/local/lib/libeb*
+            /usr/local/include/eb
+            /usr/local/bin/eb*
+          key: ${{ runner.os }}-eb-custom
+      - name: Install EB
+        if: steps.cache-eb.outputs.cache-hit != 'true'
         run: |
-          git clone https://github.com/xiaoyifang/eb.git
+          git clone --depth 1 https://github.com/xiaoyifang/eb.git
           cd eb && ./configure && make -j 8 && sudo make install && cd ..
       - uses: jurplel/install-qt-action@v4.2.1
         with:
@@ -65,6 +80,8 @@ jobs:
           export PKG_CONFIG_PATH="`brew --prefix ffmpeg@6`/lib/pkgconfig:$PKG_CONFIG_PATH"
           cmake -S . -B build_dir \
             -G Ninja \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DWITH_FFMPEG_PLAYER=ON \
             -DWITH_QT_MULTIMEDIA=OFF \
             -DWITH_TTS=OFF \


### PR DESCRIPTION
- Add ccache to speed up compilation.
- Cache 'eb' library and optimize Homebrew install.
- Remove redundant 'brew update' to save time.