### PR TITLE
Correct typo in the preferences (tack -> track)

### DIFF
--- a/locale/ar.ts
+++ b/locale/ar.ts
@@ -3119,7 +3119,7 @@ in the pressed state when the word selection changes.</source>
 المفاتيح مضغوطة عندما يتغيّر تحديد الكلمة.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>اختيار المسار فقط عندما يتم الضغط باستمرار على جميع المفاتيح المحددة:</translation>
     </message>
     <message>

--- a/locale/ay.ts
+++ b/locale/ay.ts
@@ -3200,7 +3200,7 @@ Akamp naktayataxa, taqpach teclanak limt&apos;atakis ukjakiw
 uñstiri wintanaxa uñstaraki, ajllit aru mayjt&apos;i ukja.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Tack ajlliwikiw kunapachatix taqi ajllit teclas ukanakax ch’amanchatäki ukhaxa:</translation>
     </message>
     <message>

--- a/locale/be.ts
+++ b/locale/be.ts
@@ -3114,7 +3114,7 @@ in the pressed state when the word selection changes.</source>
       <translation>Калі параметр уключаны, выплыўное акно будзе паказвацца толькі тады, калі пры змене слова будуць націснутыя ўсе абраныя клавішы.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Сачыць за абіраннем тэксту толькі націсканні ўсіх наступных клавіш:</translation>
     </message>
     <message>

--- a/locale/bg.ts
+++ b/locale/bg.ts
@@ -3120,7 +3120,7 @@ in the pressed state when the word selection changes.</source>
 избраните клавиши са натиснати, когато се промени избирането на дума.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Избиране на халки само когато всички избрани клавиши са натиснати:</translation>
     </message>
     <message>

--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -3087,7 +3087,7 @@ in the pressed state when the word selection changes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Only tack selection when all selected keys are kept pressed:</source>
+        <source>Only track selection when all selected keys are kept pressed:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/locale/cs.ts
+++ b/locale/cs.ts
@@ -3119,7 +3119,7 @@ in the pressed state when the word selection changes.</source>
 zvolené klávesy stisknuty při změně výběru.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Výběr sady pouze, když jsou stisknuty všechny vybrané klávesy:</translation>
     </message>
     <message>

--- a/locale/de.ts
+++ b/locale/de.ts
@@ -3117,7 +3117,7 @@ in the pressed state when the word selection changes.</source>
       <translation>Fallt aktiviert, wird das Popup bei Änderung der Wortauswahl nur angezeigt, wenn alle ausgewählten Tasten gedrückt sind.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Auswahl nur antippen, wenn alle ausgewählten Tasten gedrückt bleiben:</translation>
     </message>
     <message>

--- a/locale/de_CH.ts
+++ b/locale/de_CH.ts
@@ -3112,7 +3112,7 @@ in the pressed state when the word selection changes.</source>
       <translation>Fallt aktiviert, wird das Popup bei Änderung der Wortauswahl nur angezeigt, wenn alle ausgewählten Tasten gedrückt sind.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Auswahl nur antippen, wenn alle ausgewählten Tasten gedrückt bleiben:</translation>
     </message>
     <message>

--- a/locale/el.ts
+++ b/locale/el.ts
@@ -3121,7 +3121,7 @@ in the pressed state when the word selection changes.</source>
 πατημένα όλα τα παρακάτω πλήκτρα όταν γίνεται η επιλογή της λέξης.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Επιλογή μόνο όταν όλα τα επιλεγμένα πλήκτρα διατηρούνται πατημένα:</translation>
     </message>
     <message>

--- a/locale/en.ts
+++ b/locale/en.ts
@@ -3120,8 +3120,8 @@ in the pressed state when the word selection changes.</source>
 in the pressed state when the word selection changes.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
-      <translation type="unfinished">Only tack selection when all selected keys are kept pressed:</translation>
+      <source>Only track selection when all selected keys are kept pressed:</source>
+      <translation type="unfinished">Only track selection when all selected keys are kept pressed:</translation>
     </message>
     <message>
       <source>Alt key</source>

--- a/locale/eo.ts
+++ b/locale/eo.ts
@@ -3120,7 +3120,7 @@ in the pressed state when the word selection changes.</source>
 en la premita stato kiam la vortelekto ŝanĝiĝas.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Selektado de klavoj nur kiam ĉiuj elektitaj klavoj estas tenitaj premitaj:</translation>
     </message>
     <message>

--- a/locale/es.ts
+++ b/locale/es.ts
@@ -3119,7 +3119,7 @@ in the pressed state when the word selection changes.</source>
 las teclas elegidas cuando cambia la palabra seleccionada.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Sólo la selección de toques cuando todas las teclas seleccionadas se mantienen presionadas:</translation>
     </message>
     <message>

--- a/locale/es_AR.ts
+++ b/locale/es_AR.ts
@@ -3121,7 +3121,7 @@ in the pressed state when the word selection changes.</source>
       <translation>Con esta opción activada, la ventana emergente aparecerá sólo si todas las teclas seleccionadas estuvieran siendo presionadas cuando la selección de la palabra cambia.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Sólo selección de virada cuando se mantienen presionadas todas las teclas seleccionadas:</translation>
     </message>
     <message>

--- a/locale/es_BO.ts
+++ b/locale/es_BO.ts
@@ -3117,7 +3117,7 @@ in the pressed state when the word selection changes.</source>
 seleccionadas estén oprimidas cuando la selección de la palabra cambie.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Sólo selección de virada cuando se mantienen presionadas todas las teclas seleccionadas:</translation>
     </message>
     <message>

--- a/locale/fa.ts
+++ b/locale/fa.ts
@@ -3119,7 +3119,7 @@ in the pressed state when the word selection changes.</source>
 هنگام تغییر گزینش واژه همه کلیدهای برگزیده فشار داده شوند.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>فقط زمانی که همه کلیدهای انتخاب شده فشار داده شده باشند، انتخاب تکه‌ها:</translation>
     </message>
     <message>

--- a/locale/fi.ts
+++ b/locale/fi.ts
@@ -3120,7 +3120,7 @@ in the pressed state when the word selection changes.</source>
 painettuna tilassa, kun sana valinta muuttuu.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Valitse vain kun kaikki valitut näppäimet pidetään painettuna:</translation>
     </message>
     <message>

--- a/locale/fr.ts
+++ b/locale/fr.ts
@@ -3118,7 +3118,7 @@ in the pressed state when the word selection changes.</source>
       <translation>La pop-up n&apos;apparâit que si toutes les touches sélectionnées sont enfoncées lorsque la sélection de mot change.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>N'appuyer sur la sélection que lorsque toutes les touches sélectionnées sont maintenues enfoncées :</translation>
     </message>
     <message>

--- a/locale/hi.ts
+++ b/locale/hi.ts
@@ -3113,7 +3113,7 @@ in the pressed state when the word selection changes.</source>
       <translation>इसके सक्षम होने पर, जब शब्द चयन बदलता है तो पॉपअप केवल तभी दिखाई देगा जब सभी चुनी हुई कुंजियों की स्थिति दबी हुई हो।</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>केवल तभी चयन करें जब सभी चयनित कुंजियाँ दबाई जाएं:</translation>
     </message>
     <message>

--- a/locale/hu.ts
+++ b/locale/hu.ts
@@ -3120,7 +3120,7 @@ in the pressed state when the word selection changes.</source>
 kijelölésekor, ha a kiválasztott billentyűk mindegyike le van nyomva.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>A kijelölés változását csak a billentyűk együttes lenyomásakor figyelje:</translation>
     </message>
     <message>

--- a/locale/ie.ts
+++ b/locale/ie.ts
@@ -3120,8 +3120,8 @@ in the pressed state when the word selection changes.</source>
 in the pressed state when the word selection changes.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
-      <translation>Only tack selection when all selected keys are kept pressed:</translation>
+      <source>Only track selection when all selected keys are kept pressed:</source>
+      <translation>Only track selection when all selected keys are kept pressed:</translation>
     </message>
     <message>
       <source>Alt key</source>

--- a/locale/it.ts
+++ b/locale/it.ts
@@ -3120,7 +3120,7 @@ delle parole puntate quando i tasti scelti vengono effettivamente premuti.
 Le parole tradotte verranno mostrate in una finestra di dialogo a comparsa.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Tack selezione solo quando tutti i tasti selezionati vengono mantenuti premuti:</translation>
     </message>
     <message>

--- a/locale/ja.ts
+++ b/locale/ja.ts
@@ -3117,7 +3117,7 @@ in the pressed state when the word selection changes.</source>
 すべての選択されたキーが押されている状態でのみ表示されます。</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>選択したすべてのキーが押された場合のみタック選択:</translation>
     </message>
     <message>

--- a/locale/jbo.ts
+++ b/locale/jbo.ts
@@ -3120,8 +3120,8 @@ in the pressed state when the word selection changes.</source>
 in the pressed state when the word selection changes.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
-      <translation>Only tack selection when all selected keys are kept pressed:</translation>
+      <source>Only track selection when all selected keys are kept pressed:</source>
+      <translation>Only track selection when all selected keys are kept pressed:</translation>
     </message>
     <message>
       <source>Alt key</source>

--- a/locale/kab.ts
+++ b/locale/kab.ts
@@ -3120,8 +3120,8 @@ in the pressed state when the word selection changes.</source>
 in the pressed state when the word selection changes.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
-      <translation>Only tack selection when all selected keys are kept pressed:</translation>
+      <source>Only track selection when all selected keys are kept pressed:</source>
+      <translation>Only track selection when all selected keys are kept pressed:</translation>
     </message>
     <message>
       <source>Alt key</source>

--- a/locale/ko.ts
+++ b/locale/ko.ts
@@ -3118,7 +3118,7 @@ in the pressed state when the word selection changes.</source>
 눌려진 상태에서만 팝업이 나타납니다.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>선택한 모든 키를 계속 누르고 있을 때만 압정 선택:</translation>
     </message>
     <message>

--- a/locale/lt.ts
+++ b/locale/lt.ts
@@ -3120,7 +3120,7 @@ in the pressed state when the word selection changes.</source>
 po to, kai pasikeis pažymėtas žodis.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Tack pasirinkimas tik tada, kai visi pasirinkti klavišai laikomi nuspausti:</translation>
     </message>
     <message>

--- a/locale/mk.ts
+++ b/locale/mk.ts
@@ -3121,7 +3121,7 @@ in the pressed state when the word selection changes.</source>
 во притисната сосојба, кога избраните зборови не менуваат.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Избор на так само кога сите избрани копчиња се држат притиснати:</translation>
     </message>
     <message>

--- a/locale/nl.ts
+++ b/locale/nl.ts
@@ -3120,7 +3120,7 @@ in the pressed state when the word selection changes.</source>
 toetsen zijn ingedrukt wanneer de woordselectie verandert.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Alleen tack selectie als alle geselecteerde toetsen worden ingedrukt:</translation>
     </message>
     <message>

--- a/locale/pl.ts
+++ b/locale/pl.ts
@@ -3117,7 +3117,7 @@ in the pressed state when the word selection changes.</source>
 kiedy zaznaczenie słowa ulega zmianie przy naciśniętych wszystkich wybranych klawiszach.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Śledź zaznaczenie tylko wtedy, gdy wszystkie wybrane klawisze są naciśnięte:</translation>
     </message>
     <message>

--- a/locale/pt.ts
+++ b/locale/pt.ts
@@ -3120,7 +3120,7 @@ in the pressed state when the word selection changes.</source>
 no estado pressionado quando a seleção de palavras mudar.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Apenas seleção tack quando todas as chaves selecionadas forem pressionadas:</translation>
     </message>
     <message>

--- a/locale/pt_BR.ts
+++ b/locale/pt_BR.ts
@@ -3124,7 +3124,7 @@ in the pressed state when the word selection changes.</source>
 teclas do atalho estiverem premidas quando a seleção de palavra mudar.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Apenas seleção tack quando todas as chaves selecionadas forem pressionadas:</translation>
     </message>
     <message>

--- a/locale/qu.ts
+++ b/locale/qu.ts
@@ -3118,7 +3118,7 @@ in the pressed state when the word selection changes.</source>
 seleccionadas estén oprimidas cuando la selección de la palabra cambie.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Tack akllaylla llapa akllasqa llavekuna ñit'isqa kaptinlla:</translation>
     </message>
     <message>

--- a/locale/ru.ts
+++ b/locale/ru.ts
@@ -3124,7 +3124,7 @@ in the pressed state when the word selection changes.</source>
 находятся в зажатом состоянии в момент выделения слова.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Следить за выделенным текстом только когда все эти клавиши зажаты</translation>
     </message>
     <message>

--- a/locale/sk.ts
+++ b/locale/sk.ts
@@ -3115,7 +3115,7 @@ in the pressed state when the word selection changes.</source>
       <translation>Pokiaľ toto povolíte, vyskakovacie okno sa zobrazí iba v prípade, keď budú stlačené zvolené klávesy počas výberu slova.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Voľba prichytenia len vtedy, keď sú stlačené všetky zvolené klávesy:</translation>
     </message>
     <message>

--- a/locale/sq.ts
+++ b/locale/sq.ts
@@ -3115,7 +3115,7 @@ in the pressed state when the word selection changes.</source>
 janë në gjendjen e shtypur.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Zgjedhja e ngjitjes vetëm kur të gjithë tastet e zgjedhur mbahen të shtypur:</translation>
     </message>
     <message>

--- a/locale/sr.ts
+++ b/locale/sr.ts
@@ -3121,7 +3121,7 @@ in the pressed state when the word selection changes.</source>
 у притиснутом стању, када се избор речи промени.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Одабир хватања само када се сви изабрани тастери држе притиснути:</translation>
     </message>
     <message>

--- a/locale/sv.ts
+++ b/locale/sv.ts
@@ -3119,7 +3119,7 @@ in the pressed state when the word selection changes.</source>
 angivna tangenterna är nedtryckta när ordet markeras.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Endast tack val när alla valda nycklar hålls tryckt:</translation>
     </message>
     <message>

--- a/locale/tg.ts
+++ b/locale/tg.ts
@@ -3120,7 +3120,7 @@ in the pressed state when the word selection changes.</source>
 агар ҳангоми интихоби калима ҳамаи тугмаҳои интихобшуда зер карда шаванд.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Танҳо вақте ки ҳамаи тугмаҳои интихобшуда пахш карда мешаванд, интихоби такя:</translation>
     </message>
     <message>

--- a/locale/tk.ts
+++ b/locale/tk.ts
@@ -3119,7 +3119,7 @@ in the pressed state when the word selection changes.</source>
 basylan ýagdaýynda görkeziler.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Selectedhli saýlanan düwmeler basylanda diňe saýlamany çözüň:</translation>
     </message>
     <message>

--- a/locale/tr.ts
+++ b/locale/tr.ts
@@ -3118,7 +3118,7 @@ in the pressed state when the word selection changes.</source>
 Aksi halde fare, sözcüğün üzerine geldiğinde çeviri yapılır.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Yalnızca tüm seçili tuşlar basılı tutulduğunda teyel seçimi:</translation>
     </message>
     <message>

--- a/locale/uk.ts
+++ b/locale/uk.ts
@@ -3117,7 +3117,7 @@ in the pressed state when the word selection changes.</source>
 всіх вибраних клавіш з виділеним словом.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Вибір буде скинуто лише коли всі вибрані ключі будуть збережені:</translation>
     </message>
     <message>

--- a/locale/vi.ts
+++ b/locale/vi.ts
@@ -3116,7 +3116,7 @@ in the pressed state when the word selection changes.</source>
       <translation>Khi chọn từ cần tra nghĩa, nhấn phím tắt đã chọn để hiện popup.</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>Chỉ giải quyết lựa chọn khi tất cả các phím đã chọn được nhấn:</translation>
     </message>
     <message>

--- a/locale/zh_CN.ts
+++ b/locale/zh_CN.ts
@@ -3109,7 +3109,7 @@ in the pressed state when the word selection changes.</source>
       <translation>启用后，屏幕取词窗口只有在按住特定按键时才会弹出。</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>仅当指定按钮被按时，文本取词</translation>
     </message>
     <message>

--- a/locale/zh_TW.ts
+++ b/locale/zh_TW.ts
@@ -3109,7 +3109,7 @@ in the pressed state when the word selection changes.</source>
       <translation>啟用後，螢幕取詞視窗只有在按住特定按鍵時才會彈出。</translation>
     </message>
     <message>
-      <source>Only tack selection when all selected keys are kept pressed:</source>
+      <source>Only track selection when all selected keys are kept pressed:</source>
       <translation>僅在按住下列特定的按鍵時螢幕取詞才會啟動：</translation>
     </message>
     <message>

--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -689,7 +689,7 @@ be the last ones.</string>
 in the pressed state when the word selection changes.</string>
             </property>
             <property name="text">
-             <string>Only tack selection when all selected keys are kept pressed:</string>
+             <string>Only track selection when all selected keys are kept pressed:</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Fix typo in the preferences dialog:
<img width="1006" height="710" alt="image" src="https://github.com/user-attachments/assets/97c10a0b-7013-47c2-8d08-c88c7fa333bb" />
