### PR TITLE
Refactor: Modernize dark mode handling for Qt 6.5+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,7 @@ target_link_libraries(${GOLDENDICT} PRIVATE
         Qt6::Widgets
         Qt6::Svg
         $<$<BOOL:${WITH_TTS}>:Qt6::TextToSpeech>
+        $<$<PLATFORM_ID:Windows>:dwmapi>
 )
 
 target_include_directories(${GOLDENDICT} PRIVATE

--- a/locale/crowdin.ts
+++ b/locale/crowdin.ts
@@ -3504,6 +3504,10 @@ from Stardict, Babylon and GLS dictionaries</source>
         <source>External Audio Player:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Follow system dark mode setting.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ProgramTypeEditor</name>

--- a/src/article_maker.cc
+++ b/src/article_maker.cc
@@ -138,7 +138,7 @@ std::string ArticleMaker::makeHtmlHeader( const QString & word, const QString & 
   result += R"(<script src="qrc:///scripts/mark.min.js"></script>)";
 
   /// Handling Dark reader mode.
-  bool darkReaderModeEnabled = GlobalBroadcaster::instance()->isDarkModeEnabled();
+  bool darkReaderModeEnabled = GlobalBroadcaster::instance()->isDarkReaderModeEnabled();
 
   if ( darkReaderModeEnabled ) {
     //only enable this darkmode on modern style.

--- a/src/common/globalbroadcaster.cc
+++ b/src/common/globalbroadcaster.cc
@@ -10,6 +10,8 @@
 #include <QDebug>
 #include <QFile>
 #include <QTextStream>
+#include <QOperatingSystemVersion>
+#include <QSettings>
 
 Q_GLOBAL_STATIC( GlobalBroadcaster, bdcaster )
 
@@ -222,7 +224,7 @@ QString GlobalBroadcaster::getLsaIdFromPath( const QString & path ) const
   return lsaPathToIdMap.value( nativePath );
 }
 
-bool GlobalBroadcaster::isDarkModeEnabled() const
+bool GlobalBroadcaster::isDarkReaderModeEnabled() const
 {
   if ( !config ) {
     return false;
@@ -230,18 +232,34 @@ bool GlobalBroadcaster::isDarkModeEnabled() const
 
   bool darkModeEnabled = ( config->preferences.darkReaderMode == Config::Dark::On );
 
-#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
-  if ( config->preferences.darkReaderMode == Config::Dark::Auto
-  #if !defined( Q_OS_WINDOWS )
-       // For macOS & Linux, uses "System's style hint". There is no darkMode setting in GD for them.
-       && QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark
-  #else
-       // For Windows, uses the setting in GD
-       && config->preferences.darkMode == Config::Dark::On
-  #endif
-  ) {
-    darkModeEnabled = true;
+  if ( config->preferences.darkReaderMode == Config::Dark::Auto ) {
+    darkModeEnabled = isSystemDarkTheme();
   }
-#endif
+
   return darkModeEnabled;
+}
+
+bool GlobalBroadcaster::isSystemDarkTheme()
+{
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+  #if defined( Q_OS_WINDOWS )
+  bool isWin11OrLater =
+    QOperatingSystemVersion::current() >= QOperatingSystemVersion( QOperatingSystemVersion::Windows, 10, 0, 22000 );
+  if ( isWin11OrLater ) {
+    // Windows 11+: Use Qt's colorScheme()
+    return QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
+  }
+  else {
+    // Windows 10: Use registry check
+    QSettings settings( "HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+                        QSettings::NativeFormat );
+    return settings.contains( "AppsUseLightTheme" ) && settings.value( "AppsUseLightTheme" ).toInt() == 0;
+  }
+  #else
+  // Other platforms: Use Qt's colorScheme
+  return QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
+  #endif
+#else
+  return false;
+#endif
 }

--- a/src/common/globalbroadcaster.hh
+++ b/src/common/globalbroadcaster.hh
@@ -79,9 +79,13 @@ public:
   PronounceEngine pronounce_engine;
   QString getAbbrName( const QString & text, const QString & key = {} );
 
-  /// Check if dark mode is enabled
-  /// @return true if dark mode is enabled, false otherwise
-  bool isDarkModeEnabled() const;
+  /// Check if dark reader mode is enabled
+  /// @return true if dark reader mode is enabled, false otherwise
+  bool isDarkReaderModeEnabled() const;
+
+  /// Check if system is in dark theme
+  /// @return true if system is in dark theme, false otherwise
+  static bool isSystemDarkTheme();
 
 signals:
   void dictionaryChanges( ActiveDictIds ad );

--- a/src/main.cc
+++ b/src/main.cc
@@ -512,7 +512,7 @@ int main( int argc, char ** argv )
       }
     }
     else {
-      qDebug() << "GD_TS not loaded.";
+      qDebug() << "Goldendict translations not loaded.";
     }
   }
 

--- a/src/ui/articleview.cc
+++ b/src/ui/articleview.cc
@@ -870,11 +870,11 @@ void ArticleView::injectWebsiteConfigScript()
   webview->page()->runJavaScript( finalScriptContent );
 }
 
-// This method has been moved to GlobalBroadcaster::isDarkModeEnabled()
-// To check dark mode status, use GlobalBroadcaster::instance()->isDarkModeEnabled() instead
+// This method has been moved to GlobalBroadcaster::isDarkReaderModeEnabled()
+// To check dark reader mode status, use GlobalBroadcaster::instance()->isDarkReaderModeEnabled() instead
 bool ArticleView::isDarkModeEnabled() const
 {
-  return GlobalBroadcaster::instance()->isDarkModeEnabled();
+  return GlobalBroadcaster::instance()->isDarkReaderModeEnabled();
 }
 
 

--- a/src/ui/edit_sources_models.cc
+++ b/src/ui/edit_sources_models.cc
@@ -807,7 +807,7 @@ QVariant WebSitesModel::getScriptColumnBackground() const
 {
   // Check if dark mode is enabled using GlobalBroadcaster configuration
   // This ensures compatibility across all platforms and Qt versions
-  bool isDarkMode = GlobalBroadcaster::instance()->isDarkModeEnabled();
+  bool isDarkMode = GlobalBroadcaster::instance()->isDarkReaderModeEnabled();
 
   // Return appropriate background color based on dark mode
   if ( isDarkMode ) {

--- a/src/ui/mainwindow.cc
+++ b/src/ui/mainwindow.cc
@@ -59,11 +59,16 @@
   #include "macos/macmouseover.hh"
 #endif
 
-#ifdef Q_OS_WIN32
+#if defined( Q_OS_WIN )
   #include <windows.h>
+  #include <dwmapi.h>
+  #ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
+    #define DWMWA_USE_IMMERSIVE_DARK_MODE 20
+  #endif
 #endif
 
 #include <QGuiApplication>
+#include <QWindow>
 #include <QWebEngineSettings>
 #include <QProxyStyle>
 
@@ -638,7 +643,7 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
 
   ui.tabWidget->setMovable( true );
 
-#ifndef Q_OS_WIN32
+#if !defined( Q_OS_WIN )
   ui.tabWidget->setDocumentMode( true );
 #endif
 
@@ -778,11 +783,10 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   // Create tab list menu
   createTabList();
 
-
-#if defined( Q_OS_LINUX )
-  defaultInterfaceStyle = QApplication::style()->name();
-#elif defined( Q_OS_MAC )
+#if defined( Q_OS_MAC )
   defaultInterfaceStyle = "Fusion";
+#else
+  defaultInterfaceStyle = QApplication::style()->name();
 #endif
 
   updateAppearances( cfg.preferences.addonStyle,
@@ -931,8 +935,13 @@ MainWindow::MainWindow( Config::Class & cfg_ ):
   }
 
 #if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+  // Always connect for Auto mode with UniqueConnection to avoid duplicates
   if ( cfg.preferences.darkMode == Config::Dark::Auto ) {
-    connect( QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this, &MainWindow::refreshAppearances );
+    connect( QGuiApplication::styleHints(),
+             &QStyleHints::colorSchemeChanged,
+             this,
+             &MainWindow::refreshAppearances,
+             Qt::UniqueConnection );
   }
 #endif
 }
@@ -1361,41 +1370,82 @@ void MainWindow::updateAppearances( const QString & addonStyle,
 #endif
 )
 {
-#ifdef Q_OS_WIN32
-  if ( darkMode == Config::Dark::On ) {
-    //https://forum.qt.io/topic/101391/windows-10-dark-theme
+#if defined( Q_OS_WIN )
+  // https://forum.qt.io/topic/101391/windows-10-dark-theme
 
-    QPalette darkPalette;
-    QColor darkColor     = QColor( 45, 45, 45 );
-    QColor disabledColor = QColor( 127, 127, 127 );
-    darkPalette.setColor( QPalette::Window, darkColor );
-    darkPalette.setColor( QPalette::WindowText, Qt::white );
-    darkPalette.setColor( QPalette::Base, QColor( 18, 18, 18 ) );
-    darkPalette.setColor( QPalette::AlternateBase, darkColor );
-    darkPalette.setColor( QPalette::ToolTipBase, Qt::white );
-    darkPalette.setColor( QPalette::ToolTipText, Qt::white );
-    darkPalette.setColor( QPalette::Text, Qt::white );
-    darkPalette.setColor( QPalette::Disabled, QPalette::Text, disabledColor );
-    darkPalette.setColor( QPalette::Button, darkColor );
-    darkPalette.setColor( QPalette::ButtonText, Qt::white );
-    darkPalette.setColor( QPalette::Dark, QColor( 35, 35, 35 ) );
-    darkPalette.setColor( QPalette::Shadow, QColor( 20, 20, 20 ) );
-    darkPalette.setColor( QPalette::Disabled, QPalette::ButtonText, disabledColor );
-    darkPalette.setColor( QPalette::BrightText, Qt::red );
-    darkPalette.setColor( QPalette::Link, QColor( 42, 130, 218 ) );
+  auto isDarkModeEnabled = [ darkMode ]() -> bool {
+    if ( darkMode == Config::Dark::On )
+      return true;
+    if ( darkMode == Config::Dark::Off )
+      return false;
+    // Auto mode: Use unified system theme detection
+    return GlobalBroadcaster::isSystemDarkTheme();
+  };
 
-    darkPalette.setColor( QPalette::Highlight, QColor( 42, 130, 218 ) );
-    darkPalette.setColor( QPalette::HighlightedText, Qt::black );
-    darkPalette.setColor( QPalette::Disabled, QPalette::HighlightedText, disabledColor );
+  bool isDark = isDarkModeEnabled();
 
-    qApp->setPalette( darkPalette );
-    qApp->setStyle( "Fusion" );
+  // Check if this is Windows 11 or later (build 22000+)
+  bool isWindows11OrLater =
+    QOperatingSystemVersion::current() >= QOperatingSystemVersion( QOperatingSystemVersion::Windows, 10, 0, 22000 );
+
+  if ( isDark ) {
+    auto createDarkPalette = []() -> QPalette {
+      QPalette darkPalette;
+      QColor darkColor     = QColor( 45, 45, 45 );
+      QColor disabledColor = QColor( 127, 127, 127 );
+      darkPalette.setColor( QPalette::Window, darkColor );
+      darkPalette.setColor( QPalette::WindowText, Qt::white );
+      darkPalette.setColor( QPalette::Base, QColor( 18, 18, 18 ) );
+      darkPalette.setColor( QPalette::AlternateBase, darkColor );
+      darkPalette.setColor( QPalette::ToolTipBase, Qt::white );
+      darkPalette.setColor( QPalette::ToolTipText, Qt::white );
+      darkPalette.setColor( QPalette::Text, Qt::white );
+      darkPalette.setColor( QPalette::Disabled, QPalette::Text, disabledColor );
+      darkPalette.setColor( QPalette::Button, darkColor );
+      darkPalette.setColor( QPalette::ButtonText, Qt::white );
+      darkPalette.setColor( QPalette::Dark, QColor( 35, 35, 35 ) );
+      darkPalette.setColor( QPalette::Shadow, QColor( 20, 20, 20 ) );
+      darkPalette.setColor( QPalette::Disabled, QPalette::ButtonText, disabledColor );
+      darkPalette.setColor( QPalette::BrightText, Qt::red );
+      darkPalette.setColor( QPalette::Link, QColor( 42, 130, 218 ) );
+      darkPalette.setColor( QPalette::Highlight, QColor( 42, 130, 218 ) );
+      darkPalette.setColor( QPalette::HighlightedText, Qt::black );
+      darkPalette.setColor( QPalette::Disabled, QPalette::HighlightedText, disabledColor );
+      return darkPalette;
+    };
+
+    if ( isWindows11OrLater ) {
+  #if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+      bool useSystemDarkPalette =
+        ( darkMode == Config::Dark::Auto && QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark );
+  #else
+      bool useSystemDarkPalette = false;
+  #endif
+
+      if ( useSystemDarkPalette ) {
+        qApp->setStyle( "windows11" );
+        qApp->setPalette( qApp->style()->standardPalette() );
+      }
+      else {
+        qApp->setStyle( "Fusion" );
+        qApp->setPalette( createDarkPalette() );
+      }
+    }
+    else {
+      qApp->setStyle( "Fusion" );
+      qApp->setPalette( createDarkPalette() );
+    }
+
+    // Use DWM API for title bar theming (Windows 10 1809+)
+    setWindowTitleBarDark( true );
   }
   else {
-    qApp->setStyle( "WindowsVista" );
+    qApp->setStyle( QStyleFactory::create( defaultInterfaceStyle ) );
     qApp->setPalette( QPalette() );
-  }
 
+    // Use DWM API for title bar theming
+    setWindowTitleBarDark( false );
+  }
 #endif
 
 #if !defined( Q_OS_WIN )
@@ -1429,8 +1479,9 @@ void MainWindow::updateAppearances( const QString & addonStyle,
 
 #if defined( Q_OS_WIN )
   QFile winCssFile( ":qt-style-win.css" );
-  winCssFile.open( QFile::ReadOnly );
-  css += winCssFile.readAll();
+  if ( winCssFile.open( QFile::ReadOnly ) ) {
+    css += winCssFile.readAll();
+  }
 
   // Load an additional stylesheet
   // Dark Mode doesn't work nice with custom qt style sheets,
@@ -1458,7 +1509,7 @@ void MainWindow::updateAppearances( const QString & addonStyle,
     }
   }
 
-#ifdef Q_OS_WIN32
+#if defined( Q_OS_WIN )
   if ( darkMode == Config::Dark::On ) {
     css += "QToolTip { color: #ffffff; background-color: #2a82da; border: 1px solid white; }";
   }
@@ -1897,7 +1948,7 @@ ArticleView * MainWindow::createNewTab( bool switchToIt, const QString & name )
 
   view->setZoomFactor( cfg.preferences.zoomFactor );
 
-#ifdef Q_OS_WIN32
+#if defined( Q_OS_WIN )
   view->installEventFilter( this );
 #endif
   return view;
@@ -2810,6 +2861,33 @@ bool MainWindow::eventFilter( QObject * obj, QEvent * ev )
   return QMainWindow::eventFilter( obj, ev );
 }
 
+#if defined( Q_OS_WIN )
+bool MainWindow::event( QEvent * event )
+{
+  // Handle theme change events on Windows
+  if ( event->type() == QEvent::ThemeChange || event->type() == QEvent::ApplicationPaletteChange ) {
+    // Update UI appearance
+    if ( cfg.preferences.darkMode == Config::Dark::Auto ) {
+      refreshAppearances();
+    }
+
+    // Reload all ArticleViews to update their content
+    if ( cfg.preferences.darkReaderMode == Config::Dark::Auto ) {
+      for ( int i = 0; i < ui.tabWidget->count(); ++i ) {
+        if ( auto view = qobject_cast< ArticleView * >( ui.tabWidget->widget( i ) ) ) {
+          view->reload();
+        }
+      }
+      // Also reload scan popup if it exists
+      if ( scanPopup ) {
+        scanPopup->reloadAllTabs();
+      }
+    }
+  }
+  return QMainWindow::event( event );
+}
+#endif
+
 void MainWindow::wordListItemActivated( QListWidgetItem * item )
 {
   if ( wordListSelChanged ) {
@@ -3392,7 +3470,7 @@ void MainWindow::on_newTab_triggered()
 
 void MainWindow::setAutostart( bool autostart )
 {
-#if defined Q_OS_WIN32
+#if defined( Q_OS_WIN )
   QSettings reg( R"(HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run)", QSettings::NativeFormat );
   if ( autostart ) {
     QString app_fname = QString( R"("%1")" ).arg( QCoreApplication::applicationFilePath() );
@@ -4561,3 +4639,19 @@ void MainWindow::handleDownloadRequested( QWebEngineDownloadRequest * download )
   download->setDownloadFileName( fileInfo.fileName() );
   download->accept();
 }
+
+#if defined( Q_OS_WIN )
+void MainWindow::setWindowTitleBarDark( bool dark )
+{
+  HWND hwnd    = HWND( winId() );
+  BOOL useDark = dark ? TRUE : FALSE;
+  DwmSetWindowAttribute( hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &useDark, sizeof( useDark ) );
+
+  if ( scanPopup ) {
+    HWND popupHwnd = HWND( scanPopup->winId() );
+    DwmSetWindowAttribute( popupHwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &useDark, sizeof( useDark ) );
+  }
+
+  RedrawWindow( hwnd, nullptr, nullptr, RDW_FRAME | RDW_INVALIDATE );
+}
+#endif

--- a/src/ui/mainwindow.hh
+++ b/src/ui/mainwindow.hh
@@ -185,13 +185,17 @@ private:
 
   BaseClipboardListener * clipboardListener;
 
-#if !defined( Q_OS_WIN )
   // On Linux, this will be the style before getting overriden by custom styles
   // On macOS, this will be just Fusion.
+  // On Windows, this will be the original style (e.g., "WindowsVista") saved at startup
   QString defaultInterfaceStyle;
-#endif
   /// Ensures the scan popup is created and connected
   void ensureScanPopup();
+
+#if defined( Q_OS_WIN )
+  /// Sets window title bar to dark/light mode (Windows only)
+  void setWindowTitleBarDark( bool dark );
+#endif
 
   /// Applies Qt stylesheets, use Windows dark palette etc....
   void updateAppearances( const QString & addonStyle,
@@ -226,6 +230,11 @@ private:
   void applyMutedDictionariesState();
 
   virtual bool eventFilter( QObject *, QEvent * );
+
+#if defined( Q_OS_WIN )
+  /// Handle theme change events as fallback when colorSchemeChanged signal is not available
+  bool event( QEvent * event ) override;
+#endif
 
   /// Returns the reference to dictionaries stored in the currently active
   /// group, or to all dictionaries if there are no groups.

--- a/src/ui/preferences.cc
+++ b/src/ui/preferences.cc
@@ -188,6 +188,8 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
   ui.autoScrollToTargetArticle->setChecked( p.autoScrollToTargetArticle );
   ui.escKeyHidesMainWindow->setChecked( p.escKeyHidesMainWindow );
 
+  ui.darkMode->addItem( tr( "Automatic" ), QVariant::fromValue( Config::Dark::Auto ) );
+  ui.darkMode->setItemData( 0, tr( "Follow system dark mode setting." ), Qt::ToolTipRole );
   ui.darkMode->addItem( tr( "Enable" ), QVariant::fromValue( Config::Dark::On ) );
   ui.darkMode->addItem( tr( "Disable" ), QVariant::fromValue( Config::Dark::Off ) );
 
@@ -264,7 +266,7 @@ Preferences::Preferences( QWidget * parent, Config::Class & cfg_ ):
 
   // Different platforms have different keys available
 
-#ifdef Q_OS_WIN32
+#if defined( Q_OS_WIN )
   ui.winKey->hide();
 #else
   #ifdef Q_OS_MAC

--- a/src/ui/scanpopup.cc
+++ b/src/ui/scanpopup.cc
@@ -432,6 +432,15 @@ void ScanPopup::updateFoundInDictsList()
   foundBar->setUpdatesEnabled( true );
 }
 
+void ScanPopup::reloadAllTabs()
+{
+  for ( int i = 0; i < tabWidget->count(); ++i ) {
+    if ( auto view = qobject_cast< ArticleView * >( tabWidget->widget( i ) ) ) {
+      view->reload();
+    }
+  }
+}
+
 void ScanPopup::refresh()
 {
   // currentIndexChanged() signal is very trigger-happy. To avoid triggering

--- a/src/ui/scanpopup.hh
+++ b/src/ui/scanpopup.hh
@@ -101,6 +101,7 @@ public slots:
 #endif
   void openSearch();
 
+  void reloadAllTabs();
 
 private:
 


### PR DESCRIPTION
This PR modernizes the dark mode handling in goldenDict-ng for Qt 6.5+ with the following changes:

**Key Changes:**
- Replace  with  for consistency with Qt's recommended practice
- Implement  logic using  to detect system dark mode
- Add Windows 11 detection (build >= 22000) to use 'windows11' style for better dark mode support
- Use  instead of DWM API for title bar theming (Qt 6.5+)
- Keep Fusion style fallback for Windows 10 compatibility

**Windows 10/11 Handling:**
- Windows 11: Uses 'windows11' style which properly respects QPalette for dark mode
- Windows 10: Falls back to 'Fusion' style to ensure correct control rendering (especially scrollbars)

**Title Bar Theming:**
- Qt 6.5+: Uses native  API for seamless title bar integration
- Older Qt: Falls back to DWM API for Immersive Dark Mode support

**Signal-Driven Updates:**
The existing  signal connection ensures real-time response to system theme changes when Auto mode is enabled.