### PR TITLE
Add Release-chaos workflow

### DIFF
--- a/.github/workflows/Release-chaos.yml
+++ b/.github/workflows/Release-chaos.yml
@@ -1,0 +1,249 @@
+name: Release Chaos
+concurrency:
+   group: ${{ github.workflow }}-${{ github.ref }}
+   cancel-in-progress: true
+env:
+  prerelease: true
+  versionSuffix: 'chaos'
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - chaos
+    paths-ignore:
+      - 'docs/**'
+      - "howto/**"
+      - "*.md"
+      - ".clang-format"
+jobs:
+  build_macOS:
+    permissions:
+      contents: read
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-14,macos-15-intel]
+        qt_ver: [ 6.8.3, 6.10.3 ]
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          submodules: true
+      - name: Install dependencies
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
+        run: |
+          brew install --force --overwrite \
+            bzip2 \
+            create-dmg \
+            hunspell \
+            libiconv \
+            libogg \
+            libvorbis \
+            libzim \
+            lzip \
+            ninja \
+            ccache \
+            opencc \
+            fmt \
+            ffmpeg@6 \
+            tomlplusplus \
+            xapian || true
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ runner.os }}-${{ matrix.qt_ver }}
+      - name: Cache EB
+        id: cache-eb
+        uses: actions/cache@v4
+        with:
+          path: |
+            /usr/local/lib/libeb*
+            /usr/local/include/eb
+            /usr/local/bin/eb*
+          key: ${{ runner.os }}-${{ runner.arch }}-eb-custom
+      - name: Install EB
+        if: steps.cache-eb.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 https://github.com/xiaoyifang/eb.git
+          cd eb && ./configure && make -j 8 && sudo make install && cd ..
+      - uses: jurplel/install-qt-action@v4.2.1
+        with:
+          version: ${{ matrix.qt_ver }}
+          arch: clang_64
+          modules: qtwebengine qtwebchannel qtpositioning qt5compat qtmultimedia qtimageformats qtspeech
+      - name: Build
+        run: |
+          mkdir build_dir
+          export PKG_CONFIG_PATH="`brew --prefix ffmpeg@6`/lib/pkgconfig:$PKG_CONFIG_PATH"
+          cmake -S . -B build_dir \
+            -G Ninja \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DWITH_FFMPEG_PLAYER=ON \
+            -DWITH_QT_MULTIMEDIA=OFF \
+            -DWITH_TTS=OFF \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET="12.0"
+          cmake --build build_dir
+      - name: Package
+        run: |
+          cmake --install build_dir/
+      - name: Print package content
+        run: |
+          ls -Rl ./build_dir/redist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: macOS-${{ matrix.os }}-Qt${{ matrix.qt_ver }}
+          if-no-files-found: error
+          retention-days: 7
+          path: '*.dmg'
+
+  build_Windows:
+    permissions:
+      contents: read
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-2022]
+        qt_ver: [ 6.8.3, 6.10.3 ]
+        arch: [ win64_msvc2022_64 ]
+        include:
+          - arch: win64_msvc2022_64
+            vs_arch: amd64
+    steps:
+      - uses: jurplel/install-qt-action@v4.2.1
+        with:
+          version: ${{ matrix.qt_ver }}
+          arch: ${{ matrix.arch }}
+          modules: qtwebengine qtwebchannel qtpositioning qt5compat qtmultimedia qtimageformats qtspeech
+      - uses: actions/checkout@v6.0.2
+        with:
+          submodules: true
+      - name: Build
+        id: build
+        run: |
+          & 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1' `
+            -SkipAutomaticLocation -Arch ${{ matrix.vs_arch }} -HostArch amd64
+          New-Item -Path './build_dir' -ItemType Directory
+
+          cmake -S . -B "./build_dir" `
+            -G Ninja `
+            -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" `
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo `
+            -DWITH_FFMPEG_PLAYER=OFF `
+            -DWITH_VCPKG_BREAKPAD=ON
+          cmake --build "./build_dir"
+      - name: Package
+        run: |
+          cd './build_dir'
+          cpack --verbose --trace
+          cd ..
+      - name: Move files
+        shell: bash
+        run: |
+          namePrefix=$(basename "$(ls ./build_dir/*.7z)" .7z)
+
+          cd ./build_dir
+          mv "${namePrefix}.7z" "${namePrefix}-Windows-installer.7z"
+          mv "${namePrefix}.exe" "${namePrefix}-Windows-installer.exe"
+          mv ./goldendict/goldendict.exe "./${namePrefix}-Windows-main-exe-file-only.exe"
+          mv ./goldendict/goldendict.pdb "./${namePrefix}-Windows-pdb-debug-file.pdb"
+          cd ..
+          ls -R
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Windows-${{ matrix.arch }}-Qt${{ matrix.qt_ver }}
+          if-no-files-found: error
+          retention-days: 7
+          path: |
+            ./build_dir/*.exe
+            ./build_dir/*.7z
+            ./build_dir/*.pdb
+
+  generate_other_staffs:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    outputs:
+      newTag: ${{ steps.getNewTag.outputs.newTag }}
+      releaseTitle: ${{steps.getReleaseTitle.outputs.releaseTitle}}
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Load version from VERSION file
+        run: echo "version=$(xargs < VERSION)" >> $GITHUB_ENV
+      - name: Get previous tag
+        id: changelogTags
+        run: |
+          previousTag=$(git tag --sort=-creatordate | grep "_chaos" | grep -v -e "vcpkg" | head -n 1)
+          if [ -z "$previousTag" ]; then
+            previousTag=$(git tag --sort=-creatordate | grep "^v" | head -n 1)
+          fi
+          echo "prev_tag=$previousTag" >> $GITHUB_OUTPUT
+          echo "previousTag : $previousTag"
+      - name: Build Changelog
+        id: build_changelog
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: ${{ steps.changelogTags.outputs.prev_tag }}..HEAD
+        env:
+          OUTPUT: changelog.txt
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Add chaos warning to changelog
+        run: |
+          printf '%s\n' '## ⚠️ WARNING' '' '**⚠️ THIS BUILD CONTAINS BREAKING CHANGES AND IS NOT BACKWARDS COMPATIBLE!**' '' '- May cause all dictionaries to be reindexed' '- Data format may change significantly' '- No guarantee of data compatibility with previous versions' '- Backup dictionary data before upgrading' '' "Based on branch: ${GITHUB_REF_NAME}" > chaos_warning.txt
+          cat chaos_warning.txt >> changelog.txt
+      - name: Print changelog.txt
+        run: |
+          cat changelog.txt
+      - name: Get git short SHA
+        id: shortSHA
+        run: |
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Get new tag
+        id: getNewTag
+        run: |
+          echo "newTag=v${{ env.version }}_${{ env.versionSuffix }}.${{ steps.shortSHA.outputs.sha_short }}" >> $GITHUB_OUTPUT
+      - name: Get release title
+        id: getReleaseTitle
+        run: |
+          echo "releaseTitle=Chaos Build v${{env.version}}-${{ steps.shortSHA.outputs.sha_short }}" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: changelog.txt
+          if-no-files-found: error
+          retention-days: 7
+          path: ./changelog.txt
+
+  publish:
+    needs: [build_macOS, build_Windows, generate_other_staffs]
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04
+    env:
+        newTag: ${{ needs.generate_other_staffs.outputs.newTag }}
+        releaseTitle: ${{ needs.generate_other_staffs.outputs.releaseTitle }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+      - name: List all files
+        run: ls -R
+      - name: Create new tag
+        run: |
+          gh release create '${{ env.newTag }}' \
+            -t '${{ env.releaseTitle }}' \
+            --target '${{ github.ref_name }}' \
+            --notes-file=./changelog.txt \
+            --latest=false \
+            --prerelease \
+            --repo ${GITHUB_REPOSITORY}
+      - name: Upload artifacts
+        run: |
+          gh release upload '${{ env.newTag }}' --repo ${GITHUB_REPOSITORY} --clobber \
+            *.7z *.exe *.pdb *.dmg

--- a/.github/workflows/Release-chaos.yml
+++ b/.github/workflows/Release-chaos.yml
@@ -194,7 +194,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Add chaos warning to changelog
         run: |
-          printf '%s\n' '## ⚠️ WARNING' '' '**⚠️ THIS BUILD CONTAINS BREAKING CHANGES AND IS NOT BACKWARDS COMPATIBLE!**' '' '- May cause all dictionaries to be reindexed' '- Data format may change significantly' '- No guarantee of data compatibility with previous versions' '- Backup dictionary data before upgrading' '' "Based on branch: ${GITHUB_REF_NAME}" > chaos_warning.txt
+          cat > chaos_warning.txt << 'EOF'
+          > [!CAUTION]
+          > ## ⚠️ THIS BUILD CONTAINS BREAKING CHANGES AND IS NOT BACKWARDS COMPATIBLE!
+          >
+          > - **May cause all dictionaries to be reindexed**
+          > - **Data format may change significantly**
+          > - **No guarantee of data compatibility with previous versions**
+          > - **Backup dictionary data before upgrading**
+          >
+          > Based on branch: ${{ github.ref_name }}
+          EOF
+
           cat chaos_warning.txt >> changelog.txt
       - name: Print changelog.txt
         run: |


### PR DESCRIPTION
This PR adds a new GitHub Actions workflow for the chaos branch that:

- Triggers on push to chaos branch
- Creates prerelease with _chaos suffix (e.g., v1.0.0_chaos.abc123)
- Includes warning note about breaking changes in release notes
- Follows the same build process as Release-all workflow