### PR TITLE
fix: check for null scanFlag in ScanPopup to prevent crashes on non-X11 platforms

### DIFF
--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -1395,11 +1395,15 @@ bool ScanPopup::isWordPresentedInFavorites( const QString & word ) const
 #ifdef WITH_X11
 void ScanPopup::showScanFlag()
 {
-  scanFlag->showScanFlag();
+  if ( scanFlag ) {
+    scanFlag->showScanFlag();
+  }
 }
 
 void ScanPopup::hideScanFlag()
 {
-  scanFlag->hideWindow();
+  if ( scanFlag ) {
+    scanFlag->hideWindow();
+  }
 }
 #endif


### PR DESCRIPTION
fix: check for null scanFlag in ScanPopup to prevent crashes on non-X11 platforms


fix #2804