### PR TITLE
style(ui): improve UI controls visibility and naming

### DIFF
--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -2746,10 +2746,6 @@ To find &apos;*&apos;, &apos;?&apos;, &apos;[&apos;, &apos;]&apos; symbols use &
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Files comprising this dictionary:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Adjust the order by dragging and dropping items in it. Drop dictionaries to the inactive group to disable their use.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2775,6 +2771,10 @@ To find &apos;*&apos;, &apos;?&apos;, &apos;[&apos;, &apos;]&apos; symbols use &
     </message>
     <message>
         <source>New display name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dictionary components:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3494,10 +3494,6 @@ from Stardict, Babylon and GLS dictionaries</source>
     </message>
     <message>
         <source>Hide tab bar when only one tab is open.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Most Recently Used (MRU) navigation order.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/ui/edit_orderandprops.cc
+++ b/src/ui/edit_orderandprops.cc
@@ -206,6 +206,8 @@ void OrderAndProps::disableDictionaryDescription()
   ui.dictionaryTranslatesFrom->clear();
   ui.dictionaryTranslatesTo->clear();
   ui.dictionaryFileList->clear();
+  ui.dictionaryFileList->setVisible( false );
+  ui.dictionaryComponentsLabel->setVisible( false );
 
   ui.dictionaryDescription->clear();
   ui.dictionaryDescription->setVisible( false );
@@ -245,6 +247,8 @@ void OrderAndProps::describeDictionary( DictListWidget * lst, const QModelIndex 
     }
 
     ui.dictionaryFileList->setPlainText( filenamesText );
+    ui.dictionaryFileList->setVisible( dict->isLocalDictionary() );
+    ui.dictionaryComponentsLabel->setVisible( dict->isLocalDictionary() );
 
     QString descText = dict->getDescription();
     if ( !descText.isEmpty() && descText.compare( "NONE" ) != 0 ) {

--- a/src/ui/edit_orderandprops.cc
+++ b/src/ui/edit_orderandprops.cc
@@ -237,18 +237,21 @@ void OrderAndProps::describeDictionary( DictListWidget * lst, const QModelIndex 
     ui.dictionaryTranslatesFrom->setText( Language::localizedStringForId( dict->getLangFrom() ) );
     ui.dictionaryTranslatesTo->setText( Language::localizedStringForId( dict->getLangTo() ) );
 
-    const std::vector< std::string > & filenames = dict->getDictionaryFilenames();
-
-    QString filenamesText;
-
-    for ( unsigned x = 0; x < filenames.size(); x++ ) {
-      filenamesText += filenames[ x ].c_str();
-      filenamesText += '\n';
+    if ( dict->isLocalDictionary() ) {
+      const std::vector< std::string > & filenames = dict->getDictionaryFilenames();
+      QString filenamesText;
+      for ( unsigned x = 0; x < filenames.size(); x++ ) {
+        filenamesText += filenames[ x ].c_str();
+        filenamesText += '\n';
+      }
+      ui.dictionaryFileList->setPlainText( filenamesText );
+      ui.dictionaryFileList->setVisible( true );
+      ui.dictionaryComponentsLabel->setVisible( true );
     }
-
-    ui.dictionaryFileList->setPlainText( filenamesText );
-    ui.dictionaryFileList->setVisible( dict->isLocalDictionary() );
-    ui.dictionaryComponentsLabel->setVisible( dict->isLocalDictionary() );
+    else {
+      ui.dictionaryFileList->setVisible( false );
+      ui.dictionaryComponentsLabel->setVisible( false );
+    }
 
     QString descText = dict->getDescription();
     if ( !descText.isEmpty() && descText.compare( "NONE" ) != 0 ) {

--- a/src/ui/edit_orderandprops.ui
+++ b/src/ui/edit_orderandprops.ui
@@ -203,9 +203,9 @@
          </spacer>
         </item>
         <item>
-         <widget class="QLabel" name="label_11">
+         <widget class="QLabel" name="dictionaryComponentsLabel">
           <property name="text">
-           <string>Files comprising this dictionary:</string>
+           <string>Dictionary components:</string>
           </property>
          </widget>
         </item>

--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -259,9 +259,6 @@ switching to them.</string>
             </item>
             <item row="1" column="1">
              <widget class="QCheckBox" name="mruTabOrder">
-              <property name="toolTip">
-               <string>Most Recently Used (MRU) navigation order.</string>
-              </property>
               <property name="text">
                <string>Ctrl-Tab navigates tabs in MRU order</string>
               </property>


### PR DESCRIPTION
Hide 'Dictionary components' label for non-local dictionaries alongside the file list. Rename label_11 to dictionaryComponentsLabel for better code clarity. Remove redundant tooltip from MRU tab order checkbox.