### PR TITLE
opt: remove redundant gddictnamebodyseparator element

### DIFF
--- a/src/article_maker.cc
+++ b/src/article_maker.cc
@@ -657,7 +657,6 @@ void ArticleRequest::bodyFinished()
           collapse ? "false" : "true" );
 
 
-
         // If the user has enabled Anki integration in settings,
         // Show a (+) button that lets the user add a new Anki card.
         if ( ankiConnectEnabled() ) {

--- a/src/article_maker.cc
+++ b/src/article_maker.cc
@@ -656,7 +656,7 @@ void ArticleRequest::bodyFinished()
           "",
           collapse ? "false" : "true" );
 
-        head += R"(<div class="gddictnamebodyseparator"></div>)";
+
 
         // If the user has enabled Anki integration in settings,
         // Show a (+) button that lets the user add a new Anki card.

--- a/src/stylesheets/article-style-st-classic.css
+++ b/src/stylesheets/article-style-st-classic.css
@@ -48,9 +48,7 @@ pre {
   user-select: none;
 }
 
-.gddictnamebodyseparator {
-  clear: both;
-}
+
 
 /* The 'From ' string which precedes dictionary name in the heading */
 .gdfromprefix {

--- a/src/stylesheets/article-style-st-classic.css
+++ b/src/stylesheets/article-style-st-classic.css
@@ -48,8 +48,6 @@ pre {
   user-select: none;
 }
 
-
-
 /* The 'From ' string which precedes dictionary name in the heading */
 .gdfromprefix {
   display: none;

--- a/src/stylesheets/article-style-st-lingoes.css
+++ b/src/stylesheets/article-style-st-lingoes.css
@@ -88,8 +88,8 @@ body {
   content: url("qrc:///icons/collapse_article_hovered.svg");
 }
 
-.gddictnamebodyseparator {
+.gdarticlebody {
   clear: both;
   border-top: 1px solid #92b0dd;
-  margin-bottom: 1em;
+  margin-top: 1em;
 }

--- a/src/stylesheets/article-style.css
+++ b/src/stylesheets/article-style.css
@@ -132,11 +132,6 @@ gd-dict-header,
   user-select: none;
 }
 
-/* The separator is now redundant thanks to flow-root and clear:both on body */
-.gddictnamebodyseparator {
-  display: none;
-}
-
 .gdarticlebody {
   clear: both;
 }


### PR DESCRIPTION
Remove the redundant gddictnamebodyseparator element and migrate its styles to gdarticlebody where needed.