### PR TITLE
ci(workflows): fix Ubuntu dependency installation issues

### DIFF
--- a/.github/workflows/PR-check-cmake.yml
+++ b/.github/workflows/PR-check-cmake.yml
@@ -19,9 +19,9 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          # sudo apt-get update
+          sudo apt-get update
 
-          sudo apt-get install build-essential ninja-build ccache \
+          sudo apt-get install -y --fix-missing build-essential ninja-build ccache \
           libvorbis-dev zlib1g-dev libhunspell-dev x11proto-record-dev \
           libxtst-dev liblzo2-dev libbz2-dev \
           libavutil-dev libavformat-dev libeb16-dev \

--- a/.github/workflows/Sonar Cloud.yml
+++ b/.github/workflows/Sonar Cloud.yml
@@ -19,9 +19,9 @@ jobs:
     steps:            
       - name: ubuntu install thirdparty dependencies
         run: |
-          # sudo apt-get update
+          sudo apt-get update
           
-          sudo apt-get install build-essential ninja-build \
+          sudo apt-get install -y --fix-missing build-essential ninja-build \
           libvorbis-dev zlib1g-dev libhunspell-dev x11proto-record-dev \
           libxtst-dev liblzo2-dev libbz2-dev \
           libavutil-dev libavformat-dev libeb16-dev \


### PR DESCRIPTION
Fix Ubuntu dependency installation issues in CI workflows by:

- Uncommenting  to ensure package lists are up-to-date
- Adding  flags to  for more reliable installations

This should resolve potential failures when installing build dependencies on Ubuntu runners.