### PR TITLE
fix(dict): improve reindex logic and StarDict metadata parsing

### DIFF
--- a/src/dict/dictionary.cc
+++ b/src/dict/dictionary.cc
@@ -640,7 +640,7 @@ bool needToRebuildIndex( const vector< string > & dictionaryFiles, const string 
       if ( !fileInfo.exists() ) {
         continue;
       }
-      ts = fileInfo.lastModified().toSecsSinceEpoch();
+      ts = fileInfo.lastModified().toMSecsSinceEpoch();
     }
 
     if ( ts > lastModified ) {
@@ -655,7 +655,7 @@ bool needToRebuildIndex( const vector< string > & dictionaryFiles, const string 
     return true;
   }
 
-  return fileInfo.lastModified().toSecsSinceEpoch() < lastModified;
+  return fileInfo.lastModified().toMSecsSinceEpoch() < lastModified;
 }
 
 string getFtsSuffix()

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -47,7 +47,7 @@ using namespace Mdict;
 
 enum {
   kSignature            = 0x4349444d, // MDIC
-  kCurrentFormatVersion = 11 + BtreeIndexing::FormatVersion + Folding::Version
+  kCurrentFormatVersion = 12 + BtreeIndexing::FormatVersion + Folding::Version
 };
 
 DEF_EX( exCorruptDictionary, "dictionary file was tampered or corrupted", std::exception )
@@ -84,6 +84,7 @@ struct IdxHeader
 
   uint32_t mddIndexInfosOffset; // address of IndexInfos for resource files (.mdd)
   uint32_t mddIndexInfosCount;  // count of IndexInfos for resource files
+  uint64_t sourceLastModified;  // Maximum lastModified timestamp of dictionary files
 };
 static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
@@ -1408,9 +1409,25 @@ static bool indexIsOldOrBad( const vector< string > & dictFiles, const string & 
   File::Index idx( indexFile, QIODevice::ReadOnly );
   IdxHeader header;
 
-  return idx.readRecords( &header, sizeof( header ), 1 ) != 1 || header.signature != kSignature
-    || header.formatVersion != kCurrentFormatVersion || header.parserVersion != MdictParser::kParserVersion
-    || header.foldingVersion != Folding::Version;
+  if ( idx.readRecords( &header, sizeof( header ), 1 ) != 1 || header.signature != kSignature
+       || header.formatVersion != kCurrentFormatVersion || header.parserVersion != MdictParser::kParserVersion
+       || header.foldingVersion != Folding::Version ) {
+    return true;
+  }
+
+  // Check if any of the dictionary files were modified after the index was built
+  qint64 lastModified = 0;
+  for ( const auto & dictionaryFile : dictFiles ) {
+    QFileInfo fileInfo( QString::fromUtf8( dictionaryFile.c_str() ) );
+    if ( fileInfo.exists() ) {
+      qint64 ts = fileInfo.lastModified().toMSecsSinceEpoch();
+      if ( ts > lastModified ) {
+        lastModified = ts;
+      }
+    }
+  }
+
+  return header.sourceLastModified != (uint64_t)lastModified;
 }
 
 static void findResourceFiles( const string & mdx, vector< string > & dictFiles )
@@ -1616,6 +1633,19 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
       idxHeader.foldingVersion = Folding::Version;
       idxHeader.articleCount   = parser.wordCount();
       idxHeader.wordCount      = parser.wordCount();
+
+      // Compute and store the source last modified timestamp
+      qint64 lastModified = 0;
+      for ( const auto & dictionaryFile : dictFiles ) {
+        QFileInfo fileInfo( QString::fromUtf8( dictionaryFile.c_str() ) );
+        if ( fileInfo.exists() ) {
+          qint64 ts = fileInfo.lastModified().toMSecsSinceEpoch();
+          if ( ts > lastModified ) {
+            lastModified = ts;
+          }
+        }
+      }
+      idxHeader.sourceLastModified = (uint64_t)lastModified;
 
       idx.rewind();
       idx.write( &idxHeader, sizeof( idxHeader ) );

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -78,7 +78,7 @@ struct Ifo
 
 enum {
   Signature            = 0x58444953, // SIDX on little-endian, XDIS on big-endian
-  CurrentFormatVersion = 9 + BtreeIndexing::FormatVersion + Folding::Version + BtreeIndexing::ZipParseLogicVersion
+  CurrentFormatVersion = 10 + BtreeIndexing::FormatVersion + Folding::Version + BtreeIndexing::ZipParseLogicVersion
 };
 
 #pragma pack( push, 1 )
@@ -99,20 +99,37 @@ struct IdxHeader
   uint32_t zipIndexBtreeMaxElements; // Two fields from IndexInfo of the zip
                                      // resource index.
   uint32_t zipIndexRootOffset;
+  uint64_t sourceLastModified; // Maximum lastModified timestamp of dictionary files
 };
 static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
 
 ;
 
-bool indexIsOldOrBad( const string & indexFile )
+bool indexIsOldOrBad( const string & indexFile, const vector< string > & dictFiles )
 {
   File::Index idx( indexFile, QIODevice::ReadOnly );
 
   IdxHeader header;
 
-  return idx.readRecords( &header, sizeof( header ), 1 ) != 1 || header.signature != Signature
-    || header.formatVersion != CurrentFormatVersion;
+  if ( idx.readRecords( &header, sizeof( header ), 1 ) != 1 || header.signature != Signature
+       || header.formatVersion != CurrentFormatVersion ) {
+    return true;
+  }
+
+  // Check if any of the dictionary files were modified after the index was built
+  qint64 lastModified = 0;
+  for ( const auto & dictionaryFile : dictFiles ) {
+    QFileInfo fileInfo( QString::fromUtf8( dictionaryFile.c_str() ) );
+    if ( fileInfo.exists() ) {
+      qint64 ts = fileInfo.lastModified().toMSecsSinceEpoch();
+      if ( ts > lastModified ) {
+        lastModified = ts;
+      }
+    }
+  }
+
+  return header.sourceLastModified != (uint64_t)lastModified;
 }
 
 class StardictDictionary: public BtreeIndexing::BtreeDictionary
@@ -1497,56 +1514,57 @@ Ifo::Ifo( const QString & fileName )
       QByteArray optionUtf8   = option.toString().toUtf8();
       const char * optionData = optionUtf8.constData();
 
-      if ( const char * val = beginsWith( "bookname=", optionData ) ) {
-        bookname = val;
-      }
-      else if ( const char * val = beginsWith( "wordcount=", optionData ) ) {
-        auto [ ptr, ec ] = std::from_chars( val, val + strlen( val ), wordcount );
-        if ( ec != std::errc{} ) {
-          throw exBadFieldInIfo( optionData );
+      // Better parsing of key=value pairs, handling potential whitespace
+      auto parseValue = [&]( const char * key, string & target ) -> bool {
+        if ( const char * val = beginsWith( key, optionData ) ) {
+          // Skip leading whitespace after '='
+          while ( *val && ( *val == ' ' || *val == '\t' ) )
+            ++val;
+          target = val;
+          return true;
         }
-      }
-      else if ( const char * val = beginsWith( "synwordcount=", optionData ) ) {
-        auto [ ptr, ec ] = std::from_chars( val, val + strlen( val ), synwordcount );
-        if ( ec != std::errc{} ) {
-          throw exBadFieldInIfo( optionData );
+        return false;
+      };
+
+      auto parseUint32 = [&]( const char * key, uint32_t & target, bool validateOffset = false ) -> bool {
+        if ( const char * val = beginsWith( key, optionData ) ) {
+          // Skip leading whitespace after '='
+          while ( *val && ( *val == ' ' || *val == '\t' ) )
+            ++val;
+          auto [ ptr, ec ] = std::from_chars( val, val + strlen( val ), target );
+          if ( ec != std::errc{} || ( validateOffset && target != 32 && target != 64 ) ) {
+            throw exBadFieldInIfo( optionData );
+          }
+          return true;
         }
+        return false;
+      };
+
+      if ( parseValue( "bookname=", bookname ) ) {
       }
-      else if ( const char * val = beginsWith( "idxfilesize=", optionData ) ) {
-        auto [ ptr, ec ] = std::from_chars( val, val + strlen( val ), idxfilesize );
-        if ( ec != std::errc{} ) {
-          throw exBadFieldInIfo( optionData );
-        }
+      else if ( parseUint32( "wordcount=", wordcount ) ) {
       }
-      else if ( const char * val = beginsWith( "idxoffsetbits=", optionData ) ) {
-        auto [ ptr, ec ] = std::from_chars( val, val + strlen( val ), idxoffsetbits );
-        if ( ec != std::errc{} || ( idxoffsetbits != 32 && idxoffsetbits != 64 ) ) {
-          throw exBadFieldInIfo( optionData );
-        }
+      else if ( parseUint32( "synwordcount=", synwordcount ) ) {
       }
-      else if ( const char * val = beginsWith( "sametypesequence=", optionData ) ) {
-        sametypesequence = val;
+      else if ( parseUint32( "idxfilesize=", idxfilesize ) ) {
       }
-      else if ( const char * val = beginsWith( "dicttype=", optionData ) ) {
-        dicttype = val;
+      else if ( parseUint32( "idxoffsetbits=", idxoffsetbits, true ) ) {
       }
-      else if ( const char * val = beginsWith( "description=", optionData ) ) {
-        description = val;
+      else if ( parseValue( "sametypesequence=", sametypesequence ) ) {
       }
-      else if ( const char * val = beginsWith( "copyright=", optionData ) ) {
-        copyright = val;
+      else if ( parseValue( "dicttype=", dicttype ) ) {
       }
-      else if ( const char * val = beginsWith( "author=", optionData ) ) {
-        author = val;
+      else if ( parseValue( "description=", description ) ) {
       }
-      else if ( const char * val = beginsWith( "email=", optionData ) ) {
-        email = val;
+      else if ( parseValue( "copyright=", copyright ) ) {
       }
-      else if ( const char * val = beginsWith( "website=", optionData ) ) {
-        website = val;
+      else if ( parseValue( "author=", author ) ) {
       }
-      else if ( const char * val = beginsWith( "date=", optionData ) ) {
-        date = val;
+      else if ( parseValue( "email=", email ) ) {
+      }
+      else if ( parseValue( "website=", website ) ) {
+      }
+      else if ( parseValue( "date=", date ) ) {
       }
     }
   }
@@ -1902,7 +1920,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
 
       string indexFile = indicesDir + dictId;
 
-      if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile ) ) {
+      if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile, dictFiles ) ) {
         // Building the index
 
         Ifo ifo( QString::fromStdString( fileName ) );
@@ -1946,6 +1964,19 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
         // will be rewritten with the right values.
 
         idx.write( idxHeader );
+
+        // Compute and store the source last modified timestamp
+        qint64 lastModified = 0;
+        for ( const auto & dictionaryFile : dictFiles ) {
+          QFileInfo fileInfo( QString::fromUtf8( dictionaryFile.c_str() ) );
+          if ( fileInfo.exists() ) {
+            qint64 ts = fileInfo.lastModified().toMSecsSinceEpoch();
+            if ( ts > lastModified ) {
+              lastModified = ts;
+            }
+          }
+        }
+        idxHeader.sourceLastModified = (uint64_t)lastModified;
 
         idx.write( ifo.bookname.data(), ifo.bookname.size() );
         idx.write( ifo.sametypesequence.data(), ifo.sametypesequence.size() );

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -1515,7 +1515,7 @@ Ifo::Ifo( const QString & fileName )
       const char * optionData = optionUtf8.constData();
 
       // Better parsing of key=value pairs, handling potential whitespace
-      auto parseValue = [&]( const char * key, string & target ) -> bool {
+      auto parseValue = [ & ]( const char * key, string & target ) -> bool {
         if ( const char * val = beginsWith( key, optionData ) ) {
           // Skip leading whitespace after '='
           while ( *val && ( *val == ' ' || *val == '\t' ) )
@@ -1526,7 +1526,7 @@ Ifo::Ifo( const QString & fileName )
         return false;
       };
 
-      auto parseUint32 = [&]( const char * key, uint32_t & target, bool validateOffset = false ) -> bool {
+      auto parseUint32 = [ & ]( const char * key, uint32_t & target, bool validateOffset = false ) -> bool {
         if ( const char * val = beginsWith( key, optionData ) ) {
           // Skip leading whitespace after '='
           while ( *val && ( *val == ' ' || *val == '\t' ) )
@@ -1540,8 +1540,7 @@ Ifo::Ifo( const QString & fileName )
         return false;
       };
 
-      if ( parseValue( "bookname=", bookname ) ) {
-      }
+      if ( parseValue( "bookname=", bookname ) ) {}
       else if ( parseUint32( "wordcount=", wordcount ) ) {
       }
       else if ( parseUint32( "synwordcount=", synwordcount ) ) {


### PR DESCRIPTION
This PR addresses issues with dictionary reindexing and StarDict metadata loading

**Problem**: The previous logic only checked if the dictionary file was newer than the index (index.time < dict.time). This fails in the scenario you described: t1 (old dict) < t2 (new dict update) < t3 (index time).
If you restore a dictionary from a backup or revert to an older version, the "new" file might actually have an older timestamp than the existing index. The old logic would think the index is still "newer" and thus up-to-date, leading to stale data.


### Key Changes:
1. **Millisecond Timestamp Resolution**: Updated the global 
eedToRebuildIndex in dictionary.cc to use 	oMSecsSinceEpoch() instead of seconds. This prevents missing updates that occur within the same second.
2. **Identity-Based Index Validation**:
   - Added sourceLastModified to IdxHeader for both StarDict and Mdx.
   - Updated indexIsOldOrBad to verify that the current source file timestamps exactly match the ones stored during indexing.
   - This fixes the scenario where a dictionary is reverted or updated to an older timestamp (relative to the index creation) but remains 'older' than the index file.
3. **Robust StarDict Metadata Parsing**:
   - Improved the .ifo file parser in stardict.cc to handle whitespace around = and other minor formatting variations.
   - This ensures metadata fields like author, email, and description are loaded correctly even from non-perfectly formatted .ifo files.

Closes #2829


**Attention: All mdx & stardict will trigger a reindex**

For other dictionaries ,Users can use a manual reindex which intergrated into the right-context menu 
<img width="531" height="260" alt="PixPin_2026-05-09_15-33-08" src="https://github.com/user-attachments/assets/7961338d-a64b-42a6-b462-7b5cc99cfcca" />
