### PR TITLE
ci: rename Windows artifact in Manual-Build-Action

### DIFF
--- a/.github/workflows/Manual-Build-Action.yml
+++ b/.github/workflows/Manual-Build-Action.yml
@@ -146,9 +146,8 @@ jobs:
         run: |
           namePrefix=$(basename "$(ls ./build_dir/*.7z)" .7z)
 
-          # note the name will ensure `installer` ranked higher after sorting
           cd ./build_dir
-          mv "${namePrefix}.7z" "${namePrefix}-Windows-installer.7z"
+          mv "${namePrefix}.7z" "${namePrefix}-Windows.7z"
           mv ./goldendict/goldendict.exe "./${namePrefix}-Windows-exe-only.exe" 
           mv ./goldendict/goldendict.pdb "./${namePrefix}-Windows-pdb.pdb"
           cd ..


### PR DESCRIPTION
Renamed the Windows 7z artifact from \-Windows-installer.7z\ to \-Windows.7z\ and removed an outdated comment in the Manual-Build-Action workflow.