### PR TITLE
fix(mdx): use completeBaseName for fallback title instead of baseName

### DIFF
--- a/src/dict/mdictparser.cc
+++ b/src/dict/mdictparser.cc
@@ -371,7 +371,7 @@ bool MdictParser::readHeader( QDataStream & in )
   if ( title.isEmpty() || title == "Title (No HTML code allowed)" ) {
     // Use filename instead
     QFileInfo fi( filename_ );
-    title_ = fi.baseName();
+    title_ = fi.completeBaseName();
   }
   else {
     if ( title.contains( '<' ) || title.contains( '>' ) ) {

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -297,7 +297,7 @@ MdxDictionary::MdxDictionary( const string & id, const string & indexFile, const
   //fallback, use filename as dictionary name
   if ( dictionaryName.empty() ) {
     QFileInfo f( QString::fromUtf8( dictionaryFiles[ 0 ].c_str() ) );
-    dictionaryName = f.baseName().toStdString();
+    dictionaryName = f.completeBaseName().toStdString();
   }
 
   // then read the dictionary's encoding


### PR DESCRIPTION
This prevents dictionary names from being truncated after the first dot (e.g. "www" instead of "www.wikipedia.org") when the internal MDX title metadata is missing.