### PR TITLE
feat: Add option to enable JavaScript clipboard access

### DIFF
--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -3471,6 +3471,14 @@ from Stardict, Babylon and GLS dictionaries</source>
         <source>Anki</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Allow JavaScript to access clipboard in the article view.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable JavaScript clipboard access</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ProgramTypeEditor</name>

--- a/src/config.cc
+++ b/src/config.cc
@@ -153,8 +153,7 @@ Preferences::Preferences():
   inputPhraseLengthLimit( 1000 ),
   maxDictionaryRefsInContextMenu( 20 ),
   synonymSearchEnabled( true ),
-  stripClipboard( false ),
-  enableJavaScriptClipboardAccess( false )
+  stripClipboard( false )
 #if !defined( Q_OS_WIN )
   ,
   interfaceStyle( "Default" )

--- a/src/config.cc
+++ b/src/config.cc
@@ -968,7 +968,8 @@ Class load()
     }
 
     if ( !preferences.namedItem( "enableJavaScriptClipboardAccess" ).isNull() ) {
-      c.preferences.enableJavaScriptClipboardAccess = ( preferences.namedItem( "enableJavaScriptClipboardAccess" ).toElement().text() == "1" );
+      c.preferences.enableJavaScriptClipboardAccess =
+        ( preferences.namedItem( "enableJavaScriptClipboardAccess" ).toElement().text() == "1" );
     }
 
     if ( !preferences.namedItem( "maxStringsInHistory" ).isNull() ) {

--- a/src/config.cc
+++ b/src/config.cc
@@ -153,7 +153,8 @@ Preferences::Preferences():
   inputPhraseLengthLimit( 1000 ),
   maxDictionaryRefsInContextMenu( 20 ),
   synonymSearchEnabled( true ),
-  stripClipboard( false )
+  stripClipboard( false ),
+  enableJavaScriptClipboardAccess( false )
 #if !defined( Q_OS_WIN )
   ,
   interfaceStyle( "Default" )
@@ -964,6 +965,10 @@ Class load()
 
     if ( !preferences.namedItem( "suppressWebDialogs" ).isNull() ) {
       c.preferences.suppressWebDialogs = ( preferences.namedItem( "suppressWebDialogs" ).toElement().text() == "1" );
+    }
+
+    if ( !preferences.namedItem( "enableJavaScriptClipboardAccess" ).isNull() ) {
+      c.preferences.enableJavaScriptClipboardAccess = ( preferences.namedItem( "enableJavaScriptClipboardAccess" ).toElement().text() == "1" );
     }
 
     if ( !preferences.namedItem( "maxStringsInHistory" ).isNull() ) {
@@ -1979,6 +1984,10 @@ void save( const Class & c )
 
     opt = dd.createElement( "suppressWebDialogs" );
     opt.appendChild( dd.createTextNode( c.preferences.suppressWebDialogs ? "1" : "0" ) );
+    preferences.appendChild( opt );
+
+    opt = dd.createElement( "enableJavaScriptClipboardAccess" );
+    opt.appendChild( dd.createTextNode( c.preferences.enableJavaScriptClipboardAccess ? "1" : "0" ) );
     preferences.appendChild( opt );
 
     opt = dd.createElement( "maxStringsInHistory" );

--- a/src/config.hh
+++ b/src/config.hh
@@ -343,6 +343,7 @@ struct Preferences
 #endif
   bool openWebsiteInNewTab = false;
   bool suppressWebDialogs  = false;
+  bool enableJavaScriptClipboardAccess = false;
 
   qreal zoomFactor;
   qreal helpZoomFactor;

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -223,6 +223,8 @@ ArticleView::ArticleView( QWidget * parent,
   settings->setAttribute( QWebEngineSettings::PlaybackRequiresUserGesture, false );
   settings->setAttribute( QWebEngineSettings::JavascriptCanAccessClipboard,
                           cfg.preferences.enableJavaScriptClipboardAccess );
+  settings->setAttribute( QWebEngineSettings::JavascriptCanPaste,
+                          cfg.preferences.enableJavaScriptClipboardAccess );
   settings->setAttribute( QWebEngineSettings::PrintElementBackgrounds, false );
 
   expandOptionalParts = cfg.preferences.alwaysExpandOptionalParts;

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -221,7 +221,7 @@ ArticleView::ArticleView( QWidget * parent,
   settings->setAttribute( QWebEngineSettings::ErrorPageEnabled, false );
   settings->setAttribute( QWebEngineSettings::LinksIncludedInFocusChain, false );
   settings->setAttribute( QWebEngineSettings::PlaybackRequiresUserGesture, false );
-  settings->setAttribute( QWebEngineSettings::JavascriptCanAccessClipboard, false );
+  settings->setAttribute( QWebEngineSettings::JavascriptCanAccessClipboard, cfg.preferences.enableJavaScriptClipboardAccess );
   settings->setAttribute( QWebEngineSettings::PrintElementBackgrounds, false );
 
   expandOptionalParts = cfg.preferences.alwaysExpandOptionalParts;

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -223,8 +223,7 @@ ArticleView::ArticleView( QWidget * parent,
   settings->setAttribute( QWebEngineSettings::PlaybackRequiresUserGesture, false );
   settings->setAttribute( QWebEngineSettings::JavascriptCanAccessClipboard,
                           cfg.preferences.enableJavaScriptClipboardAccess );
-  settings->setAttribute( QWebEngineSettings::JavascriptCanPaste,
-                          cfg.preferences.enableJavaScriptClipboardAccess );
+  settings->setAttribute( QWebEngineSettings::JavascriptCanPaste, cfg.preferences.enableJavaScriptClipboardAccess );
   settings->setAttribute( QWebEngineSettings::PrintElementBackgrounds, false );
 
   expandOptionalParts = cfg.preferences.alwaysExpandOptionalParts;

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -221,7 +221,8 @@ ArticleView::ArticleView( QWidget * parent,
   settings->setAttribute( QWebEngineSettings::ErrorPageEnabled, false );
   settings->setAttribute( QWebEngineSettings::LinksIncludedInFocusChain, false );
   settings->setAttribute( QWebEngineSettings::PlaybackRequiresUserGesture, false );
-  settings->setAttribute( QWebEngineSettings::JavascriptCanAccessClipboard, cfg.preferences.enableJavaScriptClipboardAccess );
+  settings->setAttribute( QWebEngineSettings::JavascriptCanAccessClipboard,
+                          cfg.preferences.enableJavaScriptClipboardAccess );
   settings->setAttribute( QWebEngineSettings::PrintElementBackgrounds, false );
 
   expandOptionalParts = cfg.preferences.alwaysExpandOptionalParts;

--- a/src/ui/articlewebpage.cc
+++ b/src/ui/articlewebpage.cc
@@ -7,18 +7,19 @@ ArticleWebPage::ArticleWebPage( QObject * parent, bool isPopup_ ):
   QWebEnginePage( parent ),
   isPopup( isPopup_ )
 {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 8, 0 )
   connect( this, &QWebEnginePage::permissionRequested, this, &ArticleWebPage::onPermissionRequested );
 #endif
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 8, 0 )
 void ArticleWebPage::onPermissionRequested( const QWebEnginePermission & permission )
 {
   if ( permission.permissionType() == QWebEnginePermission::PermissionType::ClipboardReadWrite ) {
     if ( GlobalBroadcaster::instance()->getPreference()->enableJavaScriptClipboardAccess ) {
       permission.grant();
-    } else {
+    }
+    else {
       permission.deny();
     }
   }

--- a/src/ui/articlewebpage.cc
+++ b/src/ui/articlewebpage.cc
@@ -7,20 +7,23 @@ ArticleWebPage::ArticleWebPage( QObject * parent, bool isPopup_ ):
   QWebEnginePage( parent ),
   isPopup( isPopup_ )
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
   connect( this, &QWebEnginePage::permissionRequested, this, &ArticleWebPage::onPermissionRequested );
+#endif
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
 void ArticleWebPage::onPermissionRequested( const QWebEnginePermission & permission )
 {
   if ( permission.permissionType() == QWebEnginePermission::PermissionType::ClipboardReadWrite ) {
     if ( GlobalBroadcaster::instance()->getPreference()->enableJavaScriptClipboardAccess ) {
       permission.grant();
-    }
-    else {
+    } else {
       permission.deny();
     }
   }
 }
+#endif
 bool ArticleWebPage::acceptNavigationRequest( const QUrl & resUrl, NavigationType type, bool isMainFrame )
 {
   QUrl url = resUrl;

--- a/src/ui/articlewebpage.cc
+++ b/src/ui/articlewebpage.cc
@@ -7,6 +7,18 @@ ArticleWebPage::ArticleWebPage( QObject * parent, bool isPopup_ ):
   QWebEnginePage( parent ),
   isPopup( isPopup_ )
 {
+  connect( this, &QWebEnginePage::permissionRequested, this, &ArticleWebPage::onPermissionRequested );
+}
+
+void ArticleWebPage::onPermissionRequested( const QWebEnginePermission & permission )
+{
+  if ( permission.permissionType() == QWebEnginePermission::PermissionType::ClipboardReadWrite ) {
+    if ( GlobalBroadcaster::instance()->getPreference()->enableJavaScriptClipboardAccess ) {
+      permission.grant();
+    } else {
+      permission.deny();
+    }
+  }
 }
 bool ArticleWebPage::acceptNavigationRequest( const QUrl & resUrl, NavigationType type, bool isMainFrame )
 {

--- a/src/ui/articlewebpage.cc
+++ b/src/ui/articlewebpage.cc
@@ -15,7 +15,8 @@ void ArticleWebPage::onPermissionRequested( const QWebEnginePermission & permiss
   if ( permission.permissionType() == QWebEnginePermission::PermissionType::ClipboardReadWrite ) {
     if ( GlobalBroadcaster::instance()->getPreference()->enableJavaScriptClipboardAccess ) {
       permission.grant();
-    } else {
+    }
+    else {
       permission.deny();
     }
   }

--- a/src/ui/articlewebpage.hh
+++ b/src/ui/articlewebpage.hh
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <QWebEnginePage>
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
 #include <QWebEnginePermission>
+#endif
 
 struct LastReqInfo
 {
@@ -23,7 +26,9 @@ signals:
   void linkClicked( const QUrl & url );
 
 private slots:
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
   void onPermissionRequested( const QWebEnginePermission & permission );
+#endif
 
 protected:
   bool acceptNavigationRequest( const QUrl & url, NavigationType type, bool isMainFrame ) override;

--- a/src/ui/articlewebpage.hh
+++ b/src/ui/articlewebpage.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QWebEnginePage>
+#include <QWebEnginePermission>
 
 struct LastReqInfo
 {

--- a/src/ui/articlewebpage.hh
+++ b/src/ui/articlewebpage.hh
@@ -21,6 +21,9 @@ public:
 signals:
   void linkClicked( const QUrl & url );
 
+private slots:
+  void onPermissionRequested( const QWebEnginePermission & permission );
+
 protected:
   bool acceptNavigationRequest( const QUrl & url, NavigationType type, bool isMainFrame ) override;
   void javaScriptAlert( const QUrl & securityOrigin, const QString & msg ) override;

--- a/src/ui/articlewebpage.hh
+++ b/src/ui/articlewebpage.hh
@@ -2,8 +2,8 @@
 
 #include <QWebEnginePage>
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
-#include <QWebEnginePermission>
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 8, 0 )
+  #include <QWebEnginePermission>
 #endif
 
 struct LastReqInfo
@@ -26,7 +26,7 @@ signals:
   void linkClicked( const QUrl & url );
 
 private slots:
-#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 8, 0 )
   void onPermissionRequested( const QWebEnginePermission & permission );
 #endif
 

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -366,6 +366,7 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   ui.enableApplicationLog->setChecked( p.enableApplicationLog );
   ui.openWebsiteInNewTab->setChecked( p.openWebsiteInNewTab );
   ui.suppressWebDialogs->setChecked( p.suppressWebDialogs );
+  ui.enableJavaScriptClipboard->setChecked( p.enableJavaScriptClipboardAccess );
 
   //initialize add-on styles
   QString stylesDir = Config::getStylesDir();
@@ -552,8 +553,9 @@ Config::Preferences Preferences::getPreferences()
 
   p.removeInvalidIndexOnExit = ui.removeInvalidIndexOnExit->isChecked();
   p.enableApplicationLog     = ui.enableApplicationLog->isChecked();
-  p.openWebsiteInNewTab      = ui.openWebsiteInNewTab->isChecked();
+  p.openWebsiteInNewTab   = ui.openWebsiteInNewTab->isChecked();
   p.suppressWebDialogs       = ui.suppressWebDialogs->isChecked();
+  p.enableJavaScriptClipboardAccess = ui.enableJavaScriptClipboard->isChecked();
 
   p.addonStyle = ui.addonStyles->currentText();
 

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -553,7 +553,7 @@ Config::Preferences Preferences::getPreferences()
 
   p.removeInvalidIndexOnExit = ui.removeInvalidIndexOnExit->isChecked();
   p.enableApplicationLog     = ui.enableApplicationLog->isChecked();
-  p.openWebsiteInNewTab   = ui.openWebsiteInNewTab->isChecked();
+  p.openWebsiteInNewTab             = ui.openWebsiteInNewTab->isChecked();
   p.suppressWebDialogs       = ui.suppressWebDialogs->isChecked();
   p.enableJavaScriptClipboardAccess = ui.enableJavaScriptClipboard->isChecked();
 

--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -1933,6 +1933,16 @@ from Stardict, Babylon and GLS dictionaries</string>
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="enableJavaScriptClipboard">
+            <property name="toolTip">
+             <string>Allow JavaScript to access clipboard in the article view.</string>
+            </property>
+            <property name="text">
+             <string>Enable JavaScript clipboard access</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>


### PR DESCRIPTION
This commit adds a new configuration option to enable JavaScript clipboard access in the article view. The option is disabled by default for security reasons.