### PR TITLE
CI: fix lmdb dependency and tag search logic

### DIFF
--- a/.github/workflows/Manual-Build-Action.yml
+++ b/.github/workflows/Manual-Build-Action.yml
@@ -41,6 +41,7 @@ jobs:
             libogg \
             libvorbis \
             libzim \
+            lmdb \
             lzip \
             ninja \
             ccache \

--- a/.github/workflows/Release-chaos.yml
+++ b/.github/workflows/Release-chaos.yml
@@ -41,6 +41,7 @@ jobs:
             libogg \
             libvorbis \
             libzim \
+            lmdb \
             lzip \
             ninja \
             ccache \
@@ -178,9 +179,6 @@ jobs:
         id: changelogTags
         run: |
           previousTag=$(git tag --sort=-creatordate | grep "_chaos" | grep -v -e "vcpkg" | head -n 1)
-          if [ -z "$previousTag" ]; then
-            previousTag=$(git tag --sort=-creatordate | grep "^v" | head -n 1)
-          fi
           echo "prev_tag=$previousTag" >> $GITHUB_OUTPUT
           echo "previousTag : $previousTag"
       - name: Build Changelog

--- a/.github/workflows/Release-chaos.yml
+++ b/.github/workflows/Release-chaos.yml
@@ -146,8 +146,7 @@ jobs:
           namePrefix=$(basename "$(ls ./build_dir/*.7z)" .7z)
 
           cd ./build_dir
-          mv "${namePrefix}.7z" "${namePrefix}-Windows-installer.7z"
-          mv "${namePrefix}.exe" "${namePrefix}-Windows-installer.exe"
+          mv "${namePrefix}.7z" "${namePrefix}-Windows.7z"
           mv ./goldendict/goldendict.exe "./${namePrefix}-Windows-exe-only.exe"
           mv ./goldendict/goldendict.pdb "./${namePrefix}-Windows-pdb.pdb"
           cd ..


### PR DESCRIPTION
This PR:
- Adds 'lmdb' dependency to macOS build workflows (Manual and Release Chaos).
- Fixes the tag search logic to only look for '_chaos' tags.