### PR TITLE
dict: update CSS isolation ID prefix to #gdfrom-

### DIFF
--- a/src/dict/dictionary.cc
+++ b/src/dict/dictionary.cc
@@ -406,7 +406,7 @@ void Class::isolateCSS( QString & css, const QString & wrapperSelector )
   css.remove( commentRegex );
 
   // 2. Prepare prefix
-  QString idSelector = "#gd-" + QString::fromStdString( getId() );
+  QString idSelector = "#gdfrom-" + QString::fromStdString( getId() );
   QString prefix     = idSelector;
   if ( !wrapperSelector.isEmpty() ) {
     prefix += " " + wrapperSelector;


### PR DESCRIPTION
dict: update CSS isolation ID prefix to #gdfrom-

Changes the ID selector prefix in `Dictionary::isolateCSS` from `#gd-` 
to `#gdfrom-` to ensure consistency with the container IDs used 
for dictionary content in the article view.
