### PR TITLE
docs: Add --no-config option to mpv command

### DIFF
--- a/website/docs/ui_audioengine.md
+++ b/website/docs/ui_audioengine.md
@@ -16,7 +16,7 @@ ffplay -autoexit -nodisp
 
 mpv:
 ```
-mpv --no-video --no-audio-display
+mpv --no-video --no-audio-display --no-config
 ```
 
 or other audio player.


### PR DESCRIPTION
If users install and use mpv daily and also want to use mpv for Goldendict-ng, it's very likely that some plugins might interfere and make the OSD still show up. `--no-config` could predictably prevent that.