### PR TITLE
fix: prevent dictionary file locking when reloading or changing settings

### DIFF
--- a/src/common/globalbroadcaster.cc
+++ b/src/common/globalbroadcaster.cc
@@ -189,6 +189,11 @@ sptr< Dictionary::Class > GlobalBroadcaster::getDictionaryById( const QString & 
   return dictMap.value( dictId );
 }
 
+void GlobalBroadcaster::clearDictMap()
+{
+  dictMap.clear();
+}
+
 void GlobalBroadcaster::setGroups( Instances::Groups * _groups )
 {
   groups = _groups;

--- a/src/common/globalbroadcaster.hh
+++ b/src/common/globalbroadcaster.hh
@@ -51,6 +51,7 @@ public:
   void setAllDictionaries( std::vector< sptr< Dictionary::Class > > * _allDictionaries );
   const std::vector< sptr< Dictionary::Class > > * getAllDictionaries() const;
   sptr< Dictionary::Class > getDictionaryById( const QString & dictId );
+  void clearDictMap();
   void setGroups( Instances::Groups * _groups );
   const Instances::Groups * getGroups() const;
   void addLsaDictMapping( const QString & dictId, const QString & path );

--- a/src/dict/loaddictionaries.cc
+++ b/src/dict/loaddictionaries.cc
@@ -221,6 +221,7 @@ void loadDictionaries( QWidget * parent,
                        QNetworkAccessManager & dictNetMgr,
                        bool doDeferredInit_ )
 {
+  GlobalBroadcaster::instance()->clearDictMap();
   dictionaries.clear();
 
   bool showSplashWindow = !cfg.preferences.enableTrayIcon || !cfg.preferences.startToTray;

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -2262,6 +2262,8 @@ void MainWindow::editDictionaries( unsigned editDictionaryGroup )
 
       cfg = newCfg;
 
+      dictMap = Dictionary::dictToMap( dictionaries );
+
       updateGroupList();
 
       Config::save( cfg );


### PR DESCRIPTION
This PR fixes an issue where GoldenDict-ng continues to lock dictionary files after they are removed or modified in settings.

### Cause
Old \sptr<Dictionary::Class>\ references were kept alive in two static/class-level maps, preventing the ref count from reaching 0 and the old dictionaries from being destroyed:
1. \GlobalBroadcaster::dictMap\ (global dictionary lookup cache) was never cleared upon dictionary reload.
2. \MainWindow::dictMap\ (main window lookup cache) was not updated when dictionaries were modified in the dictionary settings dialog (\editDictionaries\).

### Solution
1. Introduced \clearDictMap()\ method in \GlobalBroadcaster\.
2. Clear \GlobalBroadcaster\'s dictionary cache automatically at the start of the unified \loadDictionaries()\ function.
3. Update \MainWindow::dictMap\ when dictionaries are changed inside \MainWindow::editDictionaries()\.