### PR TITLE
feat: Add hint text for external audio player configuration

### DIFF
--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -3180,19 +3180,7 @@ in the pressed state when the word selection changes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Use internal player:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Choose audio back end</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Use any external program to play audio files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Use external program:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3494,6 +3482,22 @@ from Stardict, Babylon and GLS dictionaries</source>
     </message>
     <message>
         <source>Hide tab bar when only one tab is open.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Internal Player:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use any external audio player to play audio files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>External Player:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>View detailed configuration guide</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -3500,6 +3500,10 @@ from Stardict, Babylon and GLS dictionaries</source>
         <source>View detailed configuration guide</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The audio path will be passed as a command-line argument to the external player. </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ProgramTypeEditor</name>

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -319,6 +319,13 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
 
   ui.audioPlaybackProgram->setText( p.audioPlaybackProgram );
 
+  ui.externalPlayerHint->setOpenExternalLinks( true );
+  QFont hintFont = ui.externalPlayerHint->font();
+  hintFont.setPointSize( hintFont.pointSize() - 1 );
+  ui.externalPlayerHint->setFont( hintFont );
+  QColor hintColor = palette().color( QPalette::Disabled, QPalette::Text );
+  ui.externalPlayerHint->setStyleSheet( QString( "color: %1;" ).arg( hintColor.name() ) );
+
   // Proxy server
 
   ui.useProxyServer->setChecked( p.proxyServer.enabled );

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -320,10 +320,9 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   ui.audioPlaybackProgram->setText( p.audioPlaybackProgram );
 
   ui.externalPlayerHint->setText(
-    tr( "The audio path will be passed as a command-line argument to the external player. " ) +
-    R"(<a href="https://xiaoyifang.github.io/goldendict-ng/ui_audioengine/">)" +
-    tr( "View detailed configuration guide" ) +
-    "</a>" );
+    tr( "The audio path will be passed as a command-line argument to the external player. " )
+    + R"(<a href="https://xiaoyifang.github.io/goldendict-ng/ui_audioengine/">)"
+    + tr( "View detailed configuration guide" ) + "</a>" );
   ui.externalPlayerHint->setOpenExternalLinks( true );
   QFont hintFont = ui.externalPlayerHint->font();
   hintFont.setPointSize( hintFont.pointSize() - 1 );

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -319,6 +319,11 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
 
   ui.audioPlaybackProgram->setText( p.audioPlaybackProgram );
 
+  ui.externalPlayerHint->setText(
+    tr( "The audio path will be passed as a command-line argument to the external player. " ) +
+    R"(<a href="https://xiaoyifang.github.io/goldendict-ng/ui_audioengine/">)" +
+    tr( "View detailed configuration guide" ) +
+    "</a>" );
   ui.externalPlayerHint->setOpenExternalLinks( true );
   QFont hintFont = ui.externalPlayerHint->font();
   hintFont.setPointSize( hintFont.pointSize() - 1 );

--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -1002,7 +1002,7 @@ in the pressed state when the word selection changes.</string>
              <string>Play audio files via built-in audio support</string>
             </property>
             <property name="text">
-             <string>Use internal player:</string>
+             <string>Internal Player:</string>
             </property>
            </widget>
           </item>
@@ -1016,10 +1016,10 @@ in the pressed state when the word selection changes.</string>
           <item row="1" column="0">
            <widget class="QRadioButton" name="useExternalPlayer">
             <property name="toolTip">
-             <string>Use any external program to play audio files</string>
+             <string>Use any external audio player to play audio files</string>
             </property>
             <property name="text">
-             <string>Use external program:</string>
+             <string>External Player:</string>
             </property>
            </widget>
           </item>
@@ -1030,6 +1030,19 @@ in the pressed state when the word selection changes.</string>
             </property>
             <property name="toolTip">
              <string>Enter audio player command line</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="2">
+           <widget class="QLabel" name="externalPlayerHint">
+            <property name="text">
+             <string>The audio path will be passed as a command-line argument to the external player. <a href="https://xiaoyifang.github.io/goldendict-ng/ui_audioengine/">View detailed configuration guide</a></string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::RichText</enum>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
             </property>
            </widget>
           </item>

--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -1035,9 +1035,6 @@ in the pressed state when the word selection changes.</string>
           </item>
           <item row="2" column="0" colspan="2">
            <widget class="QLabel" name="externalPlayerHint">
-            <property name="text">
-             <string>The audio path will be passed as a command-line argument to the external player. <a href="https://xiaoyifang.github.io/goldendict-ng/ui_audioengine/">View detailed configuration guide</a></string>
-            </property>
             <property name="textFormat">
              <enum>Qt::RichText</enum>
             </property>

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -3,6 +3,6 @@
 
 Since Qt6.5+, Qt uses ffmpeg as the default implementation of [QMultimedia](<https://doc.qt.io/qt-6/qtmultimedia-index.html#the-ffmpeg-backend>). So, the ffmpeg audio player option is not needed.
 
-If you still want to use ffmpeg audio player, you can [configure `ffplay` as external program](ui_audioengine.md) or build from source with CMake flag `-DWITH_FFMPEG_PLAYER=ON`.
+If you still want to use ffmpeg audio player, you can [configure `ffplay` as external player](ui_audioengine.md) or build from source with CMake flag `-DWITH_FFMPEG_PLAYER=ON`.
 
 ![alt text](img/audio-engines.png)

--- a/website/docs/ui_audioengine.md
+++ b/website/docs/ui_audioengine.md
@@ -1,7 +1,10 @@
-To configure external audio player: Preference --> Audio --> `Use external program`.
+To configure external audio player: Preference --> Audio --> `External Player`.
 
 ![external audio program](img/external-audio.png)
 
+**Note:** The player command must be either in your system PATH or specified with an absolute path.
+
+**Linux/macOS examples:**
 
 vlc:
 ```
@@ -13,10 +16,26 @@ ffplay:
 ffplay -autoexit -nodisp
 ```
 
-
 mpv:
 ```
 mpv --no-video --no-audio-display --no-config
+```
+
+**Windows examples (using absolute paths):**
+
+vlc:
+```
+"C:\Program Files\VideoLAN\VLC\vlc.exe" --intf dummy --play-and-exit
+```
+
+ffplay:
+```
+"C:\ffmpeg\bin\ffplay.exe" -autoexit -nodisp
+```
+
+mpv:
+```
+"C:\Program Files\mpv\mpv.exe" --no-video --no-audio-display --no-config
 ```
 
 or other audio player.


### PR DESCRIPTION
This PR adds a hint text below the external audio player input field in the Preferences dialog to improve user experience.

**Changes:**
- Added hint label explaining that audio path will be passed as command-line argument
- Included link to documentation: https://xiaoyifang.github.io/goldendict-ng/ui_audioengine/
- Used palette-based color for automatic dark mode compatibility
- Set font size slightly smaller than default for visual hierarchy

**Modified files:**
-  - Added QLabel widget with RichText formatting
-  - Configured label properties (open external links, font size, color)