### PR TITLE
refactor: Unify dictionaryId generation for portable and non-portable modes

### DIFF
--- a/src/dict/dictionary.cc
+++ b/src/dict/dictionary.cc
@@ -566,7 +566,7 @@ string makeDictionaryId( const vector< string > & dictionaryFiles ) noexcept
 
   for ( const auto & full : dictionaryFiles ) {
     QFileInfo fileInfo( QString::fromStdString( full ) );
-    QString dirName = fileInfo.dir().dirName();
+    QString dirName  = fileInfo.dir().dirName();
     QString baseName = fileInfo.fileName();
     sortedList.push_back( ( dirName + "/" + baseName ).toStdString() );
   }

--- a/src/dict/dictionary.cc
+++ b/src/dict/dictionary.cc
@@ -562,28 +562,13 @@ qsizetype findMatchingBracket( const QString & css, qsizetype startPos )
 string makeDictionaryId( const vector< string > & dictionaryFiles ) noexcept
 {
   std::vector< string > sortedList;
+  sortedList.reserve( dictionaryFiles.size() );
 
-  if ( Config::isPortableVersion() ) {
-    // For portable version, we use relative paths
-    sortedList.reserve( dictionaryFiles.size() );
-
-    const QDir dictionariesDir( Config::getPortableVersionDictionaryDir() );
-
-    for ( const auto & full : dictionaryFiles ) {
-      QFileInfo fileInfo( QString::fromStdString( full ) );
-
-      if ( fileInfo.isAbsolute() ) {
-        sortedList.push_back( dictionariesDir.relativeFilePath( fileInfo.filePath() ).toStdString() );
-      }
-      else {
-        // Well, it's relative. We don't technically support those, but
-        // what the heck
-        sortedList.push_back( full );
-      }
-    }
-  }
-  else {
-    sortedList = dictionaryFiles;
+  for ( const auto & full : dictionaryFiles ) {
+    QFileInfo fileInfo( QString::fromStdString( full ) );
+    QString dirName = fileInfo.dir().dirName();
+    QString baseName = fileInfo.fileName();
+    sortedList.push_back( ( dirName + "/" + baseName ).toStdString() );
   }
 
   std::sort( sortedList.begin(), sortedList.end() );
@@ -591,7 +576,6 @@ string makeDictionaryId( const vector< string > & dictionaryFiles ) noexcept
   QCryptographicHash hash( QCryptographicHash::Md5 );
 
   for ( const auto & i : sortedList ) {
-    // Note: a null byte at the end is a must
     hash.addData( { i.c_str(), static_cast< qsizetype >( i.size() + 1 ) } );
   }
 


### PR DESCRIPTION
Use parent directory name + file name combination to generate dictionaryId, no longer distinguish between portable and non-portable modes:

**Changes:**
- Removed the branch logic that distinguished between portable and non-portable modes
- Use parent directory name/file name format to generate ID (e.g. FolderA/dict.mdx)
- Preserve file extensions to differentiate dictionary formats

**Effects:**
- Same dictionary in different folders will generate different IDs, treated as separate dictionaries
- Path information is concise without full system paths
- Portable and non-portable modes now use identical generation logic