### PR TITLE
Fix: Python package manager script execution warning in deploy_website.yml (#36)

### DIFF
--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material==9.7.6
+      - run: pip install --only-binary :all: mkdocs-material==9.7.6
       - run: |
           cd website
           mkdocs gh-deploy --force


### PR DESCRIPTION
Adds \--only-binary :all:\ to \pip install mkdocs-material\ to prevent execution of setup scripts during installation.