### PR TITLE
macOS: Refresh UI appearance when system color scheme changes (#2830)

### DIFF
--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -918,6 +918,12 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   if ( cfg.preferences.checkForNewReleases ) {
     QTimer::singleShot( 10000, this, &MainWindow::checkNewRelease );
   }
+
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+  if ( cfg.preferences.darkMode == Config::Dark::Auto ) {
+    connect( QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this, &MainWindow::refreshAppearances );
+  }
+#endif
 }
 
 
@@ -1379,15 +1385,6 @@ void MainWindow::updateAppearances( const QString & addonStyle,
     qApp->setPalette( QPalette() );
   }
 
-  // Re-apply the user-configured font after resetting the palette
-  if ( cfg.preferences.enableInterfaceFont && !cfg.preferences.interfaceFont.isEmpty() ) {
-    QFont font = QApplication::font();
-    font.setFamily( cfg.preferences.interfaceFont );
-    if ( cfg.preferences.interfaceFontSize > 0 ) {
-      font.setPixelSize( cfg.preferences.interfaceFontSize );
-    }
-    QApplication::setFont( font );
-  }
 #endif
 
 #if !defined( Q_OS_WIN )
@@ -1400,6 +1397,16 @@ void MainWindow::updateAppearances( const QString & addonStyle,
     }
   }
 #endif
+
+  // Re-apply the user-configured font after resetting the palette or style
+  if ( cfg.preferences.enableInterfaceFont && !cfg.preferences.interfaceFont.isEmpty() ) {
+    QFont font = QApplication::font();
+    font.setFamily( cfg.preferences.interfaceFont );
+    if ( cfg.preferences.interfaceFontSize > 0 ) {
+      font.setPixelSize( cfg.preferences.interfaceFontSize );
+    }
+    QApplication::setFont( font );
+  }
 
 
   QByteArray css{};
@@ -1452,6 +1459,18 @@ void MainWindow::updateAppearances( const QString & addonStyle,
       scanPopup->setStyleSheet( css );
     }
   }
+}
+
+void MainWindow::refreshAppearances()
+{
+  updateAppearances( cfg.preferences.addonStyle,
+                     cfg.preferences.displayStyle,
+                     cfg.preferences.darkMode
+#if !defined( Q_OS_WIN )
+                     ,
+                     cfg.preferences.interfaceStyle
+#endif
+  );
 }
 
 void MainWindow::trayIconUpdateOrInit()
@@ -2331,13 +2350,22 @@ void MainWindow::editPreferences()
 
 #if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
       if ( cfg.preferences.darkReaderMode == Config::Dark::Auto ) {
-        connect( QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, &view, &ArticleView::reload );
+        connect( QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, &view, &ArticleView::reload, Qt::UniqueConnection );
       }
       else {
         disconnect( QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, &view, &ArticleView::reload );
       }
 #endif
     }
+
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+    if ( cfg.preferences.darkMode == Config::Dark::Auto ) {
+      connect( QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this, &MainWindow::refreshAppearances, Qt::UniqueConnection );
+    }
+    else {
+      disconnect( QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this, &MainWindow::refreshAppearances );
+    }
+#endif
 
     audioPlayerFactory.setPreferences( cfg.preferences.useInternalPlayer,
                                        cfg.preferences.internalPlayerBackend,

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -2350,7 +2350,11 @@ void MainWindow::editPreferences()
 
 #if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
       if ( cfg.preferences.darkReaderMode == Config::Dark::Auto ) {
-        connect( QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, &view, &ArticleView::reload, Qt::UniqueConnection );
+        connect( QGuiApplication::styleHints(),
+                 &QStyleHints::colorSchemeChanged,
+                 &view,
+                 &ArticleView::reload,
+                 Qt::UniqueConnection );
       }
       else {
         disconnect( QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, &view, &ArticleView::reload );
@@ -2360,10 +2364,17 @@ void MainWindow::editPreferences()
 
 #if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
     if ( cfg.preferences.darkMode == Config::Dark::Auto ) {
-      connect( QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this, &MainWindow::refreshAppearances, Qt::UniqueConnection );
+      connect( QGuiApplication::styleHints(),
+               &QStyleHints::colorSchemeChanged,
+               this,
+               &MainWindow::refreshAppearances,
+               Qt::UniqueConnection );
     }
     else {
-      disconnect( QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this, &MainWindow::refreshAppearances );
+      disconnect( QGuiApplication::styleHints(),
+                  &QStyleHints::colorSchemeChanged,
+                  this,
+                  &MainWindow::refreshAppearances );
     }
 #endif
 

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -478,6 +478,7 @@ private slots:
   void prefixMatchFinished();
   void updateMatchResults( bool finished );
   void refreshTranslateLine();
+  void refreshAppearances();
 signals:
   /// Retranslate Ctrl(Shift) + Click on dictionary pane to dictionary toolbar
   void clickOnDictPane( const QString & id );


### PR DESCRIPTION
Fixes #2830. Refresh UI appearance when system color scheme changes on macOS/Linux (Qt 6.5+). Also ensure interface font is re-applied on all platforms after style changes.