### PR TITLE
style: refactor .gddictname in st-lingoes theme

### DIFF
--- a/src/stylesheets/article-style-st-lingoes.css
+++ b/src/stylesheets/article-style-st-lingoes.css
@@ -42,17 +42,19 @@ body {
 }
 
 .gddictname {
-  display: inline-block;
+  display: flex;
+  align-items: center;
+  width: fit-content;
   /* border: 1px solid #92b0dd; */
-  padding: 0.2em;
-  padding-left: 0.5em;
-  padding-right: 0.5em;
+  padding: 0.2em 0.5em;
   margin-top: 1em;
-  margin-bottom: -0.1em;
+  margin-bottom: 0;
   background: #cfddf0;
   color: #000080;
   font-weight: normal;
   font-size: 12px;
+  cursor: pointer;
+  user-select: none;
 }
 
 .collapse_expand_area {


### PR DESCRIPTION
Refactor .gddictname from inline-block to flex layout for better alignment and usability.