### PR TITLE
CI: Separate artifact uploads for Windows build

### DIFF
--- a/.github/workflows/Manual-Build-Action.yml
+++ b/.github/workflows/Manual-Build-Action.yml
@@ -89,11 +89,12 @@ jobs:
       - name: Print package content
         run: |
           ls -Rl ./build_dir/redist
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: macOS-${{ matrix.os }}-Qt${{ matrix.qt_ver }}
           if-no-files-found: error
           retention-days: 7
+          archive: false
           path: '*.dmg'
 
   build_Windows:
@@ -152,27 +153,30 @@ jobs:
           mv ./goldendict/goldendict.pdb "./${namePrefix}-Windows-pdb.pdb"
           cd ..
           ls -R
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: Windows-${{ matrix.arch }}-Qt${{ matrix.qt_ver }}
           if-no-files-found: error
           retention-days: 7
+          archive: false
           path: |
             ./build_dir/*.7z
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: Windows-only-exe-${{ matrix.arch }}-Qt${{ matrix.qt_ver }}
           if-no-files-found: error
           retention-days: 7
+          archive: false
           path: |
             ./build_dir/*only.exe
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: Windows-pdb-${{ matrix.arch }}-Qt${{ matrix.qt_ver }}
           if-no-files-found: error
           retention-days: 7
+          archive: false
           path: |
             ./build_dir/*.pdb
          

--- a/.github/workflows/Manual-Build-Action.yml
+++ b/.github/workflows/Manual-Build-Action.yml
@@ -148,8 +148,8 @@ jobs:
           # note the name will ensure `installer` ranked higher after sorting
           cd ./build_dir
           mv "${namePrefix}.7z" "${namePrefix}-Windows-installer.7z"
-          mv ./goldendict/goldendict.exe "./${namePrefix}-Windows-main-exe-file-only.exe" 
-          mv ./goldendict/goldendict.pdb "./${namePrefix}-Windows-pdb-debug-file.pdb"
+          mv ./goldendict/goldendict.exe "./${namePrefix}-Windows-exe-only.exe" 
+          mv ./goldendict/goldendict.pdb "./${namePrefix}-Windows-pdb.pdb"
           cd ..
           ls -R
       - uses: actions/upload-artifact@v4
@@ -158,9 +158,7 @@ jobs:
           if-no-files-found: error
           retention-days: 7
           path: |
-            ./build_dir/*.exe
             ./build_dir/*.7z
-            ./build_dir/*.pdb
 
       - uses: actions/upload-artifact@v4
         with:
@@ -169,6 +167,13 @@ jobs:
           retention-days: 7
           path: |
             ./build_dir/*only.exe
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Windows-pdb-${{ matrix.arch }}-Qt${{ matrix.qt_ver }}
+          if-no-files-found: error
+          retention-days: 7
+          path: |
             ./build_dir/*.pdb
          
   

--- a/.github/workflows/Manual-Build-Action.yml
+++ b/.github/workflows/Manual-Build-Action.yml
@@ -176,7 +176,6 @@ jobs:
           name: Windows-pdb-${{ matrix.arch }}-Qt${{ matrix.qt_ver }}
           if-no-files-found: error
           retention-days: 7
-          archive: false
           path: |
             ./build_dir/*.pdb
          

--- a/.github/workflows/Release-all.yml
+++ b/.github/workflows/Release-all.yml
@@ -154,8 +154,8 @@ jobs:
           cd ./build_dir
           mv "${namePrefix}.7z" "${namePrefix}-Windows-installer.7z"
           mv "${namePrefix}.exe" "${namePrefix}-Windows-installer.exe"
-          mv ./goldendict/goldendict.exe "./${namePrefix}-Windows-main-exe-file-only.exe"
-          mv ./goldendict/goldendict.pdb "./${namePrefix}-Windows-pdb-debug-file.pdb"
+          mv ./goldendict/goldendict.exe "./${namePrefix}-Windows-exe-only.exe"
+          mv ./goldendict/goldendict.pdb "./${namePrefix}-Windows-pdb.pdb"
           cd ..
           ls -R
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/Release-all.yml
+++ b/.github/workflows/Release-all.yml
@@ -163,7 +163,6 @@ jobs:
           name: Windows-${{ matrix.arch }}-Qt${{ matrix.qt_ver }}
           if-no-files-found: error
           retention-days: 7
-          archive: false
           path: |
             ./build_dir/*.exe
             ./build_dir/*.7z

--- a/.github/workflows/Release-all.yml
+++ b/.github/workflows/Release-all.yml
@@ -94,11 +94,12 @@ jobs:
       - name: Print package content
         run: |
           ls -Rl ./build_dir/redist
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: macOS-${{ matrix.os }}-Qt${{ matrix.qt_ver }}
           if-no-files-found: error
           retention-days: 7
+          archive: false
           path: '*.dmg'
 
   build_Windows:
@@ -157,11 +158,12 @@ jobs:
           mv ./goldendict/goldendict.pdb "./${namePrefix}-Windows-pdb-debug-file.pdb"
           cd ..
           ls -R
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: Windows-${{ matrix.arch }}-Qt${{ matrix.qt_ver }}
           if-no-files-found: error
           retention-days: 7
+          archive: false
           path: |
             ./build_dir/*.exe
             ./build_dir/*.7z
@@ -257,11 +259,12 @@ jobs:
             echo "releaseTitle=v${{ env.version }}-${{ env.versionSuffix }}.${{ steps.shortSHA.outputs.sha_short }}" >> $GITHUB_OUTPUT
           fi
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: changelog.txt
           if-no-files-found: error
           retention-days: 7
+          archive: false
           path: ./changelog.txt
 
   publish:
@@ -274,7 +277,7 @@ jobs:
         releaseTitle: ${{ needs.generate_other_staffs.outputs.releaseTitle }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           merge-multiple: true
       - name: List all files

--- a/.github/workflows/Release-chaos.yml
+++ b/.github/workflows/Release-chaos.yml
@@ -92,11 +92,12 @@ jobs:
       - name: Print package content
         run: |
           ls -Rl ./build_dir/redist
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: macOS-${{ matrix.os }}-Qt${{ matrix.qt_ver }}
           if-no-files-found: error
           retention-days: 7
+          archive: false
           path: '*.dmg'
 
   build_Windows:
@@ -151,11 +152,12 @@ jobs:
           mv ./goldendict/goldendict.pdb "./${namePrefix}-Windows-pdb-debug-file.pdb"
           cd ..
           ls -R
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: Windows-${{ matrix.arch }}-Qt${{ matrix.qt_ver }}
           if-no-files-found: error
           retention-days: 7
+          archive: false
           path: |
             ./build_dir/*.exe
             ./build_dir/*.7z
@@ -223,11 +225,12 @@ jobs:
         run: |
           echo "releaseTitle=Chaos Build v${{env.version}}-${{ steps.shortSHA.outputs.sha_short }}" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: changelog.txt
           if-no-files-found: error
           retention-days: 7
+          archive: false
           path: ./changelog.txt
 
   publish:
@@ -240,7 +243,7 @@ jobs:
         releaseTitle: ${{ needs.generate_other_staffs.outputs.releaseTitle }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           merge-multiple: true
       - name: List all files

--- a/.github/workflows/Release-chaos.yml
+++ b/.github/workflows/Release-chaos.yml
@@ -157,7 +157,6 @@ jobs:
           name: Windows-${{ matrix.arch }}-Qt${{ matrix.qt_ver }}
           if-no-files-found: error
           retention-days: 7
-          archive: false
           path: |
             ./build_dir/*.exe
             ./build_dir/*.7z

--- a/.github/workflows/Release-chaos.yml
+++ b/.github/workflows/Release-chaos.yml
@@ -148,8 +148,8 @@ jobs:
           cd ./build_dir
           mv "${namePrefix}.7z" "${namePrefix}-Windows-installer.7z"
           mv "${namePrefix}.exe" "${namePrefix}-Windows-installer.exe"
-          mv ./goldendict/goldendict.exe "./${namePrefix}-Windows-main-exe-file-only.exe"
-          mv ./goldendict/goldendict.pdb "./${namePrefix}-Windows-pdb-debug-file.pdb"
+          mv ./goldendict/goldendict.exe "./${namePrefix}-Windows-exe-only.exe"
+          mv ./goldendict/goldendict.pdb "./${namePrefix}-Windows-pdb.pdb"
           cd ..
           ls -R
       - uses: actions/upload-artifact@v7


### PR DESCRIPTION
Separate Windows build artifacts into individual uploads to avoid large file issues. Also added archive: false to keep original file formats.