### PR TITLE
Refactor: Integrate Config::Events into GlobalBroadcaster

### DIFF
--- a/src/common/globalbroadcaster.cc
+++ b/src/common/globalbroadcaster.cc
@@ -245,8 +245,3 @@ bool GlobalBroadcaster::isDarkModeEnabled() const
 #endif
   return darkModeEnabled;
 }
-
-void GlobalBroadcaster::signalMutedDictionariesChanged()
-{
-  emit mutedDictionariesChanged();
-}

--- a/src/common/globalbroadcaster.cc
+++ b/src/common/globalbroadcaster.cc
@@ -245,3 +245,8 @@ bool GlobalBroadcaster::isDarkModeEnabled() const
 #endif
   return darkModeEnabled;
 }
+
+void GlobalBroadcaster::signalMutedDictionariesChanged()
+{
+  emit mutedDictionariesChanged();
+}

--- a/src/common/globalbroadcaster.hh
+++ b/src/common/globalbroadcaster.hh
@@ -92,4 +92,6 @@ signals:
   void websiteDictionarySignal( QString, QString, QString, bool, QString );
 
   void ftsStateChanged();
+
+  void mutedDictionariesChanged();
 };

--- a/src/config.cc
+++ b/src/config.cc
@@ -196,11 +196,6 @@ const Group * Class::getGroup( unsigned id ) const
   return 0;
 }
 
-void Events::signalMutedDictionariesChanged()
-{
-  emit mutedDictionariesChanged();
-}
-
 namespace {
 
 MediaWikis makeDefaultMediaWikis( bool enable )

--- a/src/config.hh
+++ b/src/config.hh
@@ -876,30 +876,6 @@ struct Class
   bool resetState = false;
 };
 
-/// Configuration-specific events. Some parts of the program need to react
-/// to specific changes in configuration. The object of this class is used
-/// to emit signals when such events happen -- and the listeners connect to
-/// them to be notified of them.
-/// This class is separate from the main Class since QObjects can't be copied.
-class Events: public QObject
-{
-  Q_OBJECT
-
-public:
-
-  /// Signals that the value of the mutedDictionaries has changed.
-  /// This emits mutedDictionariesChanged() signal, so the subscribers will
-  /// be notified.
-  void signalMutedDictionariesChanged();
-
-signals:
-
-  /// THe value of the mutedDictionaries has changed.
-  void mutedDictionariesChanged();
-
-private:
-};
-
 DEF_EX( exError, "Error with the program's configuration", std::exception )
 DEF_EX( exCantUseDataDir, "Can't use XDG_DATA_HOME directory to store GoldenDict data", exError )
 DEF_EX( exCantUseHomeDir, "Can't use home directory to store GoldenDict preferences", exError )

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -308,7 +308,7 @@ void DictionaryBar::showContextMenu( QContextMenuEvent * event, bool extended )
   if ( result && result == restoreSelectionAction ) {
     *mutedDictionaries = tempSelectionCapturedMuted.value();
     tempSelectionCapturedMuted.reset();
-    GlobalBroadcaster::instance()->signalMutedDictionariesChanged();
+    GlobalBroadcaster::instance()->mutedDictionariesChanged();
   }
 
   if ( result == editAction ) {
@@ -379,7 +379,7 @@ void DictionaryBar::actionWasTriggered( QAction * action )
       mutedDictionaries->insert( id );
     }
   }
-  GlobalBroadcaster::instance()->signalMutedDictionariesChanged();
+  GlobalBroadcaster::instance()->mutedDictionariesChanged();
 }
 
 void DictionaryBar::selectSingleDict( const QString & id )

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -14,11 +14,9 @@
 using std::vector;
 
 DictionaryBar::DictionaryBar( QWidget * parent,
-                              Config::Events & events,
                               const unsigned short & maxDictionaryRefsInContextMenu_ ):
   QToolBar( tr( "&Dictionary Bar" ), parent ),
   mutedDictionaries( nullptr ),
-  configEvents( events ),
   maxDictionaryRefsInContextMenu( maxDictionaryRefsInContextMenu_ )
 {
   normalIconSize = { this->iconSize().height(), this->iconSize().height() };
@@ -28,7 +26,7 @@ DictionaryBar::DictionaryBar( QWidget * parent,
   maxDictionaryRefsAction =
     new QAction( QIcon( ":/icons/addtab.svg" ), tr( "Extended menu with all dictionaries..." ), this );
 
-  connect( &events, &Config::Events::mutedDictionariesChanged, this, &DictionaryBar::mutedDictionariesChanged );
+  connect( GlobalBroadcaster::instance(), &GlobalBroadcaster::mutedDictionariesChanged, this, &DictionaryBar::mutedDictionariesChanged );
 
   connect( this, &QToolBar::actionTriggered, this, &DictionaryBar::actionWasTriggered );
 }
@@ -308,7 +306,7 @@ void DictionaryBar::showContextMenu( QContextMenuEvent * event, bool extended )
   if ( result && result == restoreSelectionAction ) {
     *mutedDictionaries = tempSelectionCapturedMuted.value();
     tempSelectionCapturedMuted.reset();
-    configEvents.signalMutedDictionariesChanged();
+    GlobalBroadcaster::instance()->signalMutedDictionariesChanged();
   }
 
   if ( result == editAction ) {
@@ -379,7 +377,7 @@ void DictionaryBar::actionWasTriggered( QAction * action )
       mutedDictionaries->insert( id );
     }
   }
-  configEvents.signalMutedDictionariesChanged();
+  GlobalBroadcaster::instance()->signalMutedDictionariesChanged();
 }
 
 void DictionaryBar::selectSingleDict( const QString & id )

--- a/src/ui/dictionarybar.cc
+++ b/src/ui/dictionarybar.cc
@@ -13,8 +13,7 @@
 
 using std::vector;
 
-DictionaryBar::DictionaryBar( QWidget * parent,
-                              const unsigned short & maxDictionaryRefsInContextMenu_ ):
+DictionaryBar::DictionaryBar( QWidget * parent, const unsigned short & maxDictionaryRefsInContextMenu_ ):
   QToolBar( tr( "&Dictionary Bar" ), parent ),
   mutedDictionaries( nullptr ),
   maxDictionaryRefsInContextMenu( maxDictionaryRefsInContextMenu_ )
@@ -26,7 +25,10 @@ DictionaryBar::DictionaryBar( QWidget * parent,
   maxDictionaryRefsAction =
     new QAction( QIcon( ":/icons/addtab.svg" ), tr( "Extended menu with all dictionaries..." ), this );
 
-  connect( GlobalBroadcaster::instance(), &GlobalBroadcaster::mutedDictionariesChanged, this, &DictionaryBar::mutedDictionariesChanged );
+  connect( GlobalBroadcaster::instance(),
+           &GlobalBroadcaster::mutedDictionariesChanged,
+           this,
+           &DictionaryBar::mutedDictionariesChanged );
 
   connect( this, &QToolBar::actionTriggered, this, &DictionaryBar::actionWasTriggered );
 }

--- a/src/ui/dictionarybar.hh
+++ b/src/ui/dictionarybar.hh
@@ -22,7 +22,7 @@ class DictionaryBar: public QToolBar
 public:
 
   /// Constructs an empty dictionary bar
-  DictionaryBar( QWidget * parent, Config::Events &, const unsigned short & maxDictionaryRefsInContextMenu_ );
+  DictionaryBar( QWidget * parent, const unsigned short & maxDictionaryRefsInContextMenu_ );
 
   /// Sets dictionaries to be displayed in the bar. Their statuses (enabled/
   /// disabled) are taken from the configuration data.
@@ -75,8 +75,6 @@ private:
 
   // In temporary selection, shift+click capture selections.
   std::optional< QSet< QString > > tempSelectionCapturedMuted;
-
-  Config::Events & configEvents;
 
   void selectSingleDict( const QString & id );
 

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -155,7 +155,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   addTab( this ),
   cfg( cfg_ ),
   history( cfg_.preferences.maxStringsInHistory, cfg_.maxHeadwordSize ),
-  dictionaryBar( this, configEvents, cfg.preferences.maxDictionaryRefsInContextMenu ),
+  dictionaryBar( this, cfg.preferences.maxDictionaryRefsInContextMenu ),
   articleMaker( dictionaries, groupInstances, cfg.preferences ),
   articleNetMgr( this, dictionaries, articleMaker, cfg.preferences.disallowContentFromOtherSites ),
   dictNetMgr( this ),
@@ -697,7 +697,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   // connect( ui.dictsList, &QListWidget::itemSelectionChanged, this, &MainWindow::dictsListSelectionChanged );
   // connect( ui.dictsList, &QListWidget::itemDoubleClicked, this, &MainWindow::dictsListItemActivated );
 
-  connect( &configEvents, &Config::Events::mutedDictionariesChanged, this, &MainWindow::mutedDictionariesChanged );
+  connect( GlobalBroadcaster::instance(), &GlobalBroadcaster::mutedDictionariesChanged, this, &MainWindow::mutedDictionariesChanged );
 
   this->installEventFilter( this );
 

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -697,7 +697,10 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   // connect( ui.dictsList, &QListWidget::itemSelectionChanged, this, &MainWindow::dictsListSelectionChanged );
   // connect( ui.dictsList, &QListWidget::itemDoubleClicked, this, &MainWindow::dictsListItemActivated );
 
-  connect( GlobalBroadcaster::instance(), &GlobalBroadcaster::mutedDictionariesChanged, this, &MainWindow::mutedDictionariesChanged );
+  connect( GlobalBroadcaster::instance(),
+           &GlobalBroadcaster::mutedDictionariesChanged,
+           this,
+           &MainWindow::mutedDictionariesChanged );
 
   this->installEventFilter( this );
 

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -138,7 +138,6 @@ private:
   QList< QWidget * > mruList;
   QToolButton addTab, *tabListButton;
   Config::Class & cfg;
-  Config::Events configEvents;
   History history;
   DictionaryBar dictionaryBar;
   vector< sptr< Dictionary::Class > > dictionaries;

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -263,7 +263,7 @@ ScanPopup::ScanPopup( QWidget * parent,
 #endif
   }
 
-  connect( &configEvents, &Config::Events::mutedDictionariesChanged, this, &ScanPopup::mutedDictionariesChanged );
+  connect( GlobalBroadcaster::instance(), &GlobalBroadcaster::mutedDictionariesChanged, this, &ScanPopup::mutedDictionariesChanged );
 
   definition->focus();
 

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -57,7 +57,7 @@ ScanPopup::ScanPopup( QWidget * parent,
   stopAudioAction( this ),
   openSearchAction( this ),
   wordFinder( this ),
-  dictionaryBar( this, configEvents, cfg.preferences.maxDictionaryRefsInContextMenu ),
+  dictionaryBar( this, cfg.preferences.maxDictionaryRefsInContextMenu ),
   articleNetMgr( articleNetMgr ),
   hideTimer( this )
 {

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -263,7 +263,10 @@ ScanPopup::ScanPopup( QWidget * parent,
 #endif
   }
 
-  connect( GlobalBroadcaster::instance(), &GlobalBroadcaster::mutedDictionariesChanged, this, &ScanPopup::mutedDictionariesChanged );
+  connect( GlobalBroadcaster::instance(),
+           &GlobalBroadcaster::mutedDictionariesChanged,
+           this,
+           &ScanPopup::mutedDictionariesChanged );
 
   definition->focus();
 

--- a/src/ui/scanpopup.hh
+++ b/src/ui/scanpopup.hh
@@ -135,7 +135,6 @@ private:
   QAction openSearchAction;
   QString pendingWord; // Word that is going to be translated
   WordFinder wordFinder;
-  Config::Events configEvents;
   DictionaryBar dictionaryBar;
   QToolBar * foundBar;
   QActionGroup * actionGroup = nullptr;


### PR DESCRIPTION
This PR refactors the codebase by integrating Config::Events into GlobalBroadcaster. This simplifies dependency management and reduces object proliferation by centralizing configuration-related events.