### PR TITLE
refactor(dict): unify indexIsOldOrBad logic across all dictionary types

### DIFF
--- a/src/dict/aard.cc
+++ b/src/dict/aard.cc
@@ -92,7 +92,7 @@ struct IdxHeader
 static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
 
-bool indexIsOldOrBad( string const & indexFile, const vector< string > & dictFiles )
+bool indexIsOldOrBad( const string & indexFile, const vector< string > & dictFiles )
 {
   return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion );
 }

--- a/src/dict/aard.cc
+++ b/src/dict/aard.cc
@@ -87,18 +87,14 @@ struct IdxHeader
   quint32 articleCount;
   quint32 langFrom; // Source language
   quint32 langTo;   // Target language
+  uint64_t sourceLastModified;
 };
 static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
 
-bool indexIsOldOrBad( string const & indexFile )
+bool indexIsOldOrBad( string const & indexFile, const vector< string > & dictFiles )
 {
-  File::Index idx( indexFile, QIODevice::ReadOnly );
-
-  IdxHeader header;
-
-  return idx.readRecords( &header, sizeof( header ), 1 ) != 1 || header.signature != Signature
-    || header.formatVersion != CurrentFormatVersion;
+  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion );
 }
 
 void readJSONValue( const string & source, string & str, string::size_type & pos )
@@ -769,7 +765,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
 
     string indexFile = indicesDir + dictId;
 
-    if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile ) ) {
+    if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile, dictFiles ) ) {
       try {
 
         qDebug( "Aard: Building the index for dictionary: %s", fileName.c_str() );
@@ -963,6 +959,8 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
         }
 
         idx.rewind();
+
+        idxHeader.sourceLastModified = BtreeIndexing::computeSourceLastModified( dictFiles );
 
         idx.write( &idxHeader, sizeof( idxHeader ) );
       }

--- a/src/dict/bgl.cc
+++ b/src/dict/bgl.cc
@@ -70,19 +70,17 @@ struct IdxHeader
   uint32_t iconSize;           // Size of the icon in the chunks' storage, 0 = no icon
   uint32_t descriptionAddress; // Address of the dictionary description in the chunks' storage
   uint32_t descriptionSize;    // Size of the description in the chunks' storage, 0 = no description
+  uint64_t sourceLastModified;
 };
 static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
 
-bool indexIsOldOrBad( string const & indexFile )
+bool indexIsOldOrBad( string const & indexFile, const vector< string > & dictFiles )
 {
-  File::Index idx( indexFile, QIODevice::ReadOnly );
-
-  IdxHeader header;
-
-  return idx.readRecords( &header, sizeof( header ), 1 ) != 1 || header.signature != Signature
-    || header.formatVersion != CurrentFormatVersion || header.parserVersion != Babylon::ParserVersion
-    || header.foldingVersion != Folding::Version;
+  auto extraCheck = []( const IdxHeader & h ) -> bool {
+    return h.parserVersion == Babylon::ParserVersion && h.foldingVersion == Folding::Version;
+  };
+  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion, &extraCheck );
 }
 
 // Removes the $1$-like postfix
@@ -1040,7 +1038,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
 
     string indexFile = indicesDir + dictId;
 
-    if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile ) ) {
+    if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile, dictFiles ) ) {
       // Building the index
 
       qDebug( "Bgl: Building the index for dictionary: %s", fileName.c_str() );
@@ -1179,6 +1177,8 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
         idxHeader.langTo         = b.targetLang(); //LangCoder::findIdForLanguage( Utf8::decode( b.targetLang() ) );
 
         idx.rewind();
+
+        idxHeader.sourceLastModified = BtreeIndexing::computeSourceLastModified( dictFiles );
 
         idx.write( &idxHeader, sizeof( idxHeader ) );
       }

--- a/src/dict/bgl.cc
+++ b/src/dict/bgl.cc
@@ -75,12 +75,16 @@ struct IdxHeader
 static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
 
-bool indexIsOldOrBad( string const & indexFile, const vector< string > & dictFiles )
+bool indexIsOldOrBad( const string & indexFile, const vector< string > & dictFiles )
 {
   auto extraCheck = []( const IdxHeader & h ) -> bool {
     return h.parserVersion == Babylon::ParserVersion && h.foldingVersion == Folding::Version;
   };
-  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion, &extraCheck );
+  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile,
+                                                      dictFiles,
+                                                      Signature,
+                                                      CurrentFormatVersion,
+                                                      &extraCheck );
 }
 
 // Removes the $1$-like postfix

--- a/src/dict/btreeidx.hh
+++ b/src/dict/btreeidx.hh
@@ -71,7 +71,7 @@ bool indexIsOldOrBad( const string & indexFile,
 
   // Run any extra validation (e.g. parserVersion, foldingVersion, hasZipFile, etc.)
   if constexpr ( !std::is_same_v< ExtraCheckFn, void * > ) {
-    if ( extraCheck && !extraCheck( header ) ) {
+    if ( extraCheck && !( *extraCheck )( header ) ) {
       return true;
     }
   }

--- a/src/dict/btreeidx.hh
+++ b/src/dict/btreeidx.hh
@@ -12,6 +12,8 @@
 #include <QFuture>
 #include <QList>
 #include <lmdb.h>
+#include <QFileInfo>
+#include <type_traits>
 
 
 /// A base for the dictionary which creates a btree index to look up
@@ -36,6 +38,75 @@ enum {
 DEF_EX( exIndexWasNotOpened, "The index wasn't opened", Dictionary::Ex )
 DEF_EX( exFailedToDecompressNode, "Failed to decompress a btree's node", Dictionary::Ex )
 DEF_EX( exCorruptedChainData, "Corrupted chain data in the leaf of a btree encountered", Dictionary::Ex )
+
+/// Checks whether the index file's header is old or corrupted.
+/// Returns true if the index needs to be rebuilt.
+/// This reads the header from the index file and validates:
+///   1. The file can be read and header size matches
+///   2. The signature matches the expected value
+///   3. The formatVersion matches the expected value
+///   4. The sourceLastModified timestamp (at the end of the header) matches
+///      the current dictionary files' maximum modification time
+///   5. Any additional validation via the extraCheck callback
+///
+/// Template parameters:
+///   IdxHeader - the dictionary-specific header struct (must start with signature and formatVersion)
+///   ExtraCheckFn - optional callable for additional version checks (e.g. parserVersion, foldingVersion)
+///
+/// The IdxHeader struct's LAST field must be `uint64_t sourceLastModified`.
+template< typename IdxHeader, typename ExtraCheckFn = void * >
+bool indexIsOldOrBad( const string & indexFile,
+                      const vector< string > & dictFiles,
+                      uint32_t expectedSignature,
+                      uint32_t expectedFormatVersion,
+                      ExtraCheckFn * extraCheck = nullptr )
+{
+  File::Index idx( indexFile, QIODevice::ReadOnly );
+  IdxHeader header;
+
+  if ( idx.readRecords( &header, sizeof( header ), 1 ) != 1 || header.signature != expectedSignature
+       || header.formatVersion != expectedFormatVersion ) {
+    return true;
+  }
+
+  // Run any extra validation (e.g. parserVersion, foldingVersion, hasZipFile, etc.)
+  if constexpr ( !std::is_same_v< ExtraCheckFn, void * > ) {
+    if ( extraCheck && !extraCheck( header ) ) {
+      return true;
+    }
+  }
+
+  // Check if any of the dictionary files were modified after the index was built
+  qint64 lastModified = 0;
+  for ( const auto & dictionaryFile : dictFiles ) {
+    QFileInfo fileInfo( QString::fromUtf8( dictionaryFile.c_str() ) );
+    if ( fileInfo.exists() ) {
+      qint64 ts = fileInfo.lastModified().toMSecsSinceEpoch();
+      if ( ts > lastModified ) {
+        lastModified = ts;
+      }
+    }
+  }
+
+  return header.sourceLastModified != (uint64_t)lastModified;
+}
+
+/// Computes the maximum lastModified timestamp from the given dictionary files.
+/// This should be called when building the index and the result stored in IdxHeader::sourceLastModified.
+inline uint64_t computeSourceLastModified( const vector< string > & dictFiles )
+{
+  qint64 lastModified = 0;
+  for ( const auto & dictionaryFile : dictFiles ) {
+    QFileInfo fileInfo( QString::fromUtf8( dictionaryFile.c_str() ) );
+    if ( fileInfo.exists() ) {
+      qint64 ts = fileInfo.lastModified().toMSecsSinceEpoch();
+      if ( ts > lastModified ) {
+        lastModified = ts;
+      }
+    }
+  }
+  return (uint64_t)lastModified;
+}
 
 /// This structure describes a word linked to its translation. The
 /// translation is represented as an abstract 32-bit offset.

--- a/src/dict/dictdfiles.cc
+++ b/src/dict/dictdfiles.cc
@@ -59,19 +59,15 @@ struct IdxHeader
   uint32_t indexRootOffset;
   uint32_t langFrom; // Source language
   uint32_t langTo;   // Target language
+  uint64_t sourceLastModified;
 };
 static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
 
 
-bool indexIsOldOrBad( string const & indexFile )
+bool indexIsOldOrBad( string const & indexFile, const vector< string > & dictFiles )
 {
-  File::Index idx( indexFile, QIODevice::ReadOnly );
-
-  IdxHeader header;
-
-  return idx.readRecords( &header, sizeof( header ), 1 ) != 1 || header.signature != Signature
-    || header.formatVersion != CurrentFormatVersion;
+  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion );
 }
 
 class DictdDictionary: public BtreeIndexing::BtreeDictionary
@@ -576,7 +572,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
 
       string indexFile = indicesDir + dictId;
 
-      if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile ) ) {
+      if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile, dictFiles ) ) {
         // Building the index
         string dictionaryName = nameFromFileName( dictFiles[ 0 ] );
 
@@ -716,6 +712,8 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
 
         idxHeader.langFrom = langs.first;
         idxHeader.langTo   = langs.second;
+
+        idxHeader.sourceLastModified = BtreeIndexing::computeSourceLastModified( dictFiles );
 
         idx.rewind();
 

--- a/src/dict/dictdfiles.cc
+++ b/src/dict/dictdfiles.cc
@@ -65,7 +65,7 @@ static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
 
 
-bool indexIsOldOrBad( string const & indexFile, const vector< string > & dictFiles )
+bool indexIsOldOrBad( const string & indexFile, const vector< string > & dictFiles )
 {
   return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion );
 }

--- a/src/dict/dsl.cc
+++ b/src/dict/dsl.cc
@@ -90,6 +90,7 @@ struct IdxHeader
                                      // resource index.
   uint32_t zipIndexRootOffset;
   char zipIndexSuffix[ 64 ];        // Suffix for the zip index LMDB file
+  uint64_t sourceLastModified;
 };
 static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
@@ -109,15 +110,18 @@ struct InsidedCard
   InsidedCard() = default;
 };
 
-bool indexIsOldOrBad( const string & indexFile, bool hasZipFile )
+bool indexIsOldOrBad( const string & indexFile, const vector< string > & dictFiles, bool hasZipFile )
 {
-  File::Index idx( indexFile, QIODevice::ReadOnly );
-
-  IdxHeader header;
-
-  return idx.readRecords( &header, sizeof( header ), 1 ) != 1 || header.signature != Signature
-    || header.formatVersion != CurrentFormatVersion || (bool)header.hasZipFile != hasZipFile
-    || ( hasZipFile && header.zipSupportVersion != CurrentZipSupportVersion );
+  auto extraCheck = [ hasZipFile ]( const IdxHeader & h ) -> bool {
+    if ( (bool)h.hasZipFile != hasZipFile ) {
+      return false;
+    }
+    if ( hasZipFile && h.zipSupportVersion != CurrentZipSupportVersion ) {
+      return false;
+    }
+    return true;
+  };
+  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion, &extraCheck );
 }
 
 class DslDictionary: public BtreeIndexing::BtreeDictionary
@@ -1755,7 +1759,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
       string indexFile = indicesDir + dictId;
 
       if ( Dictionary::needToRebuildIndex( dictFiles, indexFile )
-           || indexIsOldOrBad( indexFile, zipFileName.size() ) ) {
+           || indexIsOldOrBad( indexFile, dictFiles, zipFileName.size() ) ) {
         DslScanner scanner( fileName );
 
         try { // Here we intercept any errors during the read to save line at
@@ -2171,6 +2175,8 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
           idxHeader.langTo   = dslLanguageToId( scanner.getLangTo() );
 
           idx.rewind();
+
+          idxHeader.sourceLastModified = BtreeIndexing::computeSourceLastModified( dictFiles );
 
           idx.write( &idxHeader, sizeof( idxHeader ) );
 

--- a/src/dict/dsl.cc
+++ b/src/dict/dsl.cc
@@ -121,7 +121,11 @@ bool indexIsOldOrBad( const string & indexFile, const vector< string > & dictFil
     }
     return true;
   };
-  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion, &extraCheck );
+  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile,
+                                                      dictFiles,
+                                                      Signature,
+                                                      CurrentFormatVersion,
+                                                      &extraCheck );
 }
 
 class DslDictionary: public BtreeIndexing::BtreeDictionary

--- a/src/dict/epwing.cc
+++ b/src/dict/epwing.cc
@@ -56,7 +56,7 @@ struct IdxHeader
 static_assert( alignof( IdxHeader ) == 1 );
   #pragma pack( pop )
 
-bool indexIsOldOrBad( string const & indexFile, const vector< string > & dictFiles )
+bool indexIsOldOrBad( const string & indexFile, const vector< string > & dictFiles )
 {
   return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion );
 }

--- a/src/dict/epwing.cc
+++ b/src/dict/epwing.cc
@@ -51,18 +51,14 @@ struct IdxHeader
   quint32 nameSize;
   quint32 langFrom; // Source language
   quint32 langTo;   // Target language
+  uint64_t sourceLastModified;
 };
 static_assert( alignof( IdxHeader ) == 1 );
   #pragma pack( pop )
 
-bool indexIsOldOrBad( string const & indexFile )
+bool indexIsOldOrBad( string const & indexFile, const vector< string > & dictFiles )
 {
-  File::Index idx( indexFile, QIODevice::ReadOnly );
-
-  IdxHeader header;
-
-  return idx.readRecords( &header, sizeof( header ), 1 ) != 1 || header.signature != Signature
-    || header.formatVersion != CurrentFormatVersion;
+  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion );
 }
 class EpwingHeadwordsRequest;
 
@@ -1159,7 +1155,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
 
         string indexFile = indicesDir + dictId;
 
-        if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile ) ) {
+        if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile, dictFiles ) ) {
           qDebug( "Epwing: Building the index for dictionary in directory %s", dir.toUtf8().data() );
 
           QString str         = dict.title();
@@ -1231,6 +1227,8 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
           idxHeader.articleCount = articleCount;
 
           idx.rewind();
+
+          idxHeader.sourceLastModified = BtreeIndexing::computeSourceLastModified( dictFiles );
 
           idx.write( &idxHeader, sizeof( idxHeader ) );
 

--- a/src/dict/gls.cc
+++ b/src/dict/gls.cc
@@ -313,19 +313,23 @@ struct IdxHeader
                                      // resource index.
   uint32_t zipIndexRootOffset;
   char zipIndexSuffix[ 64 ];        // Suffix for the zip index LMDB file
+  uint64_t sourceLastModified;
 };
 static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
 
-bool indexIsOldOrBad( string const & indexFile, bool hasZipFile )
+bool indexIsOldOrBad( string const & indexFile, const vector< string > & dictFiles, bool hasZipFile )
 {
-  File::Index idx( indexFile, QIODevice::ReadOnly );
-
-  IdxHeader header;
-
-  return idx.readRecords( &header, sizeof( header ), 1 ) != 1 || header.signature != Signature
-    || header.formatVersion != CurrentFormatVersion || (bool)header.hasZipFile != hasZipFile
-    || ( hasZipFile && header.zipSupportVersion != CurrentZipSupportVersion );
+  auto extraCheck = [ hasZipFile ]( const IdxHeader & h ) -> bool {
+    if ( (bool)h.hasZipFile != hasZipFile ) {
+      return false;
+    }
+    if ( hasZipFile && h.zipSupportVersion != CurrentZipSupportVersion ) {
+      return false;
+    }
+    return true;
+  };
+  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion, &extraCheck );
 }
 
 class GlsDictionary: public BtreeIndexing::BtreeDictionary
@@ -1223,7 +1227,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
       string indexFile = indicesDir + dictId;
 
       if ( Dictionary::needToRebuildIndex( dictFiles, indexFile )
-           || indexIsOldOrBad( indexFile, zipFileName.size() ) ) {
+           || indexIsOldOrBad( indexFile, dictFiles, zipFileName.size() ) ) {
         GlsScanner scanner( fileName );
 
         try { // Here we intercept any errors during the read to save line at
@@ -1393,6 +1397,8 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
           }
 
           idx.rewind();
+
+          idxHeader.sourceLastModified = BtreeIndexing::computeSourceLastModified( dictFiles );
 
           idx.write( &idxHeader, sizeof( idxHeader ) );
         } // In-place try for saving line count

--- a/src/dict/gls.cc
+++ b/src/dict/gls.cc
@@ -318,7 +318,7 @@ struct IdxHeader
 static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
 
-bool indexIsOldOrBad( string const & indexFile, const vector< string > & dictFiles, bool hasZipFile )
+bool indexIsOldOrBad( const string & indexFile, const vector< string > & dictFiles, bool hasZipFile )
 {
   auto extraCheck = [ hasZipFile ]( const IdxHeader & h ) -> bool {
     if ( (bool)h.hasZipFile != hasZipFile ) {
@@ -329,7 +329,11 @@ bool indexIsOldOrBad( string const & indexFile, const vector< string > & dictFil
     }
     return true;
   };
-  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion, &extraCheck );
+  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile,
+                                                      dictFiles,
+                                                      Signature,
+                                                      CurrentFormatVersion,
+                                                      &extraCheck );
 }
 
 class GlsDictionary: public BtreeIndexing::BtreeDictionary

--- a/src/dict/lsa.cc
+++ b/src/dict/lsa.cc
@@ -59,7 +59,7 @@ struct IdxHeader
 static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
 
-bool indexIsOldOrBad( string const & indexFile, const vector< string > & dictFiles )
+bool indexIsOldOrBad( const string & indexFile, const vector< string > & dictFiles )
 {
   return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion );
 }

--- a/src/dict/lsa.cc
+++ b/src/dict/lsa.cc
@@ -54,18 +54,14 @@ struct IdxHeader
   uint32_t vorbisOffset;          // Offset of the vorbis file which contains all snds
   uint32_t indexBtreeMaxElements; // Two fields from IndexInfo
   uint32_t indexRootOffset;
+  uint64_t sourceLastModified;
 };
 static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
 
-bool indexIsOldOrBad( string const & indexFile )
+bool indexIsOldOrBad( string const & indexFile, const vector< string > & dictFiles )
 {
-  File::Index idx( indexFile, QIODevice::ReadOnly );
-
-  IdxHeader header;
-
-  return idx.readRecords( &header, sizeof( header ), 1 ) != 1 || header.signature != Signature
-    || header.formatVersion != CurrentFormatVersion;
+  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion );
 }
 
 string stripExtension( const string & str )
@@ -533,7 +529,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
 
       string indexFile = indicesDir + dictId;
 
-      if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile ) ) {
+      if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile, dictFiles ) ) {
         // Building the index
 
         qDebug( "Lsa: Building the index for dictionary: %s", i->c_str() );
@@ -601,6 +597,8 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
 
         idxHeader.signature     = Signature;
         idxHeader.formatVersion = CurrentFormatVersion;
+
+        idxHeader.sourceLastModified = BtreeIndexing::computeSourceLastModified( dictFiles );
 
         idx.rewind();
 

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -1407,30 +1407,12 @@ private:
 };
 
 
-static bool indexIsOldOrBad( const vector< string > & dictFiles, const string & indexFile )
+static bool indexIsOldOrBad( const string & indexFile, const vector< string > & dictFiles )
 {
-  File::Index idx( indexFile, QIODevice::ReadOnly );
-  IdxHeader header;
-
-  if ( idx.readRecords( &header, sizeof( header ), 1 ) != 1 || header.signature != kSignature
-       || header.formatVersion != kCurrentFormatVersion || header.parserVersion != MdictParser::kParserVersion
-       || header.foldingVersion != Folding::Version ) {
-    return true;
-  }
-
-  // Check if any of the dictionary files were modified after the index was built
-  qint64 lastModified = 0;
-  for ( const auto & dictionaryFile : dictFiles ) {
-    QFileInfo fileInfo( QString::fromUtf8( dictionaryFile.c_str() ) );
-    if ( fileInfo.exists() ) {
-      qint64 ts = fileInfo.lastModified().toMSecsSinceEpoch();
-      if ( ts > lastModified ) {
-        lastModified = ts;
-      }
-    }
-  }
-
-  return header.sourceLastModified != (uint64_t)lastModified;
+  auto extraCheck = []( const IdxHeader & h ) -> bool {
+    return h.parserVersion == MdictParser::kParserVersion && h.foldingVersion == Folding::Version;
+  };
+  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, kSignature, kCurrentFormatVersion, &extraCheck );
 }
 
 static void findResourceFiles( const string & mdx, vector< string > & dictFiles )
@@ -1477,7 +1459,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
     string dictId    = Dictionary::makeDictionaryId( dictFiles );
     string indexFile = indicesDir + dictId;
 
-    if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( dictFiles, indexFile ) ) {
+    if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile, dictFiles ) ) {
       // Building the index
 
       qDebug( "MDict: Building the index for dictionary: %s", fileName.c_str() );
@@ -1640,18 +1622,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
       idxHeader.articleCount   = parser.wordCount();
       idxHeader.wordCount      = parser.wordCount();
 
-      // Compute and store the source last modified timestamp
-      qint64 lastModified = 0;
-      for ( const auto & dictionaryFile : dictFiles ) {
-        QFileInfo fileInfo( QString::fromUtf8( dictionaryFile.c_str() ) );
-        if ( fileInfo.exists() ) {
-          qint64 ts = fileInfo.lastModified().toMSecsSinceEpoch();
-          if ( ts > lastModified ) {
-            lastModified = ts;
-          }
-        }
-      }
-      idxHeader.sourceLastModified = (uint64_t)lastModified;
+      idxHeader.sourceLastModified = BtreeIndexing::computeSourceLastModified( dictFiles );
 
       idx.rewind();
       idx.write( &idxHeader, sizeof( idxHeader ) );

--- a/src/dict/mdx.cc
+++ b/src/dict/mdx.cc
@@ -1412,7 +1412,11 @@ static bool indexIsOldOrBad( const string & indexFile, const vector< string > & 
   auto extraCheck = []( const IdxHeader & h ) -> bool {
     return h.parserVersion == MdictParser::kParserVersion && h.foldingVersion == Folding::Version;
   };
-  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, kSignature, kCurrentFormatVersion, &extraCheck );
+  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile,
+                                                      dictFiles,
+                                                      kSignature,
+                                                      kCurrentFormatVersion,
+                                                      &extraCheck );
 }
 
 static void findResourceFiles( const string & mdx, vector< string > & dictFiles )

--- a/src/dict/sdict.cc
+++ b/src/dict/sdict.cc
@@ -88,7 +88,7 @@ struct IdxHeader
 static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
 
-bool indexIsOldOrBad( string const & indexFile, const vector< string > & dictFiles )
+bool indexIsOldOrBad( const string & indexFile, const vector< string > & dictFiles )
 {
   return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion );
 }

--- a/src/dict/sdict.cc
+++ b/src/dict/sdict.cc
@@ -83,18 +83,14 @@ struct IdxHeader
   uint32_t compressionType; // Data compression in file. 0 - no compression, 1 - zip, 2 - bzip2
   uint32_t langFrom;        // Source language
   uint32_t langTo;          // Target language
+  uint64_t sourceLastModified;
 };
 static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
 
-bool indexIsOldOrBad( string const & indexFile )
+bool indexIsOldOrBad( string const & indexFile, const vector< string > & dictFiles )
 {
-  File::Index idx( indexFile, QIODevice::ReadOnly );
-
-  IdxHeader header;
-
-  return idx.readRecords( &header, sizeof( header ), 1 ) != 1 || header.signature != Signature
-    || header.formatVersion != CurrentFormatVersion;
+  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion );
 }
 
 class SdictDictionary: public BtreeIndexing::BtreeDictionary
@@ -663,7 +659,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
 
     string indexFile = indicesDir + dictId;
 
-    if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile ) ) {
+    if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile, dictFiles ) ) {
       try {
         qDebug( "SDict: Building the index for dictionary: %s", fileName.c_str() );
 
@@ -767,6 +763,8 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
         idxHeader.langFrom        = LangCoder::code2toInt( dictHeader.inputLang );
         idxHeader.langTo          = LangCoder::code2toInt( dictHeader.outputLang );
         idxHeader.compressionType = compression;
+
+        idxHeader.sourceLastModified = BtreeIndexing::computeSourceLastModified( dictFiles );
 
         idx.rewind();
 

--- a/src/dict/slob.cc
+++ b/src/dict/slob.cc
@@ -73,6 +73,7 @@ struct IdxHeader
   quint32 langFrom; // Source language
   quint32 langTo;   // Target language
   char resourceIndexSuffix[ 64 ]; // Suffix for the resource index LMDB file
+  uint64_t sourceLastModified;
 };
 static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
@@ -87,14 +88,9 @@ struct RefEntry
   QString fragment;
 };
 
-bool indexIsOldOrBad( const string & indexFile )
+bool indexIsOldOrBad( const string & indexFile, const vector< string > & dictFiles )
 {
-  File::Index idx( indexFile, QIODevice::ReadOnly );
-
-  IdxHeader header;
-
-  return idx.readRecords( &header, sizeof( header ), 1 ) != 1 || header.signature != Signature
-    || header.formatVersion != CurrentFormatVersion;
+  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion );
 }
 
 
@@ -1260,7 +1256,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
     string indexFile = indicesDir + dictId;
 
     try {
-      if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile ) ) {
+      if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile, dictFiles ) ) {
         SlobFile sf;
 
         qDebug( "Slob: Building the index for dictionary: %s", fileName.c_str() );
@@ -1353,6 +1349,8 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
 
         idxHeader.langFrom = langs.first;
         idxHeader.langTo   = langs.second;
+
+        idxHeader.sourceLastModified = BtreeIndexing::computeSourceLastModified( dictFiles );
 
         idx.rewind();
 

--- a/src/dict/sounddir.cc
+++ b/src/dict/sounddir.cc
@@ -50,7 +50,7 @@ struct IdxHeader
 static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
 
-bool indexIsOldOrBad( string const & indexFile, const vector< string > & dictFiles )
+bool indexIsOldOrBad( const string & indexFile, const vector< string > & dictFiles )
 {
   return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion );
 }

--- a/src/dict/sounddir.cc
+++ b/src/dict/sounddir.cc
@@ -45,18 +45,14 @@ struct IdxHeader
   uint32_t dirTimestampsOffset;   // Offset to directory timestamps map
   uint32_t indexBtreeMaxElements; // Two fields from IndexInfo
   uint32_t indexRootOffset;
+  uint64_t sourceLastModified;
 };
 static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
 
-bool indexIsOldOrBad( string const & indexFile )
+bool indexIsOldOrBad( string const & indexFile, const vector< string > & dictFiles )
 {
-  File::Index idx( indexFile, QIODevice::ReadOnly );
-
-  IdxHeader header;
-
-  return idx.readRecords( &header, sizeof( header ), 1 ) != 1 || header.signature != Signature
-    || header.formatVersion != CurrentFormatVersion;
+  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion );
 }
 
 class SoundDirDictionary: public BtreeIndexing::BtreeDictionary
@@ -442,7 +438,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const Config::SoundDirs & 
 
     bool rebuildNeeded;
 
-    if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile ) ) {
+    if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile, dictFiles ) ) {
       rebuildNeeded = true;
     }
     else {
@@ -564,6 +560,8 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const Config::SoundDirs & 
 
       idxHeader.signature     = Signature;
       idxHeader.formatVersion = CurrentFormatVersion;
+
+      idxHeader.sourceLastModified = BtreeIndexing::computeSourceLastModified( dictFiles );
 
       idx.rewind();
 

--- a/src/dict/stardict.cc
+++ b/src/dict/stardict.cc
@@ -109,28 +109,7 @@ static_assert( alignof( IdxHeader ) == 1 );
 
 bool indexIsOldOrBad( const string & indexFile, const vector< string > & dictFiles )
 {
-  File::Index idx( indexFile, QIODevice::ReadOnly );
-
-  IdxHeader header;
-
-  if ( idx.readRecords( &header, sizeof( header ), 1 ) != 1 || header.signature != Signature
-       || header.formatVersion != CurrentFormatVersion ) {
-    return true;
-  }
-
-  // Check if any of the dictionary files were modified after the index was built
-  qint64 lastModified = 0;
-  for ( const auto & dictionaryFile : dictFiles ) {
-    QFileInfo fileInfo( QString::fromUtf8( dictionaryFile.c_str() ) );
-    if ( fileInfo.exists() ) {
-      qint64 ts = fileInfo.lastModified().toMSecsSinceEpoch();
-      if ( ts > lastModified ) {
-        lastModified = ts;
-      }
-    }
-  }
-
-  return header.sourceLastModified != (uint64_t)lastModified;
+  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion );
 }
 
 class StardictDictionary: public BtreeIndexing::BtreeDictionary
@@ -1966,18 +1945,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
 
         idx.write( idxHeader );
 
-        // Compute and store the source last modified timestamp
-        qint64 lastModified = 0;
-        for ( const auto & dictionaryFile : dictFiles ) {
-          QFileInfo fileInfo( QString::fromUtf8( dictionaryFile.c_str() ) );
-          if ( fileInfo.exists() ) {
-            qint64 ts = fileInfo.lastModified().toMSecsSinceEpoch();
-            if ( ts > lastModified ) {
-              lastModified = ts;
-            }
-          }
-        }
-        idxHeader.sourceLastModified = (uint64_t)lastModified;
+        idxHeader.sourceLastModified = BtreeIndexing::computeSourceLastModified( dictFiles );
 
         idx.write( ifo.bookname.data(), ifo.bookname.size() );
         idx.write( ifo.sametypesequence.data(), ifo.sametypesequence.size() );

--- a/src/dict/xdxf.cc
+++ b/src/dict/xdxf.cc
@@ -110,12 +110,16 @@ struct IdxHeader
 static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
 
-bool indexIsOldOrBad( string const & indexFile, const vector< string > & dictFiles )
+bool indexIsOldOrBad( const string & indexFile, const vector< string > & dictFiles )
 {
   auto extraCheck = []( const IdxHeader & h ) -> bool {
     return h.articleFormat != 0;
   };
-  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion, &extraCheck );
+  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile,
+                                                      dictFiles,
+                                                      Signature,
+                                                      CurrentFormatVersion,
+                                                      &extraCheck );
 }
 
 

--- a/src/dict/xdxf.cc
+++ b/src/dict/xdxf.cc
@@ -105,18 +105,17 @@ struct IdxHeader
   uint32_t zipIndexRootOffset;
   uint32_t revisionNumber; // Format revision
   char zipIndexSuffix[ 64 ];        // Suffix for the zip index LMDB file
+  uint64_t sourceLastModified;
 };
 static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
 
-bool indexIsOldOrBad( string const & indexFile )
+bool indexIsOldOrBad( string const & indexFile, const vector< string > & dictFiles )
 {
-  File::Index idx( indexFile, QIODevice::ReadOnly );
-
-  IdxHeader header;
-
-  return idx.readRecords( &header, sizeof( header ), 1 ) != 1 || header.signature != Signature
-    || header.formatVersion != CurrentFormatVersion || !header.articleFormat;
+  auto extraCheck = []( const IdxHeader & h ) -> bool {
+    return h.articleFormat != 0;
+  };
+  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion, &extraCheck );
 }
 
 
@@ -1037,7 +1036,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
 
       string indexFile = indicesDir + dictId;
 
-      if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile ) ) {
+      if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile, dictFiles ) ) {
         // Building the index
 
         qDebug( "Xdxf: Building the index for dictionary: %s", fileName.c_str() );
@@ -1321,6 +1320,8 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
               idxHeader.wordCount    = wordCount;
 
               idx.rewind();
+
+              idxHeader.sourceLastModified = BtreeIndexing::computeSourceLastModified( dictFiles );
 
               idx.write( &idxHeader, sizeof( idxHeader ) );
 

--- a/src/dict/zim.cc
+++ b/src/dict/zim.cc
@@ -78,19 +78,15 @@ struct IdxHeader
   quint32 descriptionPtr;
   quint32 langFrom; // Source language
   quint32 langTo;   // Target language
+  uint64_t sourceLastModified;
 };
 static_assert( alignof( IdxHeader ) == 1 );
   #pragma pack( pop )
 
 // Some supporting functions
-bool indexIsOldOrBad( const string & indexFile )
+bool indexIsOldOrBad( const string & indexFile, const vector< string > & dictFiles )
 {
-  File::Index idx( indexFile, QIODevice::ReadOnly );
-
-  IdxHeader header;
-
-  return idx.readRecords( &header, sizeof( header ), 1 ) != 1 || header.signature != Signature
-    || header.formatVersion != CurrentFormatVersion;
+  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion );
 }
 
 quint32 getArticleCluster( const ZimFile & file, quint32 articleNumber )
@@ -804,7 +800,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
 
     try {
       //only check zim file.
-      if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile ) ) {
+      if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile, dictFiles ) ) {
         qDebug( "Zim: Building the index for dictionary: %s", fileName.c_str() );
 
         unsigned articleCount = df.getArticleCount();
@@ -886,6 +882,8 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
         idxHeader.wordCount    = wordCount;
 
         idx.rewind();
+
+        idxHeader.sourceLastModified = BtreeIndexing::computeSourceLastModified( dictFiles );
 
         idx.write( &idxHeader, sizeof( idxHeader ) );
       }

--- a/src/dict/zipsounds.cc
+++ b/src/dict/zipsounds.cc
@@ -49,18 +49,14 @@ struct IdxHeader
   uint32_t indexBtreeMaxElements; // Two fields from IndexInfo
   uint32_t indexRootOffset;
   uint32_t chunksOffset; // The offset to chunks' storage
+  uint64_t sourceLastModified;
 };
 static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
 
-bool indexIsOldOrBad( string const & indexFile )
+bool indexIsOldOrBad( string const & indexFile, const vector< string > & dictFiles )
 {
-  File::Index idx( indexFile, QIODevice::ReadOnly );
-
-  IdxHeader header;
-
-  return idx.readRecords( &header, sizeof( header ), 1 ) != 1 || header.signature != Signature
-    || header.formatVersion != CurrentFormatVersion;
+  return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion );
 }
 
 std::u32string stripExtension( const string & str )
@@ -392,7 +388,7 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
       string dictId    = Dictionary::makeDictionaryId( dictFiles );
       string indexFile = indicesDir + dictId;
 
-      if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile ) ) {
+      if ( Dictionary::needToRebuildIndex( dictFiles, indexFile ) || indexIsOldOrBad( indexFile, dictFiles ) ) {
         qDebug( "Zips: Building the index for dictionary: %s", fileName.c_str() );
 
         File::Index idx( indexFile, QIODevice::WriteOnly );
@@ -452,6 +448,8 @@ vector< sptr< Dictionary::Class > > makeDictionaries( const vector< string > & f
           idxHeader.formatVersion = CurrentFormatVersion;
 
           idxHeader.soundsCount = namesCount;
+
+          idxHeader.sourceLastModified = BtreeIndexing::computeSourceLastModified( dictFiles );
 
           idx.rewind();
 

--- a/src/dict/zipsounds.cc
+++ b/src/dict/zipsounds.cc
@@ -54,7 +54,7 @@ struct IdxHeader
 static_assert( alignof( IdxHeader ) == 1 );
 #pragma pack( pop )
 
-bool indexIsOldOrBad( string const & indexFile, const vector< string > & dictFiles )
+bool indexIsOldOrBad( const string & indexFile, const vector< string > & dictFiles )
 {
   return BtreeIndexing::indexIsOldOrBad< IdxHeader >( indexFile, dictFiles, Signature, CurrentFormatVersion );
 }


### PR DESCRIPTION
## Summary

This PR unifies the indexIsOldOrBad logic across all 15 Btree-indexed dictionary types, eliminating ~150 lines of duplicated code.

## Changes

### New Infrastructure (btreeidx.hh)
- Added BtreeIndexing::indexIsOldOrBad<IdxHeader, ExtraCheckFn>() template function
- Added BtreeIndexing::computeSourceLastModified() utility function

### Refactored Dictionary Types
All 15 Btree-indexed types now use the unified logic.

## Key Improvements
1. Eliminates ~150 lines of duplicated code
2. All types now validate sourceLastModified timestamp
3. Type-safe extensibility via ExtraCheckFn template parameter
4. Future changes only need to be made in one place